### PR TITLE
feat: add basic logging setup

### DIFF
--- a/layout/layout.go
+++ b/layout/layout.go
@@ -308,6 +308,7 @@ var baseTemplateMappings = map[TmplTarget]TmplTargetPath{
 
 	// Router
 	"router_router.tmpl":                "router/router.go",
+	"router_std_out_logger.tmpl":        "router/stdout_logger.go",
 	"router_cookies_cookies.tmpl":       "router/cookies/cookies.go",
 	"router_cookies_flash.tmpl":         "router/cookies/flash.go",
 	"router_middleware_middleware.tmpl": "router/middleware/middleware.go",

--- a/layout/templates/cmd_app_main.tmpl
+++ b/layout/templates/cmd_app_main.tmpl
@@ -83,8 +83,9 @@ func setupControllers(
 	return ctrl, nil
 }
 
-func setupRouter(ctrl controllers.Controllers, cfg config.Config) (*echo.Echo, error) {
+func setupRouter(ctx context.Context, ctrl controllers.Controllers, cfg config.Config) (*echo.Echo, error) {
 	router, err := router.New(
+		ctx,
 		ctrl,
 		cfg,
 	)
@@ -100,6 +101,20 @@ func run(ctx context.Context) error {
 	defer cancel()
 
 	cfg := config.NewConfig()
+
+	stdoutExporter := &router.StdoutExporter{
+		LogLevel:   slog.LevelInfo,
+	}
+
+	logger, shutdownLogger := router.NewLogger(ctx, stdoutExporter)
+	defer func() {
+		if err := shutdownLogger(ctx); err != nil {
+			slog.Error("Error shutting down logger", "error", err)
+		}
+	}()
+
+	slog.SetDefault(logger)
+
 
 {{- if eq .Database "postgresql"}}
 	db, err := database.NewPostgres(ctx, cfg.DB.GetDatabaseURL())
@@ -137,7 +152,8 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	handler, err := setupRouter(controllers, cfg)
+
+	handler, err := setupRouter(ctx, controllers, cfg)
 	if err != nil {
 		return err
 	}

--- a/layout/templates/router_router.tmpl
+++ b/layout/templates/router_router.tmpl
@@ -2,6 +2,7 @@
 package router
 
 import (
+	"context"
 	"encoding/gob"
 	"encoding/hex"
 	"fmt"
@@ -30,6 +31,7 @@ type Router struct {
 }
 
 func New(
+	ctx context.Context,
 	controllers controllers.Controllers,
 	cfg config.Config,
 ) (*Router, error) {
@@ -59,6 +61,7 @@ func New(
 	csrfName := "_csrf"
 
 	router.Use(
+		logger(),
 		session.Middleware(
 			sessions.NewCookieStore(
 				authKey,
@@ -80,7 +83,6 @@ func New(
 		}(), CookieSecure: config.Env == config.ProdEnvironment, CookieHTTPOnly: true, CookieSameSite: http.SameSiteStrictMode}),
 
 		echomw.Recover(),
-		echomw.Logger(),
 	)
 
 	return &Router{
@@ -212,5 +214,63 @@ func registerFlashMessagesContext(
 		c.Set(string(cookies.FlashKey), flashes)
 
 		return next(c)
+	}
+}
+
+type LogExporter interface {
+	Name() string
+	GetSlogHandler(
+		ctx context.Context,
+	) (slog.Handler, error)
+
+	Shutdown(ctx context.Context) error
+}
+
+func NewLogger(
+	ctx context.Context,
+	exporter LogExporter,
+) (*slog.Logger, func(ctx context.Context) error) {
+	handler, err := exporter.GetSlogHandler(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	return slog.New(handler), exporter.Shutdown
+}
+
+func logger() echo.MiddlewareFunc {
+	otelMiddleware := otelecho.Middleware(
+		config.ProjectName,
+	)
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if strings.Contains(c.Request().URL.Path, routes.APIRoutePrefix) ||
+				strings.Contains(c.Request().URL.Path, routes.AssetsRoutePrefix) {
+				return next(c)
+			}
+
+			start := time.Now()
+
+			var statusCode int
+			wrappedNext := func(c echo.Context) error {
+				err := next(c)
+				statusCode = c.Response().Status
+				return err
+			}
+
+			err := otelMiddleware(wrappedNext)(c)
+			duration := time.Since(start)
+
+			slog.InfoContext(c.Request().Context(), "HTTP request completed",
+				"method", c.Request().Method,
+				"path", c.Request().URL.Path,
+				"status", statusCode,
+				"remote_addr", c.RealIP(),
+				"user_agent", c.Request().UserAgent(),
+				"duration", duration.String(),
+			)
+
+			return err
+		}
 	}
 }

--- a/layout/templates/router_router.tmpl
+++ b/layout/templates/router_router.tmpl
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"time"
 
 	"{{.ModuleName}}/config"
 	"{{.ModuleName}}/controllers"
@@ -21,6 +22,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
 
 	echomw "github.com/labstack/echo/v4/middleware"
 )

--- a/layout/templates/router_std_out_logger.tmpl
+++ b/layout/templates/router_std_out_logger.tmpl
@@ -1,0 +1,36 @@
+package router
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/lmittmann/tint"
+)
+
+type StdoutExporter struct {
+	LogLevel   slog.Level
+}
+
+// GetSlogHandler implements LogExporter.
+func (s *StdoutExporter) GetSlogHandler(
+	ctx context.Context,
+) (slog.Handler, error) {
+	handler := tint.NewHandler(os.Stdout, &tint.Options{
+		Level:      s.LogLevel,
+		TimeFormat: "15:04:05",
+		AddSource:  true,
+	})
+
+	return handler, nil
+}
+
+// Name implements LogExporter.
+func (s *StdoutExporter) Name() string {
+	return "stdout"
+}
+
+// Shutdown implements LogExporter.
+func (s *StdoutExporter) Shutdown(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Adds a basic logging setup to router and also sets up the base for adding proper telemetry later with log exporters.