### PR TITLE
Rename route HandleMethod to ControllerMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ myapp/
 │   ├── app/         # Main application entry point
 │   └── migrate/     # Database migration tool
 ├── config/          # Application configuration
-├── controllers/     # Request handlers and business logic
+├── controllers/     # Request controllers and business logic
 ├── css/            # Tailwind CSS and custom styles
 ├── database/
 │   ├── migrations/  # SQL migration files

--- a/generator/controllers/testdata/base_routes.go
+++ b/generator/controllers/testdata/base_routes.go
@@ -3,12 +3,12 @@ package routes
 import "github.com/labstack/echo/v4"
 
 type Route struct {
-	Name         string
-	Path         string
-	Handler      string
-	HandleMethod string
-	Method       string
-	Middleware   []func(next echo.HandlerFunc) echo.HandlerFunc
+	Name             string
+	Path             string
+	Controller       string
+	ControllerMethod string
+	Method           string
+	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc
 }
 
 var BuildRoutes = func() []Route {

--- a/generator/controllers/testdata/product_controller_routes.go
+++ b/generator/controllers/testdata/product_controller_routes.go
@@ -23,20 +23,20 @@ var ProductRoutes = []Route{
 }
 
 var ProductIndex = Route{
-	Name:         productsNamePrefix + ".index",
-	Path:         productsRoutePrefix,
-	Method:       http.MethodGet,
-	Handler:      "Products",
-	HandleMethod: "Index",
+	Name:             productsNamePrefix + ".index",
+	Path:             productsRoutePrefix,
+	Method:           http.MethodGet,
+	Controller:       "Products",
+	ControllerMethod: "Index",
 }
 
 var ProductShow = productsShow{
 	Route: Route{
-		Name:         productsNamePrefix + ".show",
-		Path:         productsRoutePrefix + "/:id",
-		Method:       http.MethodGet,
-		Handler:      "Products",
-		HandleMethod: "Show",
+		Name:             productsNamePrefix + ".show",
+		Path:             productsRoutePrefix + "/:id",
+		Method:           http.MethodGet,
+		Controller:       "Products",
+		ControllerMethod: "Show",
 	},
 }
 
@@ -49,28 +49,28 @@ func (r productsShow) GetPath(id uuid.UUID) string {
 }
 
 var ProductNew = Route{
-	Name:         productsNamePrefix + ".new",
-	Path:         productsRoutePrefix + "/new",
-	Method:       http.MethodGet,
-	Handler:      "Products",
-	HandleMethod: "New",
+	Name:             productsNamePrefix + ".new",
+	Path:             productsRoutePrefix + "/new",
+	Method:           http.MethodGet,
+	Controller:       "Products",
+	ControllerMethod: "New",
 }
 
 var ProductCreate = Route{
-	Name:         productsNamePrefix + ".create",
-	Path:         productsRoutePrefix,
-	Method:       http.MethodPost,
-	Handler:      "Products",
-	HandleMethod: "Create",
+	Name:             productsNamePrefix + ".create",
+	Path:             productsRoutePrefix,
+	Method:           http.MethodPost,
+	Controller:       "Products",
+	ControllerMethod: "Create",
 }
 
 var ProductEdit = productsEdit{
 	Route: Route{
-		Name:         productsNamePrefix + ".edit",
-		Path:         productsRoutePrefix + "/:id/edit",
-		Method:       http.MethodGet,
-		Handler:      "Products",
-		HandleMethod: "Edit",
+		Name:             productsNamePrefix + ".edit",
+		Path:             productsRoutePrefix + "/:id/edit",
+		Method:           http.MethodGet,
+		Controller:       "Products",
+		ControllerMethod: "Edit",
 	},
 }
 
@@ -84,11 +84,11 @@ func (r productsEdit) GetPath(id uuid.UUID) string {
 
 var ProductUpdate = productsUpdate{
 	Route: Route{
-		Name:         productsNamePrefix + ".update",
-		Path:         productsRoutePrefix + "/:id",
-		Method:       http.MethodPut,
-		Handler:      "Products",
-		HandleMethod: "Update",
+		Name:             productsNamePrefix + ".update",
+		Path:             productsRoutePrefix + "/:id",
+		Method:           http.MethodPut,
+		Controller:       "Products",
+		ControllerMethod: "Update",
 	},
 }
 
@@ -102,11 +102,11 @@ func (r productsUpdate) GetPath(id uuid.UUID) string {
 
 var ProductDestroy = productsDestroy{
 	Route: Route{
-		Name:         productsNamePrefix + ".destroy",
-		Path:         productsRoutePrefix + "/:id",
-		Method:       http.MethodDelete,
-		Handler:      "Products",
-		HandleMethod: "Destroy",
+		Name:             productsNamePrefix + ".destroy",
+		Path:             productsRoutePrefix + "/:id",
+		Method:           http.MethodDelete,
+		Controller:       "Products",
+		ControllerMethod: "Destroy",
 	},
 }
 

--- a/generator/controllers/testdata/product_controller_routes_registration.go
+++ b/generator/controllers/testdata/product_controller_routes_registration.go
@@ -3,12 +3,12 @@ package routes
 import "github.com/labstack/echo/v4"
 
 type Route struct {
-	Name         string
-	Path         string
-	Handler      string
-	HandleMethod string
-	Method       string
-	Middleware   []func(next echo.HandlerFunc) echo.HandlerFunc
+	Name             string
+	Path             string
+	Controller       string
+	ControllerMethod string
+	Method           string
+	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc
 }
 
 var BuildRoutes = func() []Route {

--- a/generator/controllers/testdata/user_controller_routes.go
+++ b/generator/controllers/testdata/user_controller_routes.go
@@ -23,20 +23,20 @@ var UserRoutes = []Route{
 }
 
 var UserIndex = Route{
-	Name:         usersNamePrefix + ".index",
-	Path:         usersRoutePrefix,
-	Method:       http.MethodGet,
-	Handler:      "Users",
-	HandleMethod: "Index",
+	Name:             usersNamePrefix + ".index",
+	Path:             usersRoutePrefix,
+	Method:           http.MethodGet,
+	Controller:       "Users",
+	ControllerMethod: "Index",
 }
 
 var UserShow = usersShow{
 	Route: Route{
-		Name:         usersNamePrefix + ".show",
-		Path:         usersRoutePrefix + "/:id",
-		Method:       http.MethodGet,
-		Handler:      "Users",
-		HandleMethod: "Show",
+		Name:             usersNamePrefix + ".show",
+		Path:             usersRoutePrefix + "/:id",
+		Method:           http.MethodGet,
+		Controller:       "Users",
+		ControllerMethod: "Show",
 	},
 }
 
@@ -49,28 +49,28 @@ func (r usersShow) GetPath(id uuid.UUID) string {
 }
 
 var UserNew = Route{
-	Name:         usersNamePrefix + ".new",
-	Path:         usersRoutePrefix + "/new",
-	Method:       http.MethodGet,
-	Handler:      "Users",
-	HandleMethod: "New",
+	Name:             usersNamePrefix + ".new",
+	Path:             usersRoutePrefix + "/new",
+	Method:           http.MethodGet,
+	Controller:       "Users",
+	ControllerMethod: "New",
 }
 
 var UserCreate = Route{
-	Name:         usersNamePrefix + ".create",
-	Path:         usersRoutePrefix,
-	Method:       http.MethodPost,
-	Handler:      "Users",
-	HandleMethod: "Create",
+	Name:             usersNamePrefix + ".create",
+	Path:             usersRoutePrefix,
+	Method:           http.MethodPost,
+	Controller:       "Users",
+	ControllerMethod: "Create",
 }
 
 var UserEdit = usersEdit{
 	Route: Route{
-		Name:         usersNamePrefix + ".edit",
-		Path:         usersRoutePrefix + "/:id/edit",
-		Method:       http.MethodGet,
-		Handler:      "Users",
-		HandleMethod: "Edit",
+		Name:             usersNamePrefix + ".edit",
+		Path:             usersRoutePrefix + "/:id/edit",
+		Method:           http.MethodGet,
+		Controller:       "Users",
+		ControllerMethod: "Edit",
 	},
 }
 
@@ -84,11 +84,11 @@ func (r usersEdit) GetPath(id uuid.UUID) string {
 
 var UserUpdate = usersUpdate{
 	Route: Route{
-		Name:         usersNamePrefix + ".update",
-		Path:         usersRoutePrefix + "/:id",
-		Method:       http.MethodPut,
-		Handler:      "Users",
-		HandleMethod: "Update",
+		Name:             usersNamePrefix + ".update",
+		Path:             usersRoutePrefix + "/:id",
+		Method:           http.MethodPut,
+		Controller:       "Users",
+		ControllerMethod: "Update",
 	},
 }
 
@@ -102,11 +102,11 @@ func (r usersUpdate) GetPath(id uuid.UUID) string {
 
 var UserDestroy = usersDestroy{
 	Route: Route{
-		Name:         usersNamePrefix + ".destroy",
-		Path:         usersRoutePrefix + "/:id",
-		Method:       http.MethodDelete,
-		Handler:      "Users",
-		HandleMethod: "Destroy",
+		Name:             usersNamePrefix + ".destroy",
+		Path:             usersRoutePrefix + "/:id",
+		Method:           http.MethodDelete,
+		Controller:       "Users",
+		ControllerMethod: "Destroy",
 	},
 }
 

--- a/generator/controllers/testdata/user_controller_routes_registration.go
+++ b/generator/controllers/testdata/user_controller_routes_registration.go
@@ -3,12 +3,12 @@ package routes
 import "github.com/labstack/echo/v4"
 
 type Route struct {
-	Name         string
-	Path         string
-	Handler      string
-	HandleMethod string
-	Method       string
-	Middleware   []func(next echo.HandlerFunc) echo.HandlerFunc
+	Name             string
+	Path             string
+	Controller       string
+	ControllerMethod string
+	Method           string
+	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc
 }
 
 var BuildRoutes = func() []Route {

--- a/generator/templates/route.tmpl
+++ b/generator/templates/route.tmpl
@@ -23,21 +23,21 @@ var {{.ResourceName}}Routes = []Route{
 }
 
 var {{.ResourceName}}Index = Route{
-	Name:         {{.PluralName | ToLower}}NamePrefix + ".index",
-	Path:         {{.PluralName | ToLower}}RoutePrefix,
-	Method:       http.MethodGet,
-	Handler:      "{{.ResourceName}}s",
-	HandleMethod: "Index",
+        Name:         {{.PluralName | ToLower}}NamePrefix + ".index",
+        Path:         {{.PluralName | ToLower}}RoutePrefix,
+        Method:       http.MethodGet,
+        Controller:   "{{.ResourceName}}s",
+        ControllerMethod: "Index",
 }
 
 var {{.ResourceName}}Show = {{.PluralName | ToLower}}Show{
-	Route: Route{
-		Name:         {{.PluralName | ToLower}}NamePrefix + ".show",
-		Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id",
-		Method:       http.MethodGet,
-		Handler:      "{{.ResourceName}}s",
-		HandleMethod: "Show",
-	},
+        Route: Route{
+                Name:         {{.PluralName | ToLower}}NamePrefix + ".show",
+                Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id",
+                Method:       http.MethodGet,
+                Controller:   "{{.ResourceName}}s",
+                ControllerMethod: "Show",
+        },
 }
 
 type {{.PluralName | ToLower}}Show struct {
@@ -49,29 +49,29 @@ func (r {{.PluralName | ToLower}}Show) GetPath(id uuid.UUID) string {
 }
 
 var {{.ResourceName}}New = Route{
-	Name:         {{.PluralName | ToLower}}NamePrefix + ".new",
-	Path:         {{.PluralName | ToLower}}RoutePrefix + "/new",
-	Method:       http.MethodGet,
-	Handler:      "{{.ResourceName}}s",
-	HandleMethod: "New",
+        Name:         {{.PluralName | ToLower}}NamePrefix + ".new",
+        Path:         {{.PluralName | ToLower}}RoutePrefix + "/new",
+        Method:       http.MethodGet,
+        Controller:   "{{.ResourceName}}s",
+        ControllerMethod: "New",
 }
 
 var {{.ResourceName}}Create = Route{
-	Name:         {{.PluralName | ToLower}}NamePrefix + ".create",
-	Path:         {{.PluralName | ToLower}}RoutePrefix,
-	Method:       http.MethodPost,
-	Handler:      "{{.ResourceName}}s",
-	HandleMethod: "Create",
+        Name:         {{.PluralName | ToLower}}NamePrefix + ".create",
+        Path:         {{.PluralName | ToLower}}RoutePrefix,
+        Method:       http.MethodPost,
+        Controller:   "{{.ResourceName}}s",
+        ControllerMethod: "Create",
 }
 
 var {{.ResourceName}}Edit = {{.PluralName | ToLower}}Edit{
-	Route: Route{
-		Name:         {{.PluralName | ToLower}}NamePrefix + ".edit",
-		Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id/edit",
-		Method:       http.MethodGet,
-		Handler:      "{{.ResourceName}}s",
-		HandleMethod: "Edit",
-	},
+        Route: Route{
+                Name:         {{.PluralName | ToLower}}NamePrefix + ".edit",
+                Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id/edit",
+                Method:       http.MethodGet,
+                Controller:   "{{.ResourceName}}s",
+                ControllerMethod: "Edit",
+        },
 }
 
 type {{.PluralName | ToLower}}Edit struct {
@@ -83,13 +83,13 @@ func (r {{.PluralName | ToLower}}Edit) GetPath(id uuid.UUID) string {
 }
 
 var {{.ResourceName}}Update = {{.PluralName | ToLower}}Update{
-	Route: Route{
-		Name:         {{.PluralName | ToLower}}NamePrefix + ".update",
-		Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id",
-		Method:       http.MethodPut,
-		Handler:      "{{.ResourceName}}s",
-		HandleMethod: "Update",
-	},
+        Route: Route{
+                Name:         {{.PluralName | ToLower}}NamePrefix + ".update",
+                Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id",
+                Method:       http.MethodPut,
+                Controller:   "{{.ResourceName}}s",
+                ControllerMethod: "Update",
+        },
 }
 
 type {{.PluralName | ToLower}}Update struct {
@@ -101,13 +101,13 @@ func (r {{.PluralName | ToLower}}Update) GetPath(id uuid.UUID) string {
 }
 
 var {{.ResourceName}}Destroy = {{.PluralName | ToLower}}Destroy{
-	Route: Route{
-		Name:         {{.PluralName | ToLower}}NamePrefix + ".destroy",
-		Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id",
-		Method:       http.MethodDelete,
-		Handler:      "{{.ResourceName}}s",
-		HandleMethod: "Destroy",
-	},
+        Route: Route{
+                Name:         {{.PluralName | ToLower}}NamePrefix + ".destroy",
+                Path:         {{.PluralName | ToLower}}RoutePrefix + "/:id",
+                Method:       http.MethodDelete,
+                Controller:   "{{.ResourceName}}s",
+                ControllerMethod: "Destroy",
+        },
 }
 
 type {{.PluralName | ToLower}}Destroy struct {

--- a/layout/templates/controllers_controller.tmpl
+++ b/layout/templates/controllers_controller.tmpl
@@ -1,4 +1,4 @@
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (

--- a/layout/templates/router_router.tmpl
+++ b/layout/templates/router_router.tmpl
@@ -101,22 +101,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
-		}
+                if route.Controller == "" || route.ControllerMethod == "" {
+                        panic("Route must specify Controller and ControllerMethod fields")
+                }
 
-		controllerField := controllersValue.FieldByName(route.Handler)
-		if !controllerField.IsValid() {
-			panic(
-				fmt.Sprintf(
-					"Controller field %s not found in controllers struct",
-					route.Handler,
-				),
-			)
-		}
+                controllerField := controllersValue.FieldByName(route.Controller)
+                if !controllerField.IsValid() {
+                        panic(
+                                fmt.Sprintf(
+                                        "Controller field %s not found in controllers struct",
+                                        route.Controller,
+                                ),
+                        )
+                }
 
-		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+                controller := controllerField.Interface()
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -126,18 +126,18 @@ func (r *Router) SetupRoutes() *echo.Echo {
 		switch route.Method {
 		case http.MethodGet:
 			registeredRoutes = append(registeredRoutes, route.Name)
-			r.Handler.GET(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
-		case http.MethodPost:
-			registeredRoutes = append(registeredRoutes, route.Name)
-			r.Handler.POST(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
-		case http.MethodPut:
-			registeredRoutes = append(registeredRoutes, route.Name)
-			r.Handler.PUT(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
-		case http.MethodDelete:
-			registeredRoutes = append(registeredRoutes, route.Name)
-			r.Handler.DELETE(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
-		}
-	}
+                        r.Handler.GET(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
+                case http.MethodPost:
+                        registeredRoutes = append(registeredRoutes, route.Name)
+                        r.Handler.POST(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
+                case http.MethodPut:
+                        registeredRoutes = append(registeredRoutes, route.Name)
+                        r.Handler.PUT(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
+                case http.MethodDelete:
+                        registeredRoutes = append(registeredRoutes, route.Name)
+                        r.Handler.DELETE(route.Path, controllerFunc, middlewareFuncs...).Name = route.Name
+                }
+        }
 
 	r.Handler.RouteNotFound(
 		"/*",

--- a/layout/templates/router_routes_api.tmpl
+++ b/layout/templates/router_routes_api.tmpl
@@ -12,9 +12,9 @@ var apiRoutes = []Route{
 }
 
 var Health = Route{
-	Name:         apiNamePrefix + ".health",
-	Path:         APIRoutePrefix + "/health",
-	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+        Name:         apiNamePrefix + ".health",
+        Path:         APIRoutePrefix + "/health",
+        Method:       http.MethodGet,
+        Controller:   "API",
+        ControllerMethod: "Health",
 }

--- a/layout/templates/router_routes_assets.tmpl
+++ b/layout/templates/router_routes_assets.tmpl
@@ -22,41 +22,41 @@ var assetRoutes = []Route{
 var startTime = time.Now().Unix()
 
 var Robots = Route{
-	Name:         assetsNamePrefix + ".robots",
-	Path:         AssetsRoutePrefix + "/robots.txt",
-	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+        Name:         assetsNamePrefix + ".robots",
+        Path:         AssetsRoutePrefix + "/robots.txt",
+        Method:       http.MethodGet,
+        Controller:   "Assets",
+        ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
-	Name:         assetsNamePrefix + ".sitemap",
-	Path:         AssetsRoutePrefix + "/sitemap.xml",
-	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+        Name:         assetsNamePrefix + ".sitemap",
+        Path:         AssetsRoutePrefix + "/sitemap.xml",
+        Method:       http.MethodGet,
+        Controller:   "Assets",
+        ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
-	Name:         assetsNamePrefix + "css.stylesheet",
-	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
-	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+        Name:         assetsNamePrefix + "css.stylesheet",
+        Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
+        Method:       http.MethodGet,
+        Controller:   "Assets",
+        ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
-	Name:         assetsNamePrefix + "js.scripts",
-	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
-	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+        Name:         assetsNamePrefix + "js.scripts",
+        Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
+        Method:       http.MethodGet,
+        Controller:   "Assets",
+        ControllerMethod: "Scripts",
 }
 
 var Script = Route{
-	Name:         assetsNamePrefix + "js.script",
-	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
-	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+        Name:         assetsNamePrefix + "js.script",
+        Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
+        Method:       http.MethodGet,
+        Controller:   "Assets",
+        ControllerMethod: "Script",
 }

--- a/layout/templates/router_routes_pages.tmpl
+++ b/layout/templates/router_routes_pages.tmpl
@@ -9,10 +9,10 @@ var pageRoutes = []Route{
 }
 
 var HomePage = Route{
-	Name:         pageNamePrefix + ".home",
-	Path:         "/",
-	Method:       http.MethodGet,
-	Handler:      "Pages",
-	HandleMethod: "Home",
-	IncludeInSitemap: true,
+        Name:         pageNamePrefix + ".home",
+        Path:         "/",
+        Method:       http.MethodGet,
+        Controller:   "Pages",
+        ControllerMethod: "Home",
+        IncludeInSitemap: true,
 }

--- a/layout/templates/router_routes_routes.tmpl
+++ b/layout/templates/router_routes_routes.tmpl
@@ -4,13 +4,13 @@ package routes
 import "github.com/labstack/echo/v4"
 
 type Route struct {
-	Name         string
-	Path         string
-	Handler      string
-	HandleMethod string
-	Method       string
+	Name             string
+	Path             string
+	Controller       string
+	ControllerMethod string
+	Method           string
 	IncludeInSitemap bool
-	Middleware   []func(next echo.HandlerFunc) echo.HandlerFunc
+	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc
 }
 
 var BuildRoutes = func() []Route {

--- a/layout/testdata/Should_scaffold_project_with_github_repo.txt
+++ b/layout/testdata/Should_scaffold_project_with_github_repo.txt
@@ -1616,7 +1616,7 @@ func (a Assets) Script(c echo.Context) error {
 
 
 === controllers/controller.go ===
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (
@@ -2671,22 +2671,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
+		if route.Controller == "" || route.ControllerMethod == "" {
+			panic("Route must specify Controller and ControllerMethod fields")
 		}
 
-		controllerField := controllersValue.FieldByName(route.Handler)
+		controllerField := controllersValue.FieldByName(route.Controller)
 		if !controllerField.IsValid() {
 			panic(
 				fmt.Sprintf(
 					"Controller field %s not found in controllers struct",
-					route.Handler,
+					route.Controller,
 				),
 			)
 		}
 
 		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -2802,8 +2802,8 @@ var Health = Route{
 	Name:         apiNamePrefix + ".health",
 	Path:         APIRoutePrefix + "/health",
 	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+	Controller:   "API",
+	ControllerMethod: "Health",
 }
 
 
@@ -2835,40 +2835,40 @@ var Robots = Route{
 	Name:         assetsNamePrefix + ".robots",
 	Path:         AssetsRoutePrefix + "/robots.txt",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+	Controller:   "Assets",
+	ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
 	Name:         assetsNamePrefix + ".sitemap",
 	Path:         AssetsRoutePrefix + "/sitemap.xml",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+	Controller:   "Assets",
+	ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
 	Name:         assetsNamePrefix + "css.stylesheet",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+	Controller:   "Assets",
+	ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
 	Name:         assetsNamePrefix + "js.scripts",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+	Controller:   "Assets",
+	ControllerMethod: "Scripts",
 }
 
 var Script = Route{
 	Name:         assetsNamePrefix + "js.script",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+	Controller:   "Assets",
+	ControllerMethod: "Script",
 }
 
 
@@ -2887,8 +2887,8 @@ var HomePage = Route{
 	Name:             pageNamePrefix + ".home",
 	Path:             "/",
 	Method:           http.MethodGet,
-	Handler:          "Pages",
-	HandleMethod:     "Home",
+	Controller:   "Pages",
+	ControllerMethod: "Home",
 	IncludeInSitemap: true,
 }
 
@@ -2902,8 +2902,8 @@ import "github.com/labstack/echo/v4"
 type Route struct {
 	Name             string
 	Path             string
-	Handler          string
-	HandleMethod     string
+	Controller       string
+	ControllerMethod string
 	Method           string
 	IncludeInSitemap bool
 	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc

--- a/layout/testdata/Should_scaffold_project_with_github_repo_sqlite.txt
+++ b/layout/testdata/Should_scaffold_project_with_github_repo_sqlite.txt
@@ -1625,7 +1625,7 @@ func (a Assets) Script(c echo.Context) error {
 
 
 === controllers/controller.go ===
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (
@@ -2672,22 +2672,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
+		if route.Controller == "" || route.ControllerMethod == "" {
+			panic("Route must specify Controller and ControllerMethod fields")
 		}
 
-		controllerField := controllersValue.FieldByName(route.Handler)
+		controllerField := controllersValue.FieldByName(route.Controller)
 		if !controllerField.IsValid() {
 			panic(
 				fmt.Sprintf(
 					"Controller field %s not found in controllers struct",
-					route.Handler,
+					route.Controller,
 				),
 			)
 		}
 
 		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -2803,8 +2803,8 @@ var Health = Route{
 	Name:         apiNamePrefix + ".health",
 	Path:         APIRoutePrefix + "/health",
 	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+	Controller:   "API",
+	ControllerMethod: "Health",
 }
 
 
@@ -2836,40 +2836,40 @@ var Robots = Route{
 	Name:         assetsNamePrefix + ".robots",
 	Path:         AssetsRoutePrefix + "/robots.txt",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+	Controller:   "Assets",
+	ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
 	Name:         assetsNamePrefix + ".sitemap",
 	Path:         AssetsRoutePrefix + "/sitemap.xml",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+	Controller:   "Assets",
+	ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
 	Name:         assetsNamePrefix + "css.stylesheet",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+	Controller:   "Assets",
+	ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
 	Name:         assetsNamePrefix + "js.scripts",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+	Controller:   "Assets",
+	ControllerMethod: "Scripts",
 }
 
 var Script = Route{
 	Name:         assetsNamePrefix + "js.script",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+	Controller:   "Assets",
+	ControllerMethod: "Script",
 }
 
 
@@ -2888,8 +2888,8 @@ var HomePage = Route{
 	Name:             pageNamePrefix + ".home",
 	Path:             "/",
 	Method:           http.MethodGet,
-	Handler:          "Pages",
-	HandleMethod:     "Home",
+	Controller:   "Pages",
+	ControllerMethod: "Home",
 	IncludeInSitemap: true,
 }
 
@@ -2903,8 +2903,8 @@ import "github.com/labstack/echo/v4"
 type Route struct {
 	Name             string
 	Path             string
-	Handler          string
-	HandleMethod     string
+	Controller       string
+	ControllerMethod string
 	Method           string
 	IncludeInSitemap bool
 	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc

--- a/layout/testdata/Should_scaffold_project_with_simple_name.txt
+++ b/layout/testdata/Should_scaffold_project_with_simple_name.txt
@@ -1616,7 +1616,7 @@ func (a Assets) Script(c echo.Context) error {
 
 
 === controllers/controller.go ===
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (
@@ -2671,22 +2671,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
+		if route.Controller == "" || route.ControllerMethod == "" {
+			panic("Route must specify Controller and ControllerMethod fields")
 		}
 
-		controllerField := controllersValue.FieldByName(route.Handler)
+		controllerField := controllersValue.FieldByName(route.Controller)
 		if !controllerField.IsValid() {
 			panic(
 				fmt.Sprintf(
 					"Controller field %s not found in controllers struct",
-					route.Handler,
+					route.Controller,
 				),
 			)
 		}
 
 		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -2802,8 +2802,8 @@ var Health = Route{
 	Name:         apiNamePrefix + ".health",
 	Path:         APIRoutePrefix + "/health",
 	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+	Controller:   "API",
+	ControllerMethod: "Health",
 }
 
 
@@ -2835,40 +2835,40 @@ var Robots = Route{
 	Name:         assetsNamePrefix + ".robots",
 	Path:         AssetsRoutePrefix + "/robots.txt",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+	Controller:   "Assets",
+	ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
 	Name:         assetsNamePrefix + ".sitemap",
 	Path:         AssetsRoutePrefix + "/sitemap.xml",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+	Controller:   "Assets",
+	ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
 	Name:         assetsNamePrefix + "css.stylesheet",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+	Controller:   "Assets",
+	ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
 	Name:         assetsNamePrefix + "js.scripts",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+	Controller:   "Assets",
+	ControllerMethod: "Scripts",
 }
 
 var Script = Route{
 	Name:         assetsNamePrefix + "js.script",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+	Controller:   "Assets",
+	ControllerMethod: "Script",
 }
 
 
@@ -2887,8 +2887,8 @@ var HomePage = Route{
 	Name:             pageNamePrefix + ".home",
 	Path:             "/",
 	Method:           http.MethodGet,
-	Handler:          "Pages",
-	HandleMethod:     "Home",
+	Controller:   "Pages",
+	ControllerMethod: "Home",
 	IncludeInSitemap: true,
 }
 
@@ -2902,8 +2902,8 @@ import "github.com/labstack/echo/v4"
 type Route struct {
 	Name             string
 	Path             string
-	Handler          string
-	HandleMethod     string
+	Controller       string
+	ControllerMethod string
 	Method           string
 	IncludeInSitemap bool
 	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc

--- a/layout/testdata/Should_scaffold_project_with_simple_name_sqlite.txt
+++ b/layout/testdata/Should_scaffold_project_with_simple_name_sqlite.txt
@@ -1625,7 +1625,7 @@ func (a Assets) Script(c echo.Context) error {
 
 
 === controllers/controller.go ===
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (
@@ -2669,22 +2669,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
+		if route.Controller == "" || route.ControllerMethod == "" {
+			panic("Route must specify Controller and ControllerMethod fields")
 		}
 
-		controllerField := controllersValue.FieldByName(route.Handler)
+		controllerField := controllersValue.FieldByName(route.Controller)
 		if !controllerField.IsValid() {
 			panic(
 				fmt.Sprintf(
 					"Controller field %s not found in controllers struct",
-					route.Handler,
+					route.Controller,
 				),
 			)
 		}
 
 		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -2800,8 +2800,8 @@ var Health = Route{
 	Name:         apiNamePrefix + ".health",
 	Path:         APIRoutePrefix + "/health",
 	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+	Controller:   "API",
+	ControllerMethod: "Health",
 }
 
 
@@ -2833,40 +2833,40 @@ var Robots = Route{
 	Name:         assetsNamePrefix + ".robots",
 	Path:         AssetsRoutePrefix + "/robots.txt",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+	Controller:   "Assets",
+	ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
 	Name:         assetsNamePrefix + ".sitemap",
 	Path:         AssetsRoutePrefix + "/sitemap.xml",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+	Controller:   "Assets",
+	ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
 	Name:         assetsNamePrefix + "css.stylesheet",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+	Controller:   "Assets",
+	ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
 	Name:         assetsNamePrefix + "js.scripts",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+	Controller:   "Assets",
+	ControllerMethod: "Scripts",
 }
 
 var Script = Route{
 	Name:         assetsNamePrefix + "js.script",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+	Controller:   "Assets",
+	ControllerMethod: "Script",
 }
 
 
@@ -2885,8 +2885,8 @@ var HomePage = Route{
 	Name:             pageNamePrefix + ".home",
 	Path:             "/",
 	Method:           http.MethodGet,
-	Handler:          "Pages",
-	HandleMethod:     "Home",
+	Controller:   "Pages",
+	ControllerMethod: "Home",
 	IncludeInSitemap: true,
 }
 
@@ -2900,8 +2900,8 @@ import "github.com/labstack/echo/v4"
 type Route struct {
 	Name             string
 	Path             string
-	Handler          string
-	HandleMethod     string
+	Controller       string
+	ControllerMethod string
 	Method           string
 	IncludeInSitemap bool
 	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc

--- a/layout/testdata/Should_scaffold_project_with_simple_repo.txt
+++ b/layout/testdata/Should_scaffold_project_with_simple_repo.txt
@@ -1616,7 +1616,7 @@ func (a Assets) Script(c echo.Context) error {
 
 
 === controllers/controller.go ===
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (
@@ -2671,22 +2671,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
+		if route.Controller == "" || route.ControllerMethod == "" {
+			panic("Route must specify Controller and ControllerMethod fields")
 		}
 
-		controllerField := controllersValue.FieldByName(route.Handler)
+		controllerField := controllersValue.FieldByName(route.Controller)
 		if !controllerField.IsValid() {
 			panic(
 				fmt.Sprintf(
 					"Controller field %s not found in controllers struct",
-					route.Handler,
+					route.Controller,
 				),
 			)
 		}
 
 		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -2802,8 +2802,8 @@ var Health = Route{
 	Name:         apiNamePrefix + ".health",
 	Path:         APIRoutePrefix + "/health",
 	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+	Controller:   "API",
+	ControllerMethod: "Health",
 }
 
 
@@ -2835,40 +2835,40 @@ var Robots = Route{
 	Name:         assetsNamePrefix + ".robots",
 	Path:         AssetsRoutePrefix + "/robots.txt",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+	Controller:   "Assets",
+	ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
 	Name:         assetsNamePrefix + ".sitemap",
 	Path:         AssetsRoutePrefix + "/sitemap.xml",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+	Controller:   "Assets",
+	ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
 	Name:         assetsNamePrefix + "css.stylesheet",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+	Controller:   "Assets",
+	ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
 	Name:         assetsNamePrefix + "js.scripts",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+	Controller:   "Assets",
+	ControllerMethod: "Scripts",
 }
 
 var Script = Route{
 	Name:         assetsNamePrefix + "js.script",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+	Controller:   "Assets",
+	ControllerMethod: "Script",
 }
 
 
@@ -2887,8 +2887,8 @@ var HomePage = Route{
 	Name:             pageNamePrefix + ".home",
 	Path:             "/",
 	Method:           http.MethodGet,
-	Handler:          "Pages",
-	HandleMethod:     "Home",
+	Controller:   "Pages",
+	ControllerMethod: "Home",
 	IncludeInSitemap: true,
 }
 
@@ -2902,8 +2902,8 @@ import "github.com/labstack/echo/v4"
 type Route struct {
 	Name             string
 	Path             string
-	Handler          string
-	HandleMethod     string
+	Controller       string
+	ControllerMethod string
 	Method           string
 	IncludeInSitemap bool
 	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc

--- a/layout/testdata/Should_scaffold_project_with_simple_repo_sqlite.txt
+++ b/layout/testdata/Should_scaffold_project_with_simple_repo_sqlite.txt
@@ -1625,7 +1625,7 @@ func (a Assets) Script(c echo.Context) error {
 
 
 === controllers/controller.go ===
-// Package controllers provides HTTP handlers for the web application.
+// Package controllers provides HTTP controllers for the web application.
 package controllers
 
 import (
@@ -2669,22 +2669,22 @@ func (r *Router) SetupRoutes() *echo.Echo {
 			)
 		}
 
-		if route.Handler == "" || route.HandleMethod == "" {
-			panic("Route must specify Handler and HandleMethod fields")
+		if route.Controller == "" || route.ControllerMethod == "" {
+			panic("Route must specify Controller and ControllerMethod fields")
 		}
 
-		controllerField := controllersValue.FieldByName(route.Handler)
+		controllerField := controllersValue.FieldByName(route.Controller)
 		if !controllerField.IsValid() {
 			panic(
 				fmt.Sprintf(
 					"Controller field %s not found in controllers struct",
-					route.Handler,
+					route.Controller,
 				),
 			)
 		}
 
 		controller := controllerField.Interface()
-		controllerFunc := getHandlerFunc(controller, route.HandleMethod)
+		controllerFunc := getHandlerFunc(controller, route.ControllerMethod)
 
 		var middlewareFuncs []echo.MiddlewareFunc
 		for _, mw := range route.Middleware {
@@ -2800,8 +2800,8 @@ var Health = Route{
 	Name:         apiNamePrefix + ".health",
 	Path:         APIRoutePrefix + "/health",
 	Method:       http.MethodGet,
-	Handler:      "API",
-	HandleMethod: "Health",
+	Controller:   "API",
+	ControllerMethod: "Health",
 }
 
 
@@ -2833,40 +2833,40 @@ var Robots = Route{
 	Name:         assetsNamePrefix + ".robots",
 	Path:         AssetsRoutePrefix + "/robots.txt",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Robots",
+	Controller:   "Assets",
+	ControllerMethod: "Robots",
 }
 
 var Sitemap = Route{
 	Name:         assetsNamePrefix + ".sitemap",
 	Path:         AssetsRoutePrefix + "/sitemap.xml",
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Sitemap",
+	Controller:   "Assets",
+	ControllerMethod: "Sitemap",
 }
 
 var Stylesheet = Route{
 	Name:         assetsNamePrefix + "css.stylesheet",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/css/%v/tw.css", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Stylesheet",
+	Controller:   "Assets",
+	ControllerMethod: "Stylesheet",
 }
 
 var Scripts = Route{
 	Name:         assetsNamePrefix + "js.scripts",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/scripts.js", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Scripts",
+	Controller:   "Assets",
+	ControllerMethod: "Scripts",
 }
 
 var Script = Route{
 	Name:         assetsNamePrefix + "js.script",
 	Path:         AssetsRoutePrefix + fmt.Sprintf("/js/%v/:file", startTime),
 	Method:       http.MethodGet,
-	Handler:      "Assets",
-	HandleMethod: "Script",
+	Controller:   "Assets",
+	ControllerMethod: "Script",
 }
 
 
@@ -2885,8 +2885,8 @@ var HomePage = Route{
 	Name:             pageNamePrefix + ".home",
 	Path:             "/",
 	Method:           http.MethodGet,
-	Handler:          "Pages",
-	HandleMethod:     "Home",
+	Controller:   "Pages",
+	ControllerMethod: "Home",
 	IncludeInSitemap: true,
 }
 
@@ -2900,8 +2900,8 @@ import "github.com/labstack/echo/v4"
 type Route struct {
 	Name             string
 	Path             string
-	Handler          string
-	HandleMethod     string
+	Controller       string
+	ControllerMethod string
 	Method           string
 	IncludeInSitemap bool
 	Middleware       []func(next echo.HandlerFunc) echo.HandlerFunc


### PR DESCRIPTION
## Summary
- rename router route definitions to use Controller and ControllerMethod fields instead of Handler/HandleMethod
- update generator templates and golden fixtures to align with controller terminology
- adjust scaffolded documentation/comments to describe controllers consistently

## Testing
- go test ./... *(fails: go mod tidy requires external network access during layout golden tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df907009b0832f9b7bbe0b81598f7d