### PR TITLE
fix tailwind download url; add gitignore;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+andurel-dev

--- a/layout/cmds/download.go
+++ b/layout/cmds/download.go
@@ -120,6 +120,10 @@ func (d *ToolDownloader) getReleaseURL(goos, goarch string) (string, string, err
 
 func DownloadTailwindCLI(version, goos, goarch, destPath string) error {
 	osName := goos
+	if osName == "darwin" {
+		osName = "macos"
+	}
+
 	arch := goarch
 	if arch == "amd64" {
 		arch = "x64"


### PR DESCRIPTION
**What does this do?**
fix download url of tailwindcss for MacOS

**Which issue(s) does this PR fix/relate to?**
https://github.com/mbvlabs/andurel/issues/327

**List any changes that modify/break current functionality**
1. Adding .gitignore to prevent compiled binary app for testing being pushed/merged
2. Adding conditional logic to rename 'darwin' to 'macos'

**Did you document any new/modified functionality?**
 Add .gitignore
 Updated download.go