### PR TITLE
feat: make the cli agent friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,21 +343,6 @@ andurel extension list (alias: ls)
 
 Available extensions: `docker`, `aws-ses`, `css-components`.
 
-### `andurel llm` — LLM documentation
-
-Outputs comprehensive framework documentation for AI assistants. Supports topic-specific subcommands:
-
-```bash
-andurel llm (alias: l)
-andurel llm controllers (alias: c)
-andurel llm models (alias: m)
-andurel llm views (alias: v)
-andurel llm router (alias: r)
-andurel llm hypermedia (alias: h)
-andurel llm jobs (alias: j)
-andurel llm config (alias: cfg)
-```
-
 ### `andurel upgrade` — Framework upgrade
 
 Upgrade framework-managed files and tool versions to the latest.
@@ -403,14 +388,6 @@ andurel doctor (alias: doc) [--verbose]
 | `andurel database migrate down-to` | `downto` |
 | `andurel run` | `r` |
 | `andurel console` | `c` |
-| `andurel llm` | `l` |
-| `andurel llm controllers` | `c` |
-| `andurel llm models` | `m` |
-| `andurel llm views` | `v` |
-| `andurel llm router` | `r` |
-| `andurel llm hypermedia` | `h` |
-| `andurel llm jobs` | `j` |
-| `andurel llm config` | `cfg` |
 | `andurel tool` | `t` |
 | `andurel tool sync` | `s` |
 | `andurel tool set-version` | `sv` |

--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -90,7 +90,7 @@ func runMutation(cmd *cobra.Command, opts mutationOptions) error {
 	if err := os.Chdir(opts.RootDir); err != nil {
 		return err
 	}
-	runErr := runWithOptionalStdoutSilence(outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent, func() error {
+	runErr := runWithOptionalStdoutSilence(output.SuppressesHumanOutput(outOpts), func() error {
 		return opts.Run(opts.RootDir)
 	})
 	_ = os.Chdir(oldWD)
@@ -103,7 +103,7 @@ func runMutation(cmd *cobra.Command, opts mutationOptions) error {
 		return err
 	}
 	report := buildMutationReport(opts, before, after)
-	if outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent || outOpts.Mode == output.ModeMarkdown || outOpts.Quiet {
+	if output.SuppressesHumanOutput(outOpts) {
 		return output.OK(cmd, report, mutationSummary(report), opts.Breadcrumbs...)
 	}
 	return nil
@@ -134,7 +134,7 @@ func runDryMutation(cmd *cobra.Command, outOpts output.Options, opts mutationOpt
 	findGoModRoot = func() (string, error) {
 		return tempRoot, nil
 	}
-	runErr := runWithOptionalStdoutSilence(outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent, func() error {
+	runErr := runWithOptionalStdoutSilence(output.SuppressesHumanOutput(outOpts), func() error {
 		return opts.Run(tempRoot)
 	})
 	findGoModRoot = originalFindGoModRoot

--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -1,0 +1,408 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/spf13/cobra"
+)
+
+type mutationReport struct {
+	Action       string   `json:"action"`
+	Resource     string   `json:"resource,omitempty"`
+	DryRun       bool     `json:"dry_run,omitempty"`
+	FilesCreated []string `json:"files_created"`
+	FilesUpdated []string `json:"files_updated"`
+	FilesDeleted []string `json:"files_deleted,omitempty"`
+	RoutesAdded  []string `json:"routes_added"`
+	CommandsRun  []string `json:"commands_run"`
+	Warnings     []string `json:"warnings,omitempty"`
+	Diff         string   `json:"diff,omitempty"`
+}
+
+type mutationOptions struct {
+	Action      string
+	Resource    string
+	RootDir     string
+	DryRun      bool
+	Diff        bool
+	CommandsRun []string
+	Warnings    []string
+	Breadcrumbs []output.Breadcrumb
+	Run         func(rootDir string) error
+}
+
+type fileSnapshot map[string]fileState
+
+type fileState struct {
+	Hash    [32]byte
+	Content []byte
+	Mode    os.FileMode
+}
+
+func addDryRunDiffFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("dry-run", false, "Preview file changes without applying them")
+	cmd.Flags().Bool("diff", false, "Include a text diff preview in structured output")
+}
+
+func dryRunDiffOptions(cmd *cobra.Command) (dryRun bool, diff bool, err error) {
+	dryRun, err = cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return false, false, err
+	}
+	diff, err = cmd.Flags().GetBool("diff")
+	if err != nil {
+		return false, false, err
+	}
+	return dryRun, diff, nil
+}
+
+func runMutation(cmd *cobra.Command, opts mutationOptions) error {
+	if opts.Run == nil {
+		return output.NewError(output.CodeUsage, "mutation runner is not configured", output.ExitUsage, "")
+	}
+	if opts.RootDir == "" {
+		return output.NewError(output.CodeProjectNotFound, "project root is required", output.ExitProject, "")
+	}
+
+	outOpts, err := output.ParseOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		return runDryMutation(cmd, outOpts, opts)
+	}
+
+	before, err := snapshotFilesForReport(opts.RootDir)
+	if err != nil {
+		return err
+	}
+
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(opts.RootDir); err != nil {
+		return err
+	}
+	runErr := runWithOptionalStdoutSilence(outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent, func() error {
+		return opts.Run(opts.RootDir)
+	})
+	_ = os.Chdir(oldWD)
+	if runErr != nil {
+		return runErr
+	}
+
+	after, err := snapshotFilesForReport(opts.RootDir)
+	if err != nil {
+		return err
+	}
+	report := buildMutationReport(opts, before, after)
+	if outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent || outOpts.Mode == output.ModeMarkdown || outOpts.Quiet {
+		return output.OK(cmd, report, mutationSummary(report), opts.Breadcrumbs...)
+	}
+	return nil
+}
+
+func runDryMutation(cmd *cobra.Command, outOpts output.Options, opts mutationOptions) error {
+	tempParent, err := os.MkdirTemp("", "andurel-dry-run-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempParent)
+
+	tempRoot := filepath.Join(tempParent, filepath.Base(opts.RootDir))
+	if err := copyDir(opts.RootDir, tempRoot); err != nil {
+		return err
+	}
+
+	before, err := snapshotFilesForReport(tempRoot)
+	if err != nil {
+		return err
+	}
+
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tempRoot); err != nil {
+		return err
+	}
+	originalFindGoModRoot := findGoModRoot
+	findGoModRoot = func() (string, error) {
+		return tempRoot, nil
+	}
+	runErr := runWithOptionalStdoutSilence(outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent, func() error {
+		return opts.Run(tempRoot)
+	})
+	findGoModRoot = originalFindGoModRoot
+	_ = os.Chdir(oldWD)
+	if runErr != nil {
+		return runErr
+	}
+
+	after, err := snapshotFilesForReport(tempRoot)
+	if err != nil {
+		return err
+	}
+
+	report := buildMutationReport(opts, before, after)
+	report.DryRun = true
+	report.Warnings = append(report.Warnings, "dry run only; no files were changed")
+	if outOpts.Mode == output.ModeHuman && !outOpts.Quiet {
+		fmt.Fprintf(cmd.OutOrStdout(), "Dry run: %s\n", mutationSummary(report))
+		for _, path := range report.FilesCreated {
+			fmt.Fprintf(cmd.OutOrStdout(), "  create %s\n", path)
+		}
+		for _, path := range report.FilesUpdated {
+			fmt.Fprintf(cmd.OutOrStdout(), "  update %s\n", path)
+		}
+		for _, path := range report.FilesDeleted {
+			fmt.Fprintf(cmd.OutOrStdout(), "  delete %s\n", path)
+		}
+		return nil
+	}
+	return output.OK(cmd, report, mutationSummary(report), opts.Breadcrumbs...)
+}
+
+func buildMutationReport(opts mutationOptions, before, after fileSnapshot) mutationReport {
+	report := mutationReport{
+		Action:       opts.Action,
+		Resource:     opts.Resource,
+		DryRun:       opts.DryRun,
+		FilesCreated: []string{},
+		FilesUpdated: []string{},
+		FilesDeleted: []string{},
+		RoutesAdded:  []string{},
+		CommandsRun:  append([]string(nil), opts.CommandsRun...),
+		Warnings:     append([]string(nil), opts.Warnings...),
+	}
+
+	for path, afterState := range after {
+		beforeState, exists := before[path]
+		if !exists {
+			report.FilesCreated = append(report.FilesCreated, path)
+			if isRoutePath(path) {
+				report.RoutesAdded = append(report.RoutesAdded, path)
+			}
+			continue
+		}
+		if beforeState.Hash != afterState.Hash {
+			report.FilesUpdated = append(report.FilesUpdated, path)
+			if isRoutePath(path) {
+				report.RoutesAdded = append(report.RoutesAdded, path)
+			}
+		}
+	}
+	for path := range before {
+		if _, exists := after[path]; !exists {
+			report.FilesDeleted = append(report.FilesDeleted, path)
+		}
+	}
+
+	sort.Strings(report.FilesCreated)
+	sort.Strings(report.FilesUpdated)
+	sort.Strings(report.FilesDeleted)
+	sort.Strings(report.RoutesAdded)
+	if opts.Diff {
+		report.Diff = buildTextDiff(before, after, append(append([]string{}, report.FilesCreated...), report.FilesUpdated...))
+	}
+
+	return report
+}
+
+func mutationSummary(report mutationReport) string {
+	verb := "Changed"
+	if report.DryRun {
+		verb = "Would change"
+	}
+	total := len(report.FilesCreated) + len(report.FilesUpdated) + len(report.FilesDeleted)
+	if total == 0 {
+		return fmt.Sprintf("%s completed with no file changes", report.Action)
+	}
+	return fmt.Sprintf("%s %d files for %s", verb, total, report.Action)
+}
+
+func isRoutePath(path string) bool {
+	return strings.HasPrefix(filepath.ToSlash(path), "router/routes/")
+}
+
+func snapshotFilesForReport(root string) (fileSnapshot, error) {
+	snapshot := fileSnapshot{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if shouldSkipReportPath(rel, entry) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		snapshot[rel] = fileState{
+			Hash:    sha256.Sum256(content),
+			Content: content,
+			Mode:    info.Mode(),
+		}
+		return nil
+	})
+	return snapshot, err
+}
+
+func shouldSkipReportPath(rel string, entry os.DirEntry) bool {
+	name := entry.Name()
+	if name == ".git" || name == "bin" || name == "node_modules" || name == ".andurel-cache" {
+		return true
+	}
+	return strings.HasPrefix(rel, ".git/")
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dst, 0o755)
+		}
+		rel = filepath.ToSlash(rel)
+		if shouldSkipReportPath(rel, entry) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		target := filepath.Join(dst, filepath.FromSlash(rel))
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func buildTextDiff(before, after fileSnapshot, paths []string) string {
+	var b strings.Builder
+	sort.Strings(paths)
+	for _, path := range paths {
+		afterState := after[path]
+		if !isTextContent(afterState.Content) {
+			continue
+		}
+		beforeContent := before[path].Content
+		if len(beforeContent) > 0 && !isTextContent(beforeContent) {
+			continue
+		}
+		b.WriteString("diff --git a/")
+		b.WriteString(path)
+		b.WriteString(" b/")
+		b.WriteString(path)
+		b.WriteByte('\n')
+		if len(beforeContent) == 0 {
+			b.WriteString("--- /dev/null\n")
+		} else {
+			b.WriteString("--- a/")
+			b.WriteString(path)
+			b.WriteByte('\n')
+		}
+		b.WriteString("+++ b/")
+		b.WriteString(path)
+		b.WriteByte('\n')
+		b.WriteString(simpleLineDiff(string(beforeContent), string(afterState.Content)))
+	}
+	return b.String()
+}
+
+func runWithOptionalStdoutSilence(silence bool, run func() error) error {
+	if !silence {
+		return run()
+	}
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	os.Stdout = writer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, reader)
+		close(done)
+	}()
+
+	runErr := run()
+	_ = writer.Close()
+	os.Stdout = original
+	<-done
+	_ = reader.Close()
+	return runErr
+}
+
+func isTextContent(content []byte) bool {
+	return !bytes.Contains(content, []byte{0})
+}
+
+func simpleLineDiff(before, after string) string {
+	var b strings.Builder
+	if before != "" {
+		for line := range strings.SplitSeq(strings.TrimSuffix(before, "\n"), "\n") {
+			b.WriteString("-")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	if after != "" {
+		for line := range strings.SplitSeq(strings.TrimSuffix(after, "\n"), "\n") {
+			b.WriteString("+")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}

--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -309,7 +309,7 @@ func copyDir(src, dst string) error {
 	})
 }
 
-func copyFile(src, dst string, mode os.FileMode) error {
+func copyFile(src, dst string, mode os.FileMode) (err error) {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}
@@ -322,7 +322,11 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if closeErr := out.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
 	_, err = io.Copy(out, in)
 	return err
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/pkg/cache"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,10 @@ type helpCommand struct {
 func setStandardHelp(cmd *cobra.Command, commands ...helpCommand) {
 	helpOwner := cmd
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if renderStructuredHelpIfNeeded(cmd) {
+			return
+		}
+
 		// Output description
 		if cmd.Long != "" {
 			fmt.Println(cmd.Long)
@@ -70,6 +75,10 @@ func setStandardHelp(cmd *cobra.Command, commands ...helpCommand) {
 			// FlagUsages already has leading spaces, just print as-is
 			fmt.Print(usage)
 		}
+		if cmd.HasAvailableInheritedFlags() {
+			fmt.Println("Global Flags:")
+			fmt.Print(cmd.InheritedFlags().FlagUsages())
+		}
 	})
 }
 
@@ -83,17 +92,20 @@ func isInAndurelProject() bool {
 
 func NewRootCommand(version, date string) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:          "andurel",
-		Short:        "Andurel - The Go Web development framework",
-		Long:         `Andurel is a comprehensive web development framework for Go,`,
-		Version:      fmt.Sprintf("%s (built: %s)", version, date),
-		SilenceUsage: true,
+		Use:           "andurel",
+		Short:         "Andurel - The Go Web development framework",
+		Long:          `Andurel is a comprehensive web development framework for Go,`,
+		Version:       fmt.Sprintf("%s (built: %s)", version, date),
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			printBanner()
 			fmt.Println()
 			cmd.Help()
 		},
 	}
+
+	output.RegisterPersistentFlags(rootCmd)
 
 	rootCmd.AddCommand(newProjectCommand(version))
 	rootCmd.AddCommand(newGenerateCommand())
@@ -107,11 +119,25 @@ func NewRootCommand(version, date string) *cobra.Command {
 	rootCmd.AddCommand(newBuildCommand())
 	rootCmd.AddCommand(newUpgradeCommand(version))
 	rootCmd.AddCommand(newDoctorCommand(version))
+	rootCmd.AddCommand(newCommandsCommand(rootCmd))
+	rootCmd.AddCommand(newProjectInfoCommand())
+	rootCmd.AddCommand(newRoutesCommand())
+	rootCmd.AddCommand(newModelsCommand())
+	rootCmd.AddCommand(newMigrationsCommand())
+	rootCmd.AddCommand(newControllersCommand())
+	rootCmd.AddCommand(newViewsCommand())
+	rootCmd.AddCommand(newJobsCommand())
+	rootCmd.AddCommand(newConfigCommand())
+	rootCmd.AddCommand(newSkillCommand())
 
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
 	rootCmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		if renderStructuredHelpIfNeeded(c) {
+			return
+		}
+
 		if c.Parent() != nil {
 			c.Print(c.Short)
 			c.Println()
@@ -133,6 +159,11 @@ func NewRootCommand(version, date string) *cobra.Command {
 				c.Println("Flags:")
 				c.Print(c.LocalFlags().FlagUsages())
 			}
+			if c.HasAvailableInheritedFlags() {
+				c.Println()
+				c.Println("Global Flags:")
+				c.Print(c.InheritedFlags().FlagUsages())
+			}
 			return
 		}
 		if isInAndurelProject() {
@@ -151,7 +182,7 @@ func NewRootCommand(version, date string) *cobra.Command {
 			}
 			c.Println()
 			c.Println("Flags:")
-			c.Println(c.LocalFlags().FlagUsages())
+			c.Print(c.PersistentFlags().FlagUsages())
 			c.Println("Use \"andurel [command] --help\" for more information about a command.")
 		} else {
 			fmt.Println("Usage:")
@@ -162,6 +193,9 @@ func NewRootCommand(version, date string) *cobra.Command {
 			fmt.Printf("  %-14s %s\n", "new", "Create a new Andurel project")
 			fmt.Println()
 			fmt.Println("All commands can be run with -h (or --help) for more information.")
+			fmt.Println()
+			fmt.Println("Global Flags:")
+			fmt.Print(c.PersistentFlags().FlagUsages())
 			fmt.Println()
 			fmt.Println("Inside an Andurel application directory, some common commands are:")
 			fmt.Println()
@@ -251,7 +285,7 @@ func checkBinaries(rootDir string) error {
 
 	binPath := filepath.Join(rootDir, "bin", "shadowfax")
 	if _, err := os.Stat(binPath); err != nil {
-		return fmt.Errorf("bin/shadowfax not found. Run 'andurel tool sync' to download it")
+		return output.NewError(output.CodeMissingTool, "bin/shadowfax not found", output.ExitDependency, "Run 'andurel tool sync' to download it.")
 	}
 
 	return nil

--- a/cli/command_contract_test.go
+++ b/cli/command_contract_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -8,21 +9,40 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type discoverySummary struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type flagSummary struct {
+	Name string `json:"name"`
+}
+
 func TestRootCommandPublicSurface(t *testing.T) {
 	rootCmd := NewRootCommand("test", "test-date")
 
 	expected := []commandContract{
 		{name: "build"},
+		{name: "commands"},
+		{name: "config"},
 		{name: "console", aliases: []string{"c"}},
+		{name: "controllers"},
 		{name: "database", aliases: []string{"d", "db"}},
 		{name: "doctor", aliases: []string{"doc"}},
-		{name: "extension", aliases: []string{"ext", "e"}},
+		{name: "extension", aliases: []string{"extensions", "ext", "e"}},
 		{name: "fmt", aliases: []string{"f"}},
 		{name: "generate", aliases: []string{"g"}},
+		{name: "jobs"},
+		{name: "migrations"},
+		{name: "models"},
 		{name: "new", aliases: []string{"n"}},
+		{name: "project"},
+		{name: "routes"},
 		{name: "run", aliases: []string{"r"}},
-		{name: "tool", aliases: []string{"t"}},
+		{name: "skill"},
+		{name: "tool", aliases: []string{"tools", "t"}},
 		{name: "upgrade", aliases: []string{"up"}},
+		{name: "views"},
 	}
 
 	assertCommandSurface(t, rootCmd, expected)
@@ -44,6 +64,107 @@ func TestGenerateCommandPublicSurface(t *testing.T) {
 	assertCommandSurface(t, generateCmd, expected)
 }
 
+func TestCommandsJSONDiscovery(t *testing.T) {
+	result := runCLITest(t, "commands", "--json")
+	if result.err != nil {
+		t.Fatalf("commands --json returned error: %v\nstderr:\n%s", result.err, result.stderr)
+	}
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Name        string             `json:"name"`
+			Path        string             `json:"path"`
+			Subcommands []discoverySummary `json:"subcommands"`
+			Commands    []discoverySummary `json:"commands"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+		t.Fatalf("decode commands output: %v\nstdout:\n%s", err, result.stdout)
+	}
+	if !envelope.OK {
+		t.Fatalf("expected ok envelope: %#v", envelope)
+	}
+	if envelope.Data.Name != "andurel" || envelope.Data.Path != "andurel" {
+		t.Fatalf("unexpected root discovery: %#v", envelope.Data)
+	}
+	if !discoveryContains(envelope.Data.Subcommands, "generate", "andurel generate") {
+		t.Fatalf("expected generate subcommand in discovery: %#v", envelope.Data.Subcommands)
+	}
+	if !discoveryContains(envelope.Data.Commands, "commands", "andurel commands") {
+		t.Fatalf("expected commands command in full tree: %#v", envelope.Data.Commands)
+	}
+}
+
+func TestAgentHelpDiscovery(t *testing.T) {
+	result := runCLITest(t, "--agent", "--help")
+	if result.err != nil {
+		t.Fatalf("--agent --help returned error: %v\nstderr:\n%s", result.err, result.stderr)
+	}
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Name        string             `json:"name"`
+			Path        string             `json:"path"`
+			LocalFlags  []flagSummary      `json:"local_flags"`
+			Subcommands []discoverySummary `json:"subcommands"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+		t.Fatalf("decode agent help: %v\nstdout:\n%s", err, result.stdout)
+	}
+	if !envelope.OK {
+		t.Fatalf("expected ok envelope: %#v", envelope)
+	}
+	if envelope.Data.Name != "andurel" || envelope.Data.Path != "andurel" {
+		t.Fatalf("unexpected help data: %#v", envelope.Data)
+	}
+	if !flagDiscoveryContains(envelope.Data.LocalFlags, "agent") {
+		t.Fatalf("expected root output flags in help: %#v", envelope.Data.LocalFlags)
+	}
+	if !discoveryContains(envelope.Data.Subcommands, "commands", "andurel commands") {
+		t.Fatalf("expected commands subcommand in help: %#v", envelope.Data.Subcommands)
+	}
+}
+
+func TestGenerateAgentHelpDiscovery(t *testing.T) {
+	result := runCLITest(t, "generate", "--agent", "--help")
+	if result.err != nil {
+		t.Fatalf("generate --agent --help returned error: %v\nstderr:\n%s", result.err, result.stderr)
+	}
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Name           string             `json:"name"`
+			Path           string             `json:"path"`
+			Category       string             `json:"category"`
+			AgentNotes     string             `json:"agent_notes"`
+			InheritedFlags []flagSummary      `json:"inherited_flags"`
+			Subcommands    []discoverySummary `json:"subcommands"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+		t.Fatalf("decode generate agent help: %v\nstdout:\n%s", err, result.stdout)
+	}
+	if !envelope.OK {
+		t.Fatalf("expected ok envelope: %#v", envelope)
+	}
+	if envelope.Data.Name != "generate" || envelope.Data.Path != "andurel generate" {
+		t.Fatalf("unexpected generate help data: %#v", envelope.Data)
+	}
+	if envelope.Data.Category != "generation" || envelope.Data.AgentNotes == "" {
+		t.Fatalf("expected generate agent metadata: %#v", envelope.Data)
+	}
+	if !flagDiscoveryContains(envelope.Data.InheritedFlags, "json") {
+		t.Fatalf("expected inherited output flags: %#v", envelope.Data.InheritedFlags)
+	}
+	if !discoveryContains(envelope.Data.Subcommands, "scaffold", "andurel generate scaffold") {
+		t.Fatalf("expected scaffold subcommand in help: %#v", envelope.Data.Subcommands)
+	}
+}
+
 func TestCommandFlagsContract(t *testing.T) {
 	rootCmd := NewRootCommand("test", "test-date")
 
@@ -51,18 +172,21 @@ func TestCommandFlagsContract(t *testing.T) {
 		path  string
 		flags []string
 	}{
-		{path: "new", flags: []string{"extensions", "inertia"}},
-		{path: "generate model", flags: []string{"skip-factory", "table-name", "update", "yes", "primary-key"}},
-		{path: "generate controller", flags: []string{"inertia", "model-name"}},
-		{path: "generate scaffold", flags: []string{"skip-factory", "table-name", "primary-key", "inertia"}},
-		{path: "generate job", flags: []string{"queue"}},
+		{path: "new", flags: []string{"extensions", "inertia", "dry-run", "diff"}},
+		{path: "generate model", flags: []string{"skip-factory", "table-name", "update", "yes", "primary-key", "dry-run", "diff"}},
+		{path: "generate controller", flags: []string{"inertia", "model-name", "dry-run", "diff"}},
+		{path: "generate scaffold", flags: []string{"skip-factory", "table-name", "primary-key", "inertia", "dry-run", "diff"}},
+		{path: "generate job", flags: []string{"queue", "dry-run", "diff"}},
+		{path: "generate email", flags: []string{"dry-run", "diff"}},
+		{path: "extension add", flags: []string{"dry-run", "diff"}},
+		{path: "extension list", flags: []string{"available"}},
 		{path: "fmt", flags: []string{"check", "skip-templ", "skip-go"}},
 		{path: "database drop", flags: []string{"force"}},
 		{path: "database nuke", flags: []string{"force"}},
 		{path: "database rebuild", flags: []string{"force", "skip-seed"}},
 		{path: "build", flags: []string{"version"}},
 		{path: "doctor", flags: []string{"verbose"}},
-		{path: "upgrade", flags: []string{"dry-run"}},
+		{path: "upgrade", flags: []string{"dry-run", "diff"}},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +198,34 @@ func TestCommandFlagsContract(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func discoveryContains(commands []discoverySummary, name, path string) bool {
+	for _, command := range commands {
+		if command.Name == name && command.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func flagDiscoveryContains(flags []flagSummary, name string) bool {
+	for _, flag := range flags {
+		if flag.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRootCommandPersistentOutputFlags(t *testing.T) {
+	rootCmd := NewRootCommand("test", "test-date")
+
+	for _, flag := range []string{"json", "agent", "md", "quiet", "jq", "ids-only", "count", "verbose"} {
+		if rootCmd.PersistentFlags().Lookup(flag) == nil {
+			t.Fatalf("root command missing persistent --%s flag", flag)
+		}
 	}
 }
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,0 +1,287 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/spf13/cobra"
+)
+
+type agentConfig struct {
+	PreferredGeneratorMode       string            `json:"preferred_generator_mode,omitempty"`
+	JavaScriptRuntime            string            `json:"javascript_runtime,omitempty"`
+	DefaultNamespace             string            `json:"default_namespace,omitempty"`
+	OutputFormat                 string            `json:"output_format,omitempty"`
+	CommonDatabaseCommandOptions map[string]string `json:"common_database_command_options,omitempty"`
+	Values                       map[string]string `json:"values,omitempty"`
+}
+
+type configShowReport struct {
+	User    agentConfig `json:"user"`
+	Project agentConfig `json:"project"`
+	Cache   agentConfig `json:"cache"`
+	Merged  agentConfig `json:"merged"`
+	Paths   configPaths `json:"paths"`
+}
+
+type configPaths struct {
+	User    string `json:"user"`
+	Project string `json:"project"`
+	Cache   string `json:"cache"`
+}
+
+func newConfigCommand() *cobra.Command {
+	var scope string
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Andurel agent configuration",
+		Long:  "Manage user, project, and cache configuration for agent-friendly Andurel defaults.",
+	}
+	setAgentMetadata(cmd, "config", "Reads and writes non-secret Andurel configuration.")
+	cmd.PersistentFlags().StringVar(&scope, "scope", "project", "Config scope: project, user, or cache")
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "init",
+		Short: "Initialize config files",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := configPath(scope)
+			if err != nil {
+				return err
+			}
+			cfg := defaultAgentConfig()
+			if err := writeAgentConfig(path, cfg); err != nil {
+				return err
+			}
+			return output.OK(cmd, map[string]string{"path": path, "scope": scope}, "Initialized Andurel config")
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "show",
+		Short: "Show config",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := loadConfigShowReport()
+			if err != nil {
+				return err
+			}
+			return output.OK(cmd, report, "Loaded Andurel config")
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "set KEY VALUE",
+		Short: "Set a config value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := configPath(scope)
+			if err != nil {
+				return err
+			}
+			cfg, _ := readAgentConfig(path)
+			setConfigValue(&cfg, args[0], args[1])
+			if err := writeAgentConfig(path, cfg); err != nil {
+				return err
+			}
+			return output.OK(cmd, map[string]string{"scope": scope, "key": args[0], "value": args[1]}, "Updated Andurel config")
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "unset KEY",
+		Short: "Unset a config value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := configPath(scope)
+			if err != nil {
+				return err
+			}
+			cfg, _ := readAgentConfig(path)
+			unsetConfigValue(&cfg, args[0])
+			if err := writeAgentConfig(path, cfg); err != nil {
+				return err
+			}
+			return output.OK(cmd, map[string]string{"scope": scope, "key": args[0]}, "Updated Andurel config")
+		},
+	})
+
+	return cmd
+}
+
+func defaultAgentConfig() agentConfig {
+	return agentConfig{
+		PreferredGeneratorMode: "safe",
+		JavaScriptRuntime:      "npm",
+		OutputFormat:           "human",
+		CommonDatabaseCommandOptions: map[string]string{
+			"migrate": "up",
+		},
+		Values: map[string]string{},
+	}
+}
+
+func loadConfigShowReport() (configShowReport, error) {
+	userPath, _ := userConfigPath()
+	projectPath, _ := projectConfigPath()
+	cachePath, _ := cacheConfigPath()
+	user, _ := readAgentConfig(userPath)
+	project, _ := readAgentConfig(projectPath)
+	cacheCfg, _ := readAgentConfig(cachePath)
+	merged := mergeAgentConfigs(user, cacheCfg, project)
+	return configShowReport{
+		User:    user,
+		Project: project,
+		Cache:   cacheCfg,
+		Merged:  merged,
+		Paths: configPaths{
+			User:    userPath,
+			Project: projectPath,
+			Cache:   cachePath,
+		},
+	}, nil
+}
+
+func configPath(scope string) (string, error) {
+	switch strings.ToLower(scope) {
+	case "project":
+		return projectConfigPath()
+	case "user":
+		return userConfigPath()
+	case "cache":
+		return cacheConfigPath()
+	default:
+		return "", output.NewError(output.CodeUsage, "invalid config scope: "+scope, output.ExitUsage, "Use project, user, or cache.")
+	}
+}
+
+func projectConfigPath() (string, error) {
+	rootDir, err := findGoModRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(rootDir, ".andurel", "config.json"), nil
+}
+
+func userConfigPath() (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "andurel", "config.json"), nil
+}
+
+func userCacheDir() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "andurel"), nil
+}
+
+func cacheConfigPath() (string, error) {
+	base, err := userCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "config.json"), nil
+}
+
+func readAgentConfig(path string) (agentConfig, error) {
+	cfg := agentConfig{Values: map[string]string{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, err
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("failed to parse config %s: %w", path, err)
+	}
+	if cfg.Values == nil {
+		cfg.Values = map[string]string{}
+	}
+	return cfg, nil
+}
+
+func writeAgentConfig(path string, cfg agentConfig) error {
+	if cfg.Values == nil {
+		cfg.Values = map[string]string{}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func mergeAgentConfigs(configs ...agentConfig) agentConfig {
+	merged := agentConfig{Values: map[string]string{}, CommonDatabaseCommandOptions: map[string]string{}}
+	for _, cfg := range configs {
+		if cfg.PreferredGeneratorMode != "" {
+			merged.PreferredGeneratorMode = cfg.PreferredGeneratorMode
+		}
+		if cfg.JavaScriptRuntime != "" {
+			merged.JavaScriptRuntime = cfg.JavaScriptRuntime
+		}
+		if cfg.DefaultNamespace != "" {
+			merged.DefaultNamespace = cfg.DefaultNamespace
+		}
+		if cfg.OutputFormat != "" {
+			merged.OutputFormat = cfg.OutputFormat
+		}
+		maps.Copy(merged.CommonDatabaseCommandOptions, cfg.CommonDatabaseCommandOptions)
+		maps.Copy(merged.Values, cfg.Values)
+	}
+	return merged
+}
+
+func setConfigValue(cfg *agentConfig, key, value string) {
+	switch key {
+	case "preferred_generator_mode":
+		cfg.PreferredGeneratorMode = value
+	case "javascript_runtime":
+		cfg.JavaScriptRuntime = value
+	case "default_namespace":
+		cfg.DefaultNamespace = value
+	case "output_format":
+		cfg.OutputFormat = value
+	default:
+		if cfg.Values == nil {
+			cfg.Values = map[string]string{}
+		}
+		cfg.Values[key] = value
+	}
+}
+
+func unsetConfigValue(cfg *agentConfig, key string) {
+	switch key {
+	case "preferred_generator_mode":
+		cfg.PreferredGeneratorMode = ""
+	case "javascript_runtime":
+		cfg.JavaScriptRuntime = ""
+	case "default_namespace":
+		cfg.DefaultNamespace = ""
+	case "output_format":
+		cfg.OutputFormat = ""
+	default:
+		delete(cfg.Values, key)
+	}
+}
+
+func sortedConfigKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -85,7 +85,10 @@ func newConfigCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cfg, _ := readAgentConfig(path)
+			cfg, err := readOptionalAgentConfig(path)
+			if err != nil {
+				return err
+			}
 			setConfigValue(&cfg, args[0], args[1])
 			if err := writeAgentConfig(path, cfg); err != nil {
 				return err
@@ -103,7 +106,10 @@ func newConfigCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cfg, _ := readAgentConfig(path)
+			cfg, err := readOptionalAgentConfig(path)
+			if err != nil {
+				return err
+			}
 			unsetConfigValue(&cfg, args[0])
 			if err := writeAgentConfig(path, cfg); err != nil {
 				return err
@@ -131,9 +137,18 @@ func loadConfigShowReport() (configShowReport, error) {
 	userPath, _ := userConfigPath()
 	projectPath, _ := projectConfigPath()
 	cachePath, _ := cacheConfigPath()
-	user, _ := readAgentConfig(userPath)
-	project, _ := readAgentConfig(projectPath)
-	cacheCfg, _ := readAgentConfig(cachePath)
+	user, err := readOptionalAgentConfig(userPath)
+	if err != nil {
+		return configShowReport{}, err
+	}
+	project, err := readOptionalAgentConfig(projectPath)
+	if err != nil {
+		return configShowReport{}, err
+	}
+	cacheCfg, err := readOptionalAgentConfig(cachePath)
+	if err != nil {
+		return configShowReport{}, err
+	}
 	merged := mergeAgentConfigs(user, cacheCfg, project)
 	return configShowReport{
 		User:    user,
@@ -206,6 +221,17 @@ func readAgentConfig(path string) (agentConfig, error) {
 		cfg.Values = map[string]string{}
 	}
 	return cfg, nil
+}
+
+func readOptionalAgentConfig(path string) (agentConfig, error) {
+	cfg, err := readAgentConfig(path)
+	if err == nil {
+		return cfg, nil
+	}
+	if path == "" || os.IsNotExist(err) {
+		return agentConfig{Values: map[string]string{}}, nil
+	}
+	return agentConfig{}, err
 }
 
 func writeAgentConfig(path string, cfg agentConfig) error {

--- a/cli/discovery.go
+++ b/cli/discovery.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	agentNotesAnnotation    = "agent.notes"
+	agentCategoryAnnotation = "agent.category"
+)
+
+type commandDiscovery struct {
+	Name           string             `json:"name"`
+	Path           string             `json:"path"`
+	Aliases        []string           `json:"aliases,omitempty"`
+	Short          string             `json:"short,omitempty"`
+	Long           string             `json:"long,omitempty"`
+	Usage          string             `json:"usage"`
+	Examples       string             `json:"examples,omitempty"`
+	LocalFlags     []flagDiscovery    `json:"local_flags,omitempty"`
+	InheritedFlags []flagDiscovery    `json:"inherited_flags,omitempty"`
+	Subcommands    []commandSummary   `json:"subcommands,omitempty"`
+	AgentNotes     string             `json:"agent_notes,omitempty"`
+	Category       string             `json:"category,omitempty"`
+	Commands       []commandDiscovery `json:"commands,omitempty"`
+}
+
+type commandSummary struct {
+	Name     string   `json:"name"`
+	Path     string   `json:"path"`
+	Aliases  []string `json:"aliases,omitempty"`
+	Short    string   `json:"short,omitempty"`
+	Category string   `json:"category,omitempty"`
+}
+
+type flagDiscovery struct {
+	Name      string `json:"name"`
+	Shorthand string `json:"shorthand,omitempty"`
+	Usage     string `json:"usage,omitempty"`
+	Default   string `json:"default,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+func newCommandsCommand(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "commands",
+		Short: "Show structured command discovery data",
+		Long:  "Show the Andurel command tree, flags, descriptions, examples, and agent metadata.",
+		Example: `  andurel commands --json
+  andurel commands --agent`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := root
+			if target == nil {
+				target = cmd.Root()
+			}
+			return output.OK(cmd, discoverCommandTree(target), "Discovered Andurel commands")
+		},
+	}
+	setAgentMetadata(cmd, "discovery", "Returns structured command metadata for agent planning.")
+	return cmd
+}
+
+func renderStructuredHelpIfNeeded(cmd *cobra.Command) bool {
+	opts, err := output.ParseOptions(cmd)
+	if err != nil {
+		_ = output.RenderError(cmd, err)
+		return true
+	}
+	if opts.Mode != output.ModeAgent && opts.Mode != output.ModeJSON {
+		return false
+	}
+
+	_ = output.OK(cmd, discoverCommand(cmd), "Command help for "+cmd.CommandPath())
+	return true
+}
+
+func discoverCommandTree(root *cobra.Command) commandDiscovery {
+	discovery := discoverCommand(root)
+	for _, cmd := range availableSubcommands(root) {
+		discovery.Commands = append(discovery.Commands, discoverCommandTree(cmd))
+	}
+	return discovery
+}
+
+func discoverCommand(cmd *cobra.Command) commandDiscovery {
+	discovery := commandDiscovery{
+		Name:           cmd.Name(),
+		Path:           cmd.CommandPath(),
+		Aliases:        append([]string(nil), cmd.Aliases...),
+		Short:          strings.TrimSpace(cmd.Short),
+		Long:           strings.TrimSpace(cmd.Long),
+		Usage:          cmd.UseLine(),
+		Examples:       strings.TrimSpace(cmd.Example),
+		LocalFlags:     discoverFlags(cmd.NonInheritedFlags()),
+		InheritedFlags: discoverFlags(cmd.InheritedFlags()),
+		Subcommands:    discoverSubcommands(cmd),
+	}
+
+	if cmd.Annotations != nil {
+		discovery.AgentNotes = cmd.Annotations[agentNotesAnnotation]
+		discovery.Category = cmd.Annotations[agentCategoryAnnotation]
+	}
+
+	return discovery
+}
+
+func discoverSubcommands(cmd *cobra.Command) []commandSummary {
+	commands := availableSubcommands(cmd)
+	summaries := make([]commandSummary, 0, len(commands))
+	for _, sub := range commands {
+		summary := commandSummary{
+			Name:    sub.Name(),
+			Path:    sub.CommandPath(),
+			Aliases: append([]string(nil), sub.Aliases...),
+			Short:   strings.TrimSpace(sub.Short),
+		}
+		if sub.Annotations != nil {
+			summary.Category = sub.Annotations[agentCategoryAnnotation]
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries
+}
+
+func availableSubcommands(cmd *cobra.Command) []*cobra.Command {
+	commands := make([]*cobra.Command, 0)
+	for _, sub := range cmd.Commands() {
+		if !sub.IsAvailableCommand() || sub.Hidden {
+			continue
+		}
+		commands = append(commands, sub)
+	}
+	return commands
+}
+
+func discoverFlags(flags *pflag.FlagSet) []flagDiscovery {
+	if flags == nil {
+		return nil
+	}
+
+	discovered := make([]flagDiscovery, 0)
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		discovered = append(discovered, flagDiscovery{
+			Name:      flag.Name,
+			Shorthand: flag.Shorthand,
+			Usage:     strings.TrimSpace(flag.Usage),
+			Default:   flag.DefValue,
+			Type:      flag.Value.Type(),
+		})
+	})
+	sort.SliceStable(discovered, func(i, j int) bool {
+		return discovered[i].Name < discovered[j].Name
+	})
+	return discovered
+}
+
+func setAgentMetadata(cmd *cobra.Command, category, notes string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[agentCategoryAnnotation] = category
+	cmd.Annotations[agentNotesAnnotation] = notes
+}

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -101,6 +101,8 @@ This command will check:
 		},
 	}
 
+	doctorCmd.Flags().Bool("verbose", false, "Emit verbose diagnostic output")
+
 	return doctorCmd
 }
 

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -15,15 +15,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/layout"
 	"github.com/spf13/cobra"
 )
 
 type checkResult struct {
-	name    string
-	status  checkStatus
-	message string
-	details []string
+	category string
+	name     string
+	status   checkStatus
+	message  string
+	details  []string
 }
 
 type checkStatus int
@@ -33,6 +35,44 @@ const (
 	statusWarn
 	statusFail
 )
+
+func (s checkStatus) String() string {
+	switch s {
+	case statusPass:
+		return "pass"
+	case statusWarn:
+		return "warn"
+	case statusFail:
+		return "fail"
+	default:
+		return "unknown"
+	}
+}
+
+type doctorReport struct {
+	Version string        `json:"version,omitempty"`
+	Root    string        `json:"root,omitempty"`
+	Checks  []doctorCheck `json:"checks"`
+	Summary doctorSummary `json:"summary"`
+}
+
+type doctorCheck struct {
+	Category string   `json:"category"`
+	Name     string   `json:"name"`
+	Status   string   `json:"status"`
+	Message  string   `json:"message,omitempty"`
+	Details  []string `json:"details,omitempty"`
+	Hint     string   `json:"hint,omitempty"`
+	Blocking bool     `json:"blocking"`
+}
+
+type doctorSummary struct {
+	Total    int    `json:"total"`
+	Passed   int    `json:"passed"`
+	Warnings int    `json:"warnings"`
+	Failed   int    `json:"failed"`
+	Status   string `json:"status"`
+}
 
 func newDoctorCommand(currentVersion string) *cobra.Command {
 	doctorCmd := &cobra.Command{
@@ -50,13 +90,142 @@ This command will check:
   andurel doctor --verbose`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verbose, _ := cmd.Flags().GetBool("verbose")
+			opts, err := output.ParseOptions(cmd)
+			if err != nil {
+				return err
+			}
+			if opts.Mode == output.ModeJSON || opts.Mode == output.ModeAgent {
+				return runDoctorStructured(cmd, currentVersion, verbose)
+			}
 			return runDoctor(currentVersion, verbose)
 		},
 	}
 
-	doctorCmd.Flags().Bool("verbose", false, "Show detailed output from all checks")
-
 	return doctorCmd
+}
+
+func runDoctorStructured(cmd *cobra.Command, currentVersion string, verbose bool) error {
+	report, _ := collectDoctorReport(currentVersion, verbose)
+	if err := output.OK(cmd, report, doctorSummaryMessage(report)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func collectDoctorReport(currentVersion string, verbose bool) (doctorReport, error) {
+	var results []checkResult
+
+	results = append(results, categorizeResults("environment",
+		checkGoVersion(),
+		checkInAndurelProject(),
+	)...)
+
+	rootDir, err := findGoModRoot()
+	if err != nil {
+		return buildDoctorReport(currentVersion, "", results), err
+	}
+
+	results = append(results, categorizeResults("configuration",
+		checkLockFile(rootDir),
+		checkAndurelVersion(rootDir, currentVersion),
+		checkToolVersions(rootDir, verbose),
+	)...)
+
+	results = append(results, categorizeResults("code_quality",
+		checkGoVet(rootDir, verbose),
+		checkGoModTidy(rootDir, verbose),
+	)...)
+
+	results = append(results, categorizeResults("code_generation",
+		checkTemplGenerate(rootDir, verbose),
+	)...)
+
+	return buildDoctorReport(currentVersion, rootDir, results), nil
+}
+
+func categorizeResults(category string, results ...checkResult) []checkResult {
+	for i := range results {
+		results[i].category = category
+	}
+	return results
+}
+
+func buildDoctorReport(currentVersion, rootDir string, results []checkResult) doctorReport {
+	report := doctorReport{
+		Version: currentVersion,
+		Root:    rootDir,
+		Checks:  make([]doctorCheck, 0, len(results)),
+		Summary: doctorSummary{Total: len(results), Status: "pass"},
+	}
+
+	for _, result := range results {
+		switch result.status {
+		case statusPass:
+			report.Summary.Passed++
+		case statusWarn:
+			report.Summary.Warnings++
+		case statusFail:
+			report.Summary.Failed++
+		}
+
+		report.Checks = append(report.Checks, doctorCheckFromResult(result))
+	}
+
+	if report.Summary.Failed > 0 {
+		report.Summary.Status = "fail"
+	} else if report.Summary.Warnings > 0 {
+		report.Summary.Status = "warn"
+	}
+
+	return report
+}
+
+func doctorCheckFromResult(result checkResult) doctorCheck {
+	return doctorCheck{
+		Category: result.category,
+		Name:     result.name,
+		Status:   result.status.String(),
+		Message:  result.message,
+		Details:  append([]string(nil), result.details...),
+		Hint:     doctorHint(result),
+		Blocking: result.status == statusFail,
+	}
+}
+
+func doctorHint(result checkResult) string {
+	if result.status == statusPass {
+		return ""
+	}
+
+	switch result.name {
+	case "Andurel project":
+		return "Run this from a directory containing an Andurel project's go.mod file."
+	case "andurel.lock":
+		return "Run from a generated Andurel project root with a valid andurel.lock file."
+	case "Andurel version":
+		return "Use the Andurel version recorded in andurel.lock or run andurel upgrade."
+	case "tool versions":
+		return "Run andurel tool sync to install or update framework tools."
+	case "go vet":
+		return "Run go vet ./... and fix the reported issues."
+	case "go mod tidy":
+		return "Run go mod tidy and commit the resulting go.mod or go.sum changes."
+	case "views generate":
+		return "Run andurel generate view and fix any template generation errors."
+	default:
+		return ""
+	}
+}
+
+func doctorSummaryMessage(report doctorReport) string {
+	switch report.Summary.Status {
+	case "fail":
+		return "Doctor checks failed"
+	case "warn":
+		return "Doctor checks completed with warnings"
+	default:
+		return "Doctor checks passed"
+	}
 }
 
 func runDoctor(currentVersion string, verbose bool) error {

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -105,7 +105,13 @@ This command will check:
 }
 
 func runDoctorStructured(cmd *cobra.Command, currentVersion string, verbose bool) error {
-	report, _ := collectDoctorReport(currentVersion, verbose)
+	report, err := collectDoctorReport(currentVersion, verbose)
+	if err != nil {
+		return err
+	}
+	if report.Summary.Status == "fail" {
+		return output.NewError(output.CodeError, doctorSummaryMessage(report), output.ExitUsage, "Inspect the failed doctor checks and address the reported issues.")
+	}
 	if err := output.OK(cmd, report, doctorSummaryMessage(report)); err != nil {
 		return err
 	}

--- a/cli/extension.go
+++ b/cli/extension.go
@@ -3,14 +3,16 @@ package cli
 import (
 	"fmt"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/layout"
 	"github.com/spf13/cobra"
 )
 
 func newExtensionCommand() *cobra.Command {
+	var showAvailable bool
 	extensionCmd := &cobra.Command{
 		Use:     "extension",
-		Aliases: []string{"ext", "e"},
+		Aliases: []string{"extensions", "ext", "e"},
 		Short:   "Manage project extensions",
 		Long: `Add and list extensions applied to the current Andurel project.
 
@@ -18,18 +20,26 @@ Extensions add optional features like Docker or email integration. Adding an
 extension generates its code files and updates framework-managed files.`,
 		Example: `  andurel extension add docker
   andurel extension list`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExtensionList(cmd, showAvailable)
+		},
 	}
+	setAgentMetadata(extensionCmd, "introspection", "Read-only by default; use extension add for mutations.")
 
 	extensionCmd.AddCommand(
 		newExtensionAddCommand(),
 		newExtensionListCommand(),
 	)
+	extensionCmd.Flags().BoolVar(&showAvailable, "available", false, "List available built-in extensions")
 
 	return extensionCmd
 }
 
 func newExtensionAddCommand() *cobra.Command {
-	return &cobra.Command{
+	var dryRun bool
+	var diff bool
+	cmd := &cobra.Command{
 		Use:     "add [extension-name]",
 		Aliases: []string{"a"},
 		Short:   "Add an extension to the project",
@@ -51,22 +61,41 @@ files in place.`,
 				return err
 			}
 
-			applied, err := layout.ApplyExtension(rootDir, extensionName)
-			if err != nil {
-				return err
-			}
-
-			for _, name := range applied {
-				fmt.Printf("Extension '%s' added to project\n", name)
-			}
-
-			return nil
+			return runMutation(cmd, mutationOptions{
+				Action:   "extension add",
+				Resource: extensionName,
+				RootDir:  rootDir,
+				DryRun:   dryRun,
+				Diff:     diff,
+				CommandsRun: []string{
+					"goose fix",
+					"templ generate",
+					"go mod tidy",
+				},
+				Breadcrumbs: []output.Breadcrumb{
+					{Command: "andurel doctor", Description: "Verify project health after applying the extension"},
+				},
+				Run: func(rootDir string) error {
+					applied, err := layout.ApplyExtension(rootDir, extensionName)
+					if err != nil {
+						return err
+					}
+					for _, name := range applied {
+						fmt.Printf("Extension '%s' added to project\n", name)
+					}
+					return nil
+				},
+			})
 		},
 	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying the extension")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
+	return cmd
 }
 
 func newExtensionListCommand() *cobra.Command {
-	return &cobra.Command{
+	var showAvailable bool
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List all extensions applied to the project",
@@ -74,27 +103,63 @@ func newExtensionListCommand() *cobra.Command {
 		Example: "  andurel extension list",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rootDir, err := findGoModRoot()
-			if err != nil {
-				return err
-			}
-
-			lock, err := layout.ReadLockFile(rootDir)
-			if err != nil {
-				return fmt.Errorf("failed to read lock file: %w", err)
-			}
-
-			if len(lock.Extensions) == 0 {
-				fmt.Println("No extensions applied to this project")
-				return nil
-			}
-
-			fmt.Println("Extensions:")
-			for name, ext := range lock.Extensions {
-				fmt.Printf("  - %s (applied: %s)\n", name, ext.AppliedAt)
-			}
-
-			return nil
+			return runExtensionList(cmd, showAvailable)
 		},
 	}
+	cmd.Flags().BoolVar(&showAvailable, "available", false, "List available built-in extensions")
+	return cmd
+}
+
+func runExtensionList(cmd *cobra.Command, showAvailable bool) error {
+	rootDir, err := findGoModRoot()
+	if err != nil {
+		return err
+	}
+
+	lock, err := layout.ReadLockFile(rootDir)
+	if err != nil {
+		return fmt.Errorf("failed to read lock file: %w", err)
+	}
+
+	infos := extensionInfos(lock)
+	if showAvailable {
+		applied := map[string]bool{}
+		for _, info := range infos {
+			applied[info.Name] = true
+		}
+		available, err := layout.AvailableExtensionNames()
+		if err != nil {
+			return err
+		}
+		for _, name := range available {
+			if applied[name] {
+				continue
+			}
+			infos = append(infos, extensionInfo{Name: name, Available: true})
+		}
+	}
+
+	opts, err := output.ParseOptions(cmd)
+	if err != nil {
+		return err
+	}
+	if opts.Mode == output.ModeJSON || opts.Mode == output.ModeAgent || opts.Mode == output.ModeMarkdown || opts.Quiet {
+		return output.OK(cmd, infos, "Listed extensions")
+	}
+
+	if len(infos) == 0 {
+		fmt.Println("No extensions applied to this project")
+		return nil
+	}
+
+	fmt.Println("Extensions:")
+	for _, info := range infos {
+		if info.AppliedAt != "" {
+			fmt.Printf("  - %s (applied: %s)\n", info.Name, info.AppliedAt)
+		} else {
+			fmt.Printf("  - %s\n", info.Name)
+		}
+	}
+
+	return nil
 }

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +18,7 @@ import (
 func chdirToProjectRoot() error {
 	rootDir, err := findGoModRoot()
 	if err != nil {
-		return fmt.Errorf("not in an andurel project directory: %w", err)
+		return output.WrapError(output.CodeProjectNotFound, err, output.ExitProject, "Run this from a directory containing an Andurel project's go.mod file.")
 	}
 	return os.Chdir(rootDir)
 }
@@ -51,6 +52,7 @@ names, and Admin-prefixed route/view symbols.`,
   andurel generate job SendWelcomeEmail
   andurel generate email WelcomeEmail`,
 	}
+	setAgentMetadata(cmd, "generation", "Requires an Andurel project root for generators that inspect or write project files.")
 
 	cmd.AddCommand(
 		newGenerateModelCommand(),

--- a/cli/generate_controller.go
+++ b/cli/generate_controller.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	generatorpkg "github.com/mbvlabs/andurel/generator"
 	controllergen "github.com/mbvlabs/andurel/generator/controllers"
 	"github.com/mbvlabs/andurel/generator/files"
@@ -21,6 +22,8 @@ func newGenerateControllerCommand() *cobra.Command {
 		inertia   bool
 		modelName string
 		api       bool
+		dryRun    bool
+		diff      bool
 	)
 
 	cmd := &cobra.Command{
@@ -88,24 +91,39 @@ namespace segment in the name, and the default action set excludes new/edit.`,
 			name := args[0]
 			actions := args[1:]
 
-			if err := chdirToProjectRoot(); err != nil {
+			rootDir, err := findGoModRoot()
+			if err != nil {
 				return err
 			}
 
-			inertiaStr := ""
-			if inertia {
-				inertiaStr = generatorpkg.ReadInertia()
-			}
-
-			return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
-				return generateControllerWithActionsFunc(name, modelName, actions, inertiaStr, api)
-			})(cmd, args)
+			return runMutation(cmd, mutationOptions{
+				Action:   "generate controller",
+				Resource: name,
+				RootDir:  rootDir,
+				DryRun:   dryRun,
+				Diff:     diff,
+				Breadcrumbs: []output.Breadcrumb{
+					{Command: "andurel routes --json", Description: "Inspect generated route files"},
+					{Command: "andurel doctor", Description: "Verify project health"},
+				},
+				Run: func(rootDir string) error {
+					inertiaStr := ""
+					if inertia {
+						inertiaStr = generatorpkg.ReadInertia()
+					}
+					return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
+						return generateControllerWithActionsFunc(name, modelName, actions, inertiaStr, api)
+					})(cmd, args)
+				},
+			})
 		},
 	}
 
 	cmd.Flags().BoolVar(&api, "api", false, "Generate a JSON API controller under controllers/api")
 	cmd.Flags().BoolVar(&inertia, "inertia", false, "Generate Inertia views using the adapter configured in andurel.lock")
 	cmd.Flags().StringVar(&modelName, "model-name", "", "Use a different model name for model-backed controller generation")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
 
 	return cmd
 }

--- a/cli/generate_email.go
+++ b/cli/generate_email.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/generator/templates"
 	"github.com/mbvlabs/andurel/pkg/constants"
 	"github.com/mbvlabs/andurel/pkg/naming"
@@ -17,6 +18,9 @@ type emailTemplateData struct {
 }
 
 func newGenerateEmailCommand() *cobra.Command {
+	var dryRun bool
+	var diff bool
+
 	cmd := &cobra.Command{
 		Use:     "email NAME",
 		Aliases: []string{"e"},
@@ -40,15 +44,32 @@ email.SendMarketing.`,
 			}
 			name := args[0]
 
-			if err := chdirToProjectRoot(); err != nil {
+			rootDir, err := findGoModRoot()
+			if err != nil {
 				return err
 			}
 
-			return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
-				return generateEmail(name)
-			})(cmd, args)
+			return runMutation(cmd, mutationOptions{
+				Action:   "generate email",
+				Resource: name,
+				RootDir:  rootDir,
+				DryRun:   dryRun,
+				Diff:     diff,
+				Breadcrumbs: []output.Breadcrumb{
+					{Command: "andurel views --json", Description: "Inspect generated templates"},
+					{Command: "andurel doctor", Description: "Verify project health"},
+				},
+				Run: func(rootDir string) error {
+					return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
+						return generateEmail(name)
+					})(cmd, args)
+				},
+			})
 		},
 	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
 
 	return cmd
 }

--- a/cli/generate_job.go
+++ b/cli/generate_job.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	generatorpkg "github.com/mbvlabs/andurel/generator"
 	"github.com/mbvlabs/andurel/generator/files"
 	"github.com/mbvlabs/andurel/generator/templates"
@@ -29,6 +30,8 @@ type workerTemplateData struct {
 
 func newGenerateJobCommand() *cobra.Command {
 	var queueName string
+	var dryRun bool
+	var diff bool
 
 	cmd := &cobra.Command{
 		Use:     "job NAME",
@@ -64,17 +67,33 @@ when inserting the job.`,
 			}
 			name := args[0]
 
-			if err := chdirToProjectRoot(); err != nil {
+			rootDir, err := findGoModRoot()
+			if err != nil {
 				return err
 			}
 
-			return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
-				return generateJob(name, queueName)
-			})(cmd, args)
+			return runMutation(cmd, mutationOptions{
+				Action:   "generate job",
+				Resource: name,
+				RootDir:  rootDir,
+				DryRun:   dryRun,
+				Diff:     diff,
+				Breadcrumbs: []output.Breadcrumb{
+					{Command: "andurel jobs --json", Description: "Inspect generated jobs"},
+					{Command: "andurel doctor", Description: "Verify project health"},
+				},
+				Run: func(rootDir string) error {
+					return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
+						return generateJob(name, queueName)
+					})(cmd, args)
+				},
+			})
 		},
 	}
 
 	cmd.Flags().StringVar(&queueName, "queue", "", "Assign the job to a specific queue")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
 
 	return cmd
 }

--- a/cli/generate_model.go
+++ b/cli/generate_model.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,8 @@ func newGenerateModelCommand() *cobra.Command {
 		updateModel      bool
 		autoApply        bool
 		primaryKeyColumn string
+		dryRun           bool
+		diff             bool
 	)
 
 	cmd := &cobra.Command{
@@ -59,24 +62,36 @@ Use --update to sync an existing model file with migration changes.`,
 			}
 			name := args[0]
 
-			if err := chdirToProjectRoot(); err != nil {
+			rootDir, err := findGoModRoot()
+			if err != nil {
 				return err
 			}
 
-			if updateModel {
-				return runModelUpdateFunc(name, autoApply)
-			}
-
-			return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
-				gen, err := newGenerator()
-				if err != nil {
-					return err
-				}
-				if primaryKeyColumn != "" {
-					return gen.GenerateModelWithPK(name, tableName, skipFactory, primaryKeyColumn)
-				}
-				return gen.GenerateModel(name, tableName, skipFactory)
-			})(cmd, args)
+			return runMutation(cmd, mutationOptions{
+				Action:   "generate model",
+				Resource: name,
+				RootDir:  rootDir,
+				DryRun:   dryRun,
+				Diff:     diff,
+				Breadcrumbs: []output.Breadcrumb{
+					{Command: "andurel doctor", Description: "Verify generated model health"},
+				},
+				Run: func(rootDir string) error {
+					if updateModel {
+						return runModelUpdateFunc(name, autoApply)
+					}
+					return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
+						gen, err := newGenerator()
+						if err != nil {
+							return err
+						}
+						if primaryKeyColumn != "" {
+							return gen.GenerateModelWithPK(name, tableName, skipFactory, primaryKeyColumn)
+						}
+						return gen.GenerateModel(name, tableName, skipFactory)
+					})(cmd, args)
+				},
+			})
 		},
 	}
 
@@ -85,6 +100,8 @@ Use --update to sync an existing model file with migration changes.`,
 	cmd.Flags().BoolVar(&updateModel, "update", false, "Update an existing model from migration changes")
 	cmd.Flags().BoolVar(&autoApply, "yes", false, "Apply changes without prompting for confirmation")
 	cmd.Flags().StringVar(&primaryKeyColumn, "primary-key", "", "Specify the primary key column (skips interactive detection)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
 
 	return cmd
 }

--- a/cli/generate_scaffold.go
+++ b/cli/generate_scaffold.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	generatorpkg "github.com/mbvlabs/andurel/generator"
 	"github.com/mbvlabs/andurel/pkg/naming"
 	"github.com/spf13/cobra"
@@ -15,6 +16,8 @@ func newGenerateScaffoldCommand() *cobra.Command {
 		primaryKeyColumn string
 		inertia          bool
 		api              bool
+		dryRun           bool
+		diff             bool
 	)
 
 	cmd := &cobra.Command{
@@ -75,23 +78,36 @@ with echo.JSON responses. No views are generated.`,
 				return err
 			}
 
-			if err := chdirToProjectRoot(); err != nil {
+			rootDir, err := findGoModRoot()
+			if err != nil {
 				return err
 			}
 
-			inertiaStr := ""
-			if inertia {
-				inertiaStr = generatorpkg.ReadInertia()
-			}
+			return runMutation(cmd, mutationOptions{
+				Action:   "generate scaffold",
+				Resource: name,
+				RootDir:  rootDir,
+				DryRun:   dryRun,
+				Diff:     diff,
+				Breadcrumbs: []output.Breadcrumb{
+					{Command: "andurel database migrate up", Description: "Apply migrations before using the resource"},
+					{Command: "andurel run", Description: "Start the development server"},
+				},
+				Run: func(rootDir string) error {
+					inertiaStr := ""
+					if inertia {
+						inertiaStr = generatorpkg.ReadInertia()
+					}
+					return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
+						gen, err := newGenerator()
+						if err != nil {
+							return err
+						}
 
-			return withGenerateCleanup(func(_ *cobra.Command, _ []string) error {
-				gen, err := newGenerator()
-				if err != nil {
-					return err
-				}
-
-				return gen.GenerateScaffold(resourceName, namespace, tableName, skipFactory, primaryKeyColumn, inertiaStr, api)
-			})(cmd, args)
+						return gen.GenerateScaffold(resourceName, namespace, tableName, skipFactory, primaryKeyColumn, inertiaStr, api)
+					})(cmd, args)
+				},
+			})
 		},
 	}
 
@@ -100,6 +116,8 @@ with echo.JSON responses. No views are generated.`,
 	cmd.Flags().StringVar(&primaryKeyColumn, "primary-key", "", "Specify the primary key column (skips interactive detection)")
 	cmd.Flags().BoolVar(&api, "api", false, "Generate a JSON API controller under controllers/api")
 	cmd.Flags().BoolVar(&inertia, "inertia", false, "Generate Inertia views using the adapter configured in andurel.lock")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
 
 	return cmd
 }

--- a/cli/introspection.go
+++ b/cli/introspection.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/mbvlabs/andurel/layout"
+	"github.com/spf13/cobra"
+)
+
+type projectInfo struct {
+	Root               string                 `json:"root"`
+	Module             string                 `json:"module,omitempty"`
+	GoVersion          string                 `json:"go_version,omitempty"`
+	AndurelVersion     string                 `json:"andurel_version,omitempty"`
+	ScaffoldConfig     *layout.ScaffoldConfig `json:"scaffold_config,omitempty"`
+	DatabaseConfig     *layout.DatabaseConfig `json:"database_config,omitempty"`
+	Extensions         []extensionInfo        `json:"extensions"`
+	Tools              []toolInfo             `json:"tools"`
+	ConfigPath         string                 `json:"config_path,omitempty"`
+	UserConfigPath     string                 `json:"user_config_path,omitempty"`
+	UserCacheDirectory string                 `json:"user_cache_directory,omitempty"`
+}
+
+type projectItem struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Kind string `json:"kind,omitempty"`
+}
+
+type extensionInfo struct {
+	Name      string `json:"name"`
+	AppliedAt string `json:"applied_at,omitempty"`
+	Available bool   `json:"available,omitempty"`
+}
+
+type toolInfo struct {
+	Name       string `json:"name"`
+	Version    string `json:"version,omitempty"`
+	Source     string `json:"source,omitempty"`
+	Path       string `json:"path,omitempty"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	Installed  bool   `json:"installed"`
+}
+
+func newProjectInfoCommand() *cobra.Command {
+	projectCmd := &cobra.Command{
+		Use:   "project",
+		Short: "Inspect Andurel project metadata",
+		Long:  "Inspect project metadata derived from go.mod, andurel.lock, and Andurel config files.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectInfo(cmd)
+		},
+	}
+	setAgentMetadata(projectCmd, "introspection", "Read-only project metadata. Prefer this before generation.")
+
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show project metadata",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectInfo(cmd)
+		},
+	}
+	setAgentMetadata(infoCmd, "introspection", "Read-only project metadata. Prefer this before generation.")
+	projectCmd.AddCommand(infoCmd)
+	return projectCmd
+}
+
+func runProjectInfo(cmd *cobra.Command) error {
+	rootDir, err := findGoModRoot()
+	if err != nil {
+		return err
+	}
+	info, err := collectProjectInfo(rootDir)
+	if err != nil {
+		return err
+	}
+	return output.OK(cmd, info, "Project info loaded")
+}
+
+func collectProjectInfo(rootDir string) (projectInfo, error) {
+	module, goVersion, _ := readGoModMetadata(rootDir)
+	lock, err := layout.ReadLockFile(rootDir)
+	if err != nil {
+		return projectInfo{}, err
+	}
+	userConfig, _ := userConfigPath()
+	userCache, _ := userCacheDir()
+	info := projectInfo{
+		Root:               rootDir,
+		Module:             module,
+		GoVersion:          goVersion,
+		AndurelVersion:     lock.Version,
+		ScaffoldConfig:     lock.ScaffoldConfig,
+		DatabaseConfig:     lock.DatabaseConfig,
+		Extensions:         extensionInfos(lock),
+		Tools:              toolInfos(rootDir, lock),
+		ConfigPath:         filepath.Join(rootDir, ".andurel", "config.json"),
+		UserConfigPath:     userConfig,
+		UserCacheDirectory: userCache,
+	}
+	return info, nil
+}
+
+func newRoutesCommand() *cobra.Command {
+	return readOnlyListCommand("routes", "List route files", "router/routes", ".go")
+}
+
+func newModelsCommand() *cobra.Command {
+	return readOnlyListCommand("models", "List model files", "models", ".go")
+}
+
+func newMigrationsCommand() *cobra.Command {
+	return readOnlyListCommand("migrations", "List migration files", filepath.Join("database", "migrations"), ".sql")
+}
+
+func newControllersCommand() *cobra.Command {
+	return readOnlyListCommand("controllers", "List controller files", "controllers", ".go")
+}
+
+func newViewsCommand() *cobra.Command {
+	return readOnlyListCommand("views", "List view templates", "views", ".templ")
+}
+
+func newJobsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "jobs",
+		Short: "List job and worker files",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rootDir, err := findGoModRoot()
+			if err != nil {
+				return err
+			}
+			items := []projectItem{}
+			jobs, _ := listProjectFiles(rootDir, filepath.Join("queue", "jobs"), ".go", "job")
+			workers, _ := listProjectFiles(rootDir, "queue", ".go", "worker")
+			items = append(items, jobs...)
+			items = append(items, workers...)
+			sortProjectItems(items)
+			return output.OK(cmd, items, "Listed jobs")
+		},
+	}
+	setAgentMetadata(cmd, "introspection", "Read-only list of queue job and worker files.")
+	return cmd
+}
+
+func readOnlyListCommand(use, short, dir, ext string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rootDir, err := findGoModRoot()
+			if err != nil {
+				return err
+			}
+			items, err := listProjectFiles(rootDir, dir, ext, strings.TrimSuffix(use, "s"))
+			if err != nil {
+				return err
+			}
+			return output.OK(cmd, items, short)
+		},
+	}
+	setAgentMetadata(cmd, "introspection", "Read-only project shape inspection.")
+	return cmd
+}
+
+func listProjectFiles(rootDir, relDir, ext, kind string) ([]projectItem, error) {
+	base := filepath.Join(rootDir, relDir)
+	if _, err := os.Stat(base); err != nil {
+		return []projectItem{}, nil
+	}
+	items := []projectItem{}
+	err := filepath.WalkDir(base, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if ext != "" && filepath.Ext(path) != ext {
+			return nil
+		}
+		rel, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return err
+		}
+		name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		items = append(items, projectItem{
+			Name: name,
+			Path: filepath.ToSlash(rel),
+			Kind: kind,
+		})
+		return nil
+	})
+	sortProjectItems(items)
+	return items, err
+}
+
+func sortProjectItems(items []projectItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].Path < items[j].Path
+	})
+}
+
+func readGoModMetadata(rootDir string) (module, goVersion string, err error) {
+	data, err := os.ReadFile(filepath.Join(rootDir, "go.mod"))
+	if err != nil {
+		return "", "", err
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "module":
+			module = fields[1]
+		case "go":
+			goVersion = fields[1]
+		}
+	}
+	return module, goVersion, nil
+}
+
+func extensionInfos(lock *layout.AndurelLock) []extensionInfo {
+	infos := []extensionInfo{}
+	if lock == nil {
+		return infos
+	}
+	for name, ext := range lock.Extensions {
+		appliedAt := ""
+		if ext != nil {
+			appliedAt = ext.AppliedAt
+		}
+		infos = append(infos, extensionInfo{Name: name, AppliedAt: appliedAt})
+	}
+	sort.SliceStable(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	return infos
+}
+
+func toolInfos(rootDir string, lock *layout.AndurelLock) []toolInfo {
+	infos := []toolInfo{}
+	if lock == nil {
+		return infos
+	}
+	for name, tool := range lock.Tools {
+		info := toolInfo{Name: name}
+		if tool != nil {
+			info.Version = tool.Version
+			info.Source = tool.Source
+			info.Path = tool.Path
+		}
+		if info.Path != "" {
+			info.BinaryPath = info.Path
+		} else {
+			info.BinaryPath = filepath.ToSlash(filepath.Join("bin", name))
+		}
+		if _, err := os.Stat(filepath.Join(rootDir, filepath.FromSlash(info.BinaryPath))); err == nil {
+			info.Installed = true
+		}
+		infos = append(infos, info)
+	}
+	sort.SliceStable(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	return infos
+}

--- a/cli/new_project.go
+++ b/cli/new_project.go
@@ -149,7 +149,7 @@ func newProject(cmd *cobra.Command, args []string, version string, dryRun bool, 
 }
 
 func newProjectReport(projectName, basePath string, dryRun bool, diff bool, scaffold func(target string) error) (mutationReport, error) {
-	targetPath := basePath
+	var targetPath string
 	if dryRun {
 		tempDir, err := os.MkdirTemp("", "andurel-new-dry-run-*")
 		if err != nil {

--- a/cli/new_project.go
+++ b/cli/new_project.go
@@ -115,8 +115,8 @@ func newProject(cmd *cobra.Command, args []string, version string, dryRun bool, 
 	if err != nil {
 		return err
 	}
-	if dryRun || opts.Mode == output.ModeJSON || opts.Mode == output.ModeAgent || opts.Mode == output.ModeMarkdown || opts.Quiet {
-		silence := opts.Mode == output.ModeJSON || opts.Mode == output.ModeAgent
+	if dryRun || output.SuppressesHumanOutput(opts) {
+		silence := output.SuppressesHumanOutput(opts)
 		report, err := newProjectReport(projectName, basePath, dryRun, diff, func(target string) error {
 			return runWithOptionalStdoutSilence(silence, func() error {
 				return layout.Scaffold(target, projectName, database, cssFramework, version, extensions, "uberfx", adapter, javascriptRuntime)

--- a/cli/new_project.go
+++ b/cli/new_project.go
@@ -4,14 +4,18 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/layout"
 
 	"github.com/spf13/cobra"
 )
 
 func newProjectCommand(version string) *cobra.Command {
+	var dryRun bool
+	var diff bool
 	projectCmd := &cobra.Command{
 		Use:     "new [project-name]",
 		Aliases: []string{"n"},
@@ -27,9 +31,9 @@ creation, run 'andurel tool sync' to download required binaries.`,
 				return cmd.Help()
 			}
 			if isInAndurelProject() {
-				return fmt.Errorf("cannot create a new project inside an existing Andurel project")
+				return output.NewError(output.CodeUnsafeAction, "cannot create a new project inside an existing Andurel project", output.ExitUnsafe, "Run andurel new from a parent directory outside an existing project.")
 			}
-			return newProject(cmd, args, version)
+			return newProject(cmd, args, version, dryRun, diff)
 		},
 	}
 
@@ -38,11 +42,13 @@ creation, run 'andurel tool sync' to download required binaries.`,
 
 	projectCmd.Flags().
 		String("inertia", "", "Inertia adapter to use (vue, react). Optionally append /npm|pnpm|bun|yarn to specify the JS runtime (default: npm)")
+	projectCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview project files without creating them")
+	projectCmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
 
 	return projectCmd
 }
 
-func newProject(cmd *cobra.Command, args []string, version string) error {
+func newProject(cmd *cobra.Command, args []string, version string, dryRun bool, diff bool) error {
 	projectName := args[0]
 	basePath := "./" + projectName
 
@@ -105,8 +111,25 @@ func newProject(cmd *cobra.Command, args []string, version string) error {
 	if err != nil {
 		return err
 	}
-	if err := layout.Scaffold(basePath, projectName, database, cssFramework, version, extensions, "uberfx", adapter, javascriptRuntime); err != nil {
+	opts, err := output.ParseOptions(cmd)
+	if err != nil {
 		return err
+	}
+	if dryRun || opts.Mode == output.ModeJSON || opts.Mode == output.ModeAgent || opts.Mode == output.ModeMarkdown || opts.Quiet {
+		silence := opts.Mode == output.ModeJSON || opts.Mode == output.ModeAgent
+		report, err := newProjectReport(projectName, basePath, dryRun, diff, func(target string) error {
+			return runWithOptionalStdoutSilence(silence, func() error {
+				return layout.Scaffold(target, projectName, database, cssFramework, version, extensions, "uberfx", adapter, javascriptRuntime)
+			})
+		})
+		if err != nil {
+			return err
+		}
+		return output.OK(cmd, report, mutationSummary(report), output.Breadcrumb{Command: "andurel tool sync"}, output.Breadcrumb{Command: "andurel database migrate up"}, output.Breadcrumb{Command: "andurel run"})
+	}
+
+	if err := layout.Scaffold(basePath, projectName, database, cssFramework, version, extensions, "uberfx", adapter, javascriptRuntime); err != nil {
+		return output.WrapError(output.CodeGenerationFailed, err, output.ExitGeneration, "Inspect the scaffold inputs and retry.")
 	}
 
 	fmt.Printf("\n🎉 Successfully created project: %s\n", projectName)
@@ -123,4 +146,40 @@ func newProject(cmd *cobra.Command, args []string, version string) error {
 	fmt.Printf("  andurel run\n")
 
 	return nil
+}
+
+func newProjectReport(projectName, basePath string, dryRun bool, diff bool, scaffold func(target string) error) (mutationReport, error) {
+	targetPath := basePath
+	if dryRun {
+		tempDir, err := os.MkdirTemp("", "andurel-new-dry-run-*")
+		if err != nil {
+			return mutationReport{}, err
+		}
+		defer os.RemoveAll(tempDir)
+		targetPath = filepath.Join(tempDir, projectName)
+		if err := scaffold(targetPath); err != nil {
+			return mutationReport{}, err
+		}
+	} else {
+		targetPath = basePath
+		if err := scaffold(targetPath); err != nil {
+			return mutationReport{}, err
+		}
+	}
+
+	absTarget, err := filepath.Abs(targetPath)
+	if err != nil {
+		return mutationReport{}, err
+	}
+	after, err := snapshotFilesForReport(absTarget)
+	if err != nil {
+		return mutationReport{}, err
+	}
+	report := buildMutationReport(mutationOptions{
+		Action:   "new project",
+		Resource: projectName,
+		DryRun:   dryRun,
+		Diff:     diff,
+	}, fileSnapshot{}, after)
+	return report, nil
 }

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -190,8 +190,23 @@ func ParseOptions(cmd *cobra.Command) (Options, error) {
 	opts.IDsOnly, _ = cmd.Flags().GetBool("ids-only")
 	opts.Count, _ = cmd.Flags().GetBool("count")
 	opts.Verbose, _ = cmd.Flags().GetBool("verbose")
+	if opts.JQ != "" && opts.Mode == ModeHuman {
+		opts.Mode = ModeJSON
+	}
 
 	return opts, nil
+}
+
+// UsesStructuredOutput reports whether a command should render through the
+// shared output contract instead of human prose.
+func UsesStructuredOutput(opts Options) bool {
+	return opts.Mode != ModeHuman
+}
+
+// SuppressesHumanOutput reports whether command progress from lower-level
+// routines should be hidden before rendering the final response.
+func SuppressesHumanOutput(opts Options) bool {
+	return UsesStructuredOutput(opts) || opts.Quiet
 }
 
 // OK renders a successful response using the selected output mode.
@@ -199,9 +214,6 @@ func OK(cmd *cobra.Command, data any, summary string, breadcrumbs ...Breadcrumb)
 	opts, err := ParseOptions(cmd)
 	if err != nil {
 		return err
-	}
-	if opts.JQ != "" && opts.Mode == ModeHuman {
-		opts.Mode = ModeJSON
 	}
 
 	renderData := data

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -157,9 +158,9 @@ func ParseOptions(cmd *cobra.Command) (Options, error) {
 		return opts, nil
 	}
 
-	jsonMode, _ := cmd.Flags().GetBool("json")
-	agentMode, _ := cmd.Flags().GetBool("agent")
-	mdMode, _ := cmd.Flags().GetBool("md")
+	jsonMode, _ := boolFlag(cmd, "json")
+	agentMode, _ := boolFlag(cmd, "agent")
+	mdMode, _ := boolFlag(cmd, "md")
 
 	selected := 0
 	for _, enabled := range []bool{jsonMode, agentMode, mdMode} {
@@ -185,16 +186,32 @@ func ParseOptions(cmd *cobra.Command) (Options, error) {
 		opts.Mode = ModeMarkdown
 	}
 
-	opts.Quiet, _ = cmd.Flags().GetBool("quiet")
-	opts.JQ, _ = cmd.Flags().GetString("jq")
-	opts.IDsOnly, _ = cmd.Flags().GetBool("ids-only")
-	opts.Count, _ = cmd.Flags().GetBool("count")
-	opts.Verbose, _ = cmd.Flags().GetBool("verbose")
+	opts.Quiet, _ = boolFlag(cmd, "quiet")
+	opts.JQ, _ = stringFlag(cmd, "jq")
+	opts.IDsOnly, _ = boolFlag(cmd, "ids-only")
+	opts.Count, _ = boolFlag(cmd, "count")
+	opts.Verbose, _ = boolFlag(cmd, "verbose")
 	if opts.JQ != "" && opts.Mode == ModeHuman {
 		opts.Mode = ModeJSON
 	}
 
 	return opts, nil
+}
+
+func boolFlag(cmd *cobra.Command, name string) (bool, error) {
+	flag := cmd.Flag(name)
+	if flag == nil {
+		return false, nil
+	}
+	return strconv.ParseBool(flag.Value.String())
+}
+
+func stringFlag(cmd *cobra.Command, name string) (string, error) {
+	flag := cmd.Flag(name)
+	if flag == nil {
+		return "", nil
+	}
+	return flag.Value.String(), nil
 }
 
 // UsesStructuredOutput reports whether a command should render through the

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -1,0 +1,463 @@
+// Package output defines the shared CLI response contract for agent-friendly
+// output modes.
+package output
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	CodeError                 = "error"
+	CodeUsage                 = "usage_error"
+	CodeOutputMode            = "invalid_output_mode"
+	CodeProjectNotFound       = "project_not_found"
+	CodeMissingTool           = "missing_tool"
+	CodeInvalidExtension      = "invalid_extension"
+	CodeInvalidInertiaAdapter = "invalid_inertia_adapter"
+	CodeUnsafeAction          = "unsafe_action_requires_confirmation"
+	CodeGenerationFailed      = "generation_failed"
+	CodeExternalCommandFailed = "external_command_failed"
+	CodeConfigError           = "config_error"
+	CodeAmbiguousInput        = "ambiguous_input"
+	ExitUsage                 = 1
+	ExitProject               = 2
+	ExitDependency            = 3
+	ExitUnsafe                = 4
+	ExitGeneration            = 5
+	ExitExternal              = 6
+	ExitConfig                = 7
+	ExitAmbiguous             = 8
+)
+
+// Mode is the selected output format for a command invocation.
+type Mode string
+
+const (
+	ModeHuman    Mode = "human"
+	ModeJSON     Mode = "json"
+	ModeAgent    Mode = "agent"
+	ModeMarkdown Mode = "markdown"
+)
+
+// Options are parsed from the root persistent output flags.
+type Options struct {
+	Mode    Mode
+	Quiet   bool
+	JQ      string
+	IDsOnly bool
+	Count   bool
+	Verbose bool
+}
+
+// Breadcrumb is a follow-up action an agent or human can take.
+type Breadcrumb struct {
+	Command     string `json:"cmd"`
+	Description string `json:"description,omitempty"`
+}
+
+// Envelope wraps successful structured command output.
+type Envelope struct {
+	OK          bool         `json:"ok"`
+	Data        any          `json:"data,omitempty"`
+	Summary     string       `json:"summary,omitempty"`
+	Breadcrumbs []Breadcrumb `json:"breadcrumbs,omitempty"`
+}
+
+// ErrorEnvelope wraps failed structured command output.
+type ErrorEnvelope struct {
+	OK       bool   `json:"ok"`
+	Code     string `json:"code"`
+	Error    string `json:"error"`
+	Hint     string `json:"hint,omitempty"`
+	ExitCode int    `json:"exit_code,omitempty"`
+}
+
+// CLIError is a typed command error with a stable machine-readable code.
+type CLIError struct {
+	Code     string
+	Message  string
+	Hint     string
+	ExitCode int
+	Cause    error
+}
+
+func (e *CLIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return e.Code
+}
+
+func (e *CLIError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// NewError creates a typed CLI error.
+func NewError(code, message string, exitCode int, hint string) *CLIError {
+	return &CLIError{
+		Code:     code,
+		Message:  message,
+		Hint:     hint,
+		ExitCode: exitCode,
+	}
+}
+
+// WrapError creates a typed CLI error while preserving the wrapped cause.
+func WrapError(code string, cause error, exitCode int, hint string) *CLIError {
+	return &CLIError{
+		Code:     code,
+		Cause:    cause,
+		ExitCode: exitCode,
+		Hint:     hint,
+	}
+}
+
+// ExitCode returns the process exit code for an error.
+func ExitCode(err error) int {
+	envelope := Fail(err)
+	if envelope.ExitCode == 0 {
+		return ExitUsage
+	}
+	return envelope.ExitCode
+}
+
+// RegisterPersistentFlags adds the shared agent-friendly output flags.
+func RegisterPersistentFlags(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+	flags.Bool("json", false, "Emit JSON output")
+	flags.Bool("agent", false, "Emit structured output optimized for agents")
+	flags.Bool("md", false, "Emit Markdown output")
+	flags.Bool("quiet", false, "Suppress non-essential human output")
+	flags.String("jq", "", "Apply a jq expression to structured output")
+	flags.Bool("ids-only", false, "Emit only resource identifiers when supported")
+	flags.Bool("count", false, "Emit only resource counts when supported")
+	flags.Bool("verbose", false, "Emit verbose output")
+}
+
+// ParseOptions returns output options from command flags.
+func ParseOptions(cmd *cobra.Command) (Options, error) {
+	opts := Options{Mode: ModeHuman}
+	if cmd == nil {
+		return opts, nil
+	}
+
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	agentMode, _ := cmd.Flags().GetBool("agent")
+	mdMode, _ := cmd.Flags().GetBool("md")
+
+	selected := 0
+	for _, enabled := range []bool{jsonMode, agentMode, mdMode} {
+		if enabled {
+			selected++
+		}
+	}
+	if selected > 1 {
+		return opts, NewError(
+			CodeOutputMode,
+			"choose only one output mode: --json, --agent, or --md",
+			ExitUsage,
+			"Run the command again with a single output mode flag.",
+		)
+	}
+
+	switch {
+	case agentMode:
+		opts.Mode = ModeAgent
+	case jsonMode:
+		opts.Mode = ModeJSON
+	case mdMode:
+		opts.Mode = ModeMarkdown
+	}
+
+	opts.Quiet, _ = cmd.Flags().GetBool("quiet")
+	opts.JQ, _ = cmd.Flags().GetString("jq")
+	opts.IDsOnly, _ = cmd.Flags().GetBool("ids-only")
+	opts.Count, _ = cmd.Flags().GetBool("count")
+	opts.Verbose, _ = cmd.Flags().GetBool("verbose")
+
+	return opts, nil
+}
+
+// OK renders a successful response using the selected output mode.
+func OK(cmd *cobra.Command, data any, summary string, breadcrumbs ...Breadcrumb) error {
+	opts, err := ParseOptions(cmd)
+	if err != nil {
+		return err
+	}
+	if opts.JQ != "" && opts.Mode == ModeHuman {
+		opts.Mode = ModeJSON
+	}
+
+	renderData := data
+	if opts.JQ != "" {
+		renderData, err = applyJQ(data, opts.JQ)
+		if err != nil {
+			return err
+		}
+	}
+
+	envelope := Envelope{
+		OK:          true,
+		Data:        renderData,
+		Summary:     summary,
+		Breadcrumbs: breadcrumbs,
+	}
+
+	return renderOK(cmd.OutOrStdout(), opts, envelope)
+}
+
+// Fail converts any error into a structured error envelope.
+func Fail(err error) ErrorEnvelope {
+	if err == nil {
+		return ErrorEnvelope{OK: false, Code: CodeError, Error: "unknown error", ExitCode: ExitUsage}
+	}
+
+	var cliErr *CLIError
+	if errors.As(err, &cliErr) {
+		code := cliErr.Code
+		if code == "" {
+			code = CodeError
+		}
+		exitCode := cliErr.ExitCode
+		if exitCode == 0 {
+			exitCode = ExitUsage
+		}
+		return ErrorEnvelope{
+			OK:       false,
+			Code:     code,
+			Error:    cliErr.Error(),
+			Hint:     cliErr.Hint,
+			ExitCode: exitCode,
+		}
+	}
+
+	classified := classifyError(err)
+	if classified != nil {
+		return Fail(classified)
+	}
+
+	return ErrorEnvelope{
+		OK:       false,
+		Code:     CodeError,
+		Error:    err.Error(),
+		ExitCode: ExitUsage,
+	}
+}
+
+func classifyError(err error) *CLIError {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "not in an andurel project") ||
+		strings.Contains(msg, "go.mod could not be found") ||
+		strings.Contains(msg, "go.mod not found"):
+		return WrapError(
+			CodeProjectNotFound,
+			err,
+			ExitProject,
+			"Run this from a directory containing an Andurel project's go.mod file.",
+		)
+	case strings.Contains(msg, "bin/") && strings.Contains(msg, "not found"):
+		return WrapError(CodeMissingTool, err, ExitDependency, "Run andurel tool sync to install project tools.")
+	case strings.Contains(msg, "unknown extension") || strings.Contains(msg, "invalid extension"):
+		return WrapError(CodeInvalidExtension, err, ExitUsage, "Run andurel extension list --available to inspect available extensions.")
+	case strings.Contains(msg, "invalid inertia adapter"):
+		return WrapError(CodeInvalidInertiaAdapter, err, ExitUsage, "Use vue or react, optionally followed by /npm, /pnpm, /bun, or /yarn.")
+	case strings.Contains(msg, "requires --force") || strings.Contains(msg, "use --force") || strings.Contains(msg, "without --force"):
+		return WrapError(CodeUnsafeAction, err, ExitUnsafe, "Re-run with --force after confirming the destructive action is intended.")
+	case strings.Contains(msg, "generation failed") || strings.Contains(msg, "failed to generate"):
+		return WrapError(CodeGenerationFailed, err, ExitGeneration, "Inspect the error details and generated files, then retry.")
+	case strings.Contains(msg, "external command") || strings.Contains(msg, "command failed"):
+		return WrapError(CodeExternalCommandFailed, err, ExitExternal, "Inspect the command output and required tools.")
+	case strings.Contains(msg, "lock file") || strings.Contains(msg, "andurel.lock") || strings.Contains(msg, "config"):
+		return WrapError(CodeConfigError, err, ExitConfig, "Inspect andurel.lock and .andurel/config.json.")
+	case strings.Contains(msg, "ambiguous"):
+		return WrapError(CodeAmbiguousInput, err, ExitAmbiguous, "Provide a more specific command argument.")
+	default:
+		return nil
+	}
+}
+
+// RenderError renders a failed response using the selected output mode.
+func RenderError(cmd *cobra.Command, err error) error {
+	opts, parseErr := ParseOptions(cmd)
+	if parseErr != nil {
+		err = parseErr
+	}
+
+	envelope := Fail(err)
+	if opts.Mode == ModeJSON || opts.Mode == ModeAgent {
+		return writeJSON(cmd.ErrOrStderr(), envelope)
+	}
+	if opts.Mode == ModeMarkdown {
+		if envelope.Hint != "" {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "**Error:** %s\n\n%s\n", envelope.Error, envelope.Hint)
+			return nil
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "**Error:** %s\n", envelope.Error)
+		return nil
+	}
+
+	if envelope.Hint != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\nHint: %s\n", envelope.Error, envelope.Hint)
+		return nil
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", envelope.Error)
+	return nil
+}
+
+func renderOK(w io.Writer, opts Options, envelope Envelope) error {
+	switch opts.Mode {
+	case ModeJSON, ModeAgent:
+		return writeJSON(w, envelope)
+	case ModeMarkdown:
+		return writeMarkdown(w, opts, envelope)
+	default:
+		return writeHuman(w, opts, envelope)
+	}
+}
+
+func writeJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func applyJQ(data any, expr string) (any, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" || expr == "." {
+		return data, nil
+	}
+	if !strings.HasPrefix(expr, ".") {
+		return nil, NewError(CodeUsage, "only simple jq-style field paths are supported", ExitUsage, "Use an expression like .field or .nested.field.")
+	}
+
+	current := any(map[string]any{"data": data})
+	parts := strings.SplitSeq(strings.TrimPrefix(expr, "."), ".")
+	for part := range parts {
+		if part == "" {
+			continue
+		}
+		next, ok := lookupField(current, part)
+		if !ok {
+			return nil, NewError(CodeUsage, "jq path not found: "+expr, ExitUsage, "Use andurel commands --json to inspect available fields.")
+		}
+		current = next
+	}
+	return current, nil
+}
+
+func lookupField(value any, name string) (any, bool) {
+	if value == nil {
+		return nil, false
+	}
+	if m, ok := value.(map[string]any); ok {
+		v, exists := m[name]
+		return v, exists
+	}
+
+	rv := reflect.ValueOf(value)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil, false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil, false
+	}
+
+	rt := rv.Type()
+	for i := range rv.NumField() {
+		field := rt.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+		if jsonName == "" {
+			jsonName = field.Name
+		}
+		if jsonName == name || strings.EqualFold(field.Name, name) {
+			return rv.Field(i).Interface(), true
+		}
+	}
+	return nil, false
+}
+
+func writeMarkdown(w io.Writer, opts Options, envelope Envelope) error {
+	if envelope.Summary != "" && !opts.Quiet {
+		if _, err := fmt.Fprintf(w, "%s\n", envelope.Summary); err != nil {
+			return err
+		}
+	}
+	if len(envelope.Breadcrumbs) == 0 || opts.Quiet {
+		return nil
+	}
+
+	if envelope.Summary != "" {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "Next steps:"); err != nil {
+		return err
+	}
+	for _, breadcrumb := range envelope.Breadcrumbs {
+		line := breadcrumb.Command
+		if breadcrumb.Description != "" {
+			line = fmt.Sprintf("%s - %s", line, breadcrumb.Description)
+		}
+		if _, err := fmt.Fprintf(w, "- `%s`\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHuman(w io.Writer, opts Options, envelope Envelope) error {
+	if opts.Quiet {
+		return nil
+	}
+	if envelope.Summary != "" {
+		if _, err := fmt.Fprintln(w, envelope.Summary); err != nil {
+			return err
+		}
+	}
+	if len(envelope.Breadcrumbs) == 0 {
+		return nil
+	}
+
+	if envelope.Summary != "" {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "Next steps:"); err != nil {
+		return err
+	}
+	for _, breadcrumb := range envelope.Breadcrumbs {
+		line := strings.TrimSpace(breadcrumb.Command)
+		if breadcrumb.Description != "" {
+			line = fmt.Sprintf("%s - %s", line, breadcrumb.Description)
+		}
+		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/output/output_test.go
+++ b/cli/output/output_test.go
@@ -1,0 +1,98 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestParseOptionsSelectsAgentMode(t *testing.T) {
+	cmd := &cobra.Command{Use: "andurel"}
+	RegisterPersistentFlags(cmd)
+	if err := cmd.PersistentFlags().Set("agent", "true"); err != nil {
+		t.Fatalf("set --agent: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set("jq", ".data"); err != nil {
+		t.Fatalf("set --jq: %v", err)
+	}
+
+	opts, err := ParseOptions(cmd)
+	if err != nil {
+		t.Fatalf("ParseOptions returned error: %v", err)
+	}
+	if opts.Mode != ModeAgent {
+		t.Fatalf("expected agent mode, got %s", opts.Mode)
+	}
+	if opts.JQ != ".data" {
+		t.Fatalf("expected jq expression to be preserved, got %q", opts.JQ)
+	}
+}
+
+func TestParseOptionsRejectsMultipleOutputModes(t *testing.T) {
+	cmd := &cobra.Command{Use: "andurel"}
+	RegisterPersistentFlags(cmd)
+	if err := cmd.PersistentFlags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set("md", "true"); err != nil {
+		t.Fatalf("set --md: %v", err)
+	}
+
+	_, err := ParseOptions(cmd)
+	if err == nil {
+		t.Fatalf("expected conflict error")
+	}
+
+	var cliErr *CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError, got %T", err)
+	}
+	if cliErr.Code != CodeOutputMode {
+		t.Fatalf("expected code %q, got %q", CodeOutputMode, cliErr.Code)
+	}
+}
+
+func TestOKRendersJSONEnvelope(t *testing.T) {
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "andurel"}
+	RegisterPersistentFlags(cmd)
+	cmd.SetOut(&out)
+	if err := cmd.PersistentFlags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	err := OK(cmd, map[string]string{"id": "post"}, "Generated post", Breadcrumb{Command: "andurel run"})
+	if err != nil {
+		t.Fatalf("OK returned error: %v", err)
+	}
+
+	var envelope Envelope
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode envelope: %v\n%s", err, out.String())
+	}
+	if !envelope.OK || envelope.Summary != "Generated post" {
+		t.Fatalf("unexpected envelope: %#v", envelope)
+	}
+	if len(envelope.Breadcrumbs) != 1 || envelope.Breadcrumbs[0].Command != "andurel run" {
+		t.Fatalf("unexpected breadcrumbs: %#v", envelope.Breadcrumbs)
+	}
+}
+
+func TestFailPreservesTypedErrorFields(t *testing.T) {
+	err := NewError("project_not_found", "not in an Andurel project", ExitProject, "Run this from a project root.")
+
+	envelope := Fail(err)
+	if envelope.OK {
+		t.Fatalf("error envelope should not be ok")
+	}
+	if envelope.Code != "project_not_found" || envelope.ExitCode != ExitProject {
+		t.Fatalf("unexpected envelope: %#v", envelope)
+	}
+	if !strings.Contains(envelope.Hint, "project root") {
+		t.Fatalf("expected hint to be preserved, got %q", envelope.Hint)
+	}
+}

--- a/cli/skill.go
+++ b/cli/skill.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/mbvlabs/andurel/skills"
+	"github.com/spf13/cobra"
+)
+
+type skillReport struct {
+	Name string `json:"name"`
+	Path string `json:"path,omitempty"`
+	Body string `json:"body,omitempty"`
+}
+
+func newSkillCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Show or install the embedded Andurel agent skill",
+		Long:  "Show or install the embedded Andurel agent skill with command recipes and invariants.",
+	}
+	setAgentMetadata(cmd, "skill", "Provides the embedded Andurel agent skill.")
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "show",
+		Short: "Show the embedded Andurel skill",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output.OK(cmd, skillReport{Name: "andurel", Body: skills.AndurelSkill}, "Loaded Andurel skill")
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "install",
+		Short: "Install the embedded Andurel skill into CODEX_HOME",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := codexSkillPath()
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(target, []byte(skills.AndurelSkill), 0o644); err != nil {
+				return err
+			}
+			return output.OK(cmd, skillReport{Name: "andurel", Path: target}, "Installed Andurel skill")
+		},
+	})
+
+	return cmd
+}
+
+func codexSkillPath() (string, error) {
+	home := os.Getenv("CODEX_HOME")
+	if home == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		home = filepath.Join(userHome, ".codex")
+	}
+	return filepath.Join(home, "skills", "andurel", "SKILL.md"), nil
+}

--- a/cli/tool.go
+++ b/cli/tool.go
@@ -1,28 +1,65 @@
 package cli
 
 import (
+	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/mbvlabs/andurel/layout"
 	"github.com/spf13/cobra"
 )
 
 func newToolCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "tool",
-		Aliases: []string{"t"},
+		Aliases: []string{"tools", "t"},
 		Short:   "Manage project tools and binaries",
 		Long: `Manage CLI tools and binaries used by your Andurel project.
 
 Tools are defined in andurel.lock and downloaded to bin/. Use the
 subcommands below to sync, configure, or run tools.`,
 		Example: `  andurel tool sync
+  andurel tools --json
   andurel tool set-version templ 0.3.977
   andurel tool dblab
   andurel tool mailpit`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rootDir, err := findGoModRoot()
+			if err != nil {
+				return err
+			}
+			lock, err := layout.ReadLockFile(rootDir)
+			if err != nil {
+				return err
+			}
+			return output.OK(cmd, toolInfos(rootDir, lock), "Listed tools")
+		},
 	}
+	setAgentMetadata(cmd, "introspection", "Read-only by default; use subcommands for tool mutations.")
 
 	cmd.AddCommand(newSyncCommand())
 	cmd.AddCommand(newSetVersionCommand())
 	cmd.AddCommand(newDblabCommand())
 	cmd.AddCommand(newMailpitCommand())
+	cmd.AddCommand(newToolListCommand())
 
 	return cmd
+}
+
+func newToolListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls", "status"},
+		Short:   "List project tool status",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rootDir, err := findGoModRoot()
+			if err != nil {
+				return err
+			}
+			lock, err := layout.ReadLockFile(rootDir)
+			if err != nil {
+				return err
+			}
+			return output.OK(cmd, toolInfos(rootDir, lock), "Listed tools")
+		},
+	}
 }

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/layout/upgrade"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,7 @@ your application code to work with any API changes in the new version.`,
 	}
 
 	upgradeCmd.Flags().Bool("dry-run", false, "Show what would be changed without applying")
+	upgradeCmd.Flags().Bool("diff", false, "Include a text diff preview in structured output")
 
 	return upgradeCmd
 }
@@ -44,6 +46,14 @@ func runUpgrade(cmd *cobra.Command, targetVersion string) error {
 	if err != nil {
 		return err
 	}
+	diff, err := cmd.Flags().GetBool("diff")
+	if err != nil {
+		return err
+	}
+	outOpts, err := output.ParseOptions(cmd)
+	if err != nil {
+		return err
+	}
 
 	opts := upgrade.UpgradeOptions{
 		DryRun:        dryRun,
@@ -51,16 +61,59 @@ func runUpgrade(cmd *cobra.Command, targetVersion string) error {
 		TargetVersion: targetVersion,
 	}
 
-	fmt.Printf("Upgrading project to version %s...\n\n", targetVersion)
+	if outOpts.Mode != output.ModeJSON && outOpts.Mode != output.ModeAgent {
+		fmt.Printf("Upgrading project to version %s...\n\n", targetVersion)
+	}
 
 	upgrader, err := upgrade.NewUpgrader(projectRoot, opts)
 	if err != nil {
 		return fmt.Errorf("failed to initialize upgrader: %w", err)
 	}
 
-	report, err := upgrader.Execute()
+	before, snapErr := snapshotFilesForReport(projectRoot)
+	if snapErr != nil {
+		return snapErr
+	}
+	report, err := func() (*upgrade.UpgradeReport, error) {
+		if outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent {
+			var report *upgrade.UpgradeReport
+			runErr := runWithOptionalStdoutSilence(true, func() error {
+				var executeErr error
+				report, executeErr = upgrader.Execute()
+				return executeErr
+			})
+			return report, runErr
+		}
+		return upgrader.Execute()
+	}()
 	if err != nil {
 		return err
+	}
+
+	if outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent || outOpts.Mode == output.ModeMarkdown || outOpts.Quiet {
+		after, err := snapshotFilesForReport(projectRoot)
+		if err != nil {
+			return err
+		}
+		artifactReport := buildMutationReport(mutationOptions{
+			Action:   "upgrade",
+			Resource: targetVersion,
+			DryRun:   dryRun,
+			Diff:     diff,
+			CommandsRun: []string{
+				"andurel tool sync",
+			},
+		}, before, after)
+		if dryRun && report != nil {
+			artifactReport.FilesUpdated = append([]string(nil), report.ReplacedFiles...)
+			artifactReport.FilesDeleted = append([]string(nil), report.RemovedFiles...)
+			artifactReport.Warnings = append(artifactReport.Warnings, "dry run only; no files were changed")
+		}
+		data := map[string]any{
+			"upgrade":   report,
+			"artifacts": artifactReport,
+		}
+		return output.OK(cmd, data, mutationSummary(artifactReport), output.Breadcrumb{Command: "andurel doctor"}, output.Breadcrumb{Command: "git diff"})
 	}
 
 	if dryRun {

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -61,7 +61,7 @@ func runUpgrade(cmd *cobra.Command, targetVersion string) error {
 		TargetVersion: targetVersion,
 	}
 
-	if outOpts.Mode != output.ModeJSON && outOpts.Mode != output.ModeAgent {
+	if !output.SuppressesHumanOutput(outOpts) {
 		fmt.Printf("Upgrading project to version %s...\n\n", targetVersion)
 	}
 
@@ -75,7 +75,7 @@ func runUpgrade(cmd *cobra.Command, targetVersion string) error {
 		return snapErr
 	}
 	report, err := func() (*upgrade.UpgradeReport, error) {
-		if outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent {
+		if output.SuppressesHumanOutput(outOpts) {
 			var report *upgrade.UpgradeReport
 			runErr := runWithOptionalStdoutSilence(true, func() error {
 				var executeErr error
@@ -90,7 +90,7 @@ func runUpgrade(cmd *cobra.Command, targetVersion string) error {
 		return err
 	}
 
-	if outOpts.Mode == output.ModeJSON || outOpts.Mode == output.ModeAgent || outOpts.Mode == output.ModeMarkdown || outOpts.Quiet {
+	if output.SuppressesHumanOutput(outOpts) {
 		after, err := snapshotFilesForReport(projectRoot)
 		if err != nil {
 			return err

--- a/e2e/scaffold_matrix_test.go
+++ b/e2e/scaffold_matrix_test.go
@@ -283,7 +283,7 @@ func newScaffoldNormalizer(t *testing.T, project *internal.Project) *scaffoldNor
 		t.Fatalf("failed to read .env.example for normalization: %v", err)
 	}
 
-	for _, line := range strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n") {
 		key, value, ok := strings.Cut(line, "=")
 		if !ok || value == "" {
 			continue

--- a/generator/controllers/main_injector.go
+++ b/generator/controllers/main_injector.go
@@ -314,8 +314,8 @@ func readModulePathFromRoot(rootDir string) (string, error) {
 	}
 	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		if after, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(after), nil
 		}
 	}
 	return "", fmt.Errorf("module declaration not found in go.mod")

--- a/generator/controllers/template_renderer.go
+++ b/generator/controllers/template_renderer.go
@@ -139,8 +139,8 @@ func inertiaDataType(field GeneratedField) string {
 		return "time.Time"
 	}
 
-	if strings.HasPrefix(field.GoType, "*") {
-		return strings.TrimPrefix(field.GoType, "*")
+	if after, ok := strings.CutPrefix(field.GoType, "*"); ok {
+		return after
 	}
 
 	return field.GoType

--- a/generator/models/generator_test.go
+++ b/generator/models/generator_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/mbvlabs/andurel/generator/internal/catalog"
@@ -86,10 +87,5 @@ func tableHasPrimaryKey(table *catalog.Table) bool {
 }
 
 func hasImport(imports []string, target string) bool {
-	for _, imp := range imports {
-		if imp == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(imports, target)
 }

--- a/layout/extension_add_test.go
+++ b/layout/extension_add_test.go
@@ -494,10 +494,10 @@ func TestApplyExtension_UberFxMode(t *testing.T) {
 
 // extractEnvValue extracts the value for a given key from KEY=VALUE format text.
 func extractEnvValue(text, key string) string {
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, key+"=") {
-			return strings.TrimPrefix(line, key+"=")
+		if after, ok := strings.CutPrefix(line, key+"="); ok {
+			return after
 		}
 	}
 	return ""

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -563,17 +564,13 @@ func processTemplatedFiles(
 	data extensions.TemplateData,
 ) error {
 	mappings := make(map[TmplTarget]TmplTargetPath, len(baseTemplateMappings)+len(fxTemplateOverrides)+len(inertiaSharedTemplateMappings)+len(inertiaVueTemplateMappings))
-	for k, v := range baseTemplateMappings {
-		mappings[k] = v
-	}
+	maps.Copy(mappings, baseTemplateMappings)
 
 	if td, ok := data.(*TemplateData); ok && td.DIMode == "uberfx" {
 		for k := range fxSkippedTemplates {
 			delete(mappings, k)
 		}
-		for k, v := range fxTemplateOverrides {
-			mappings[k] = v
-		}
+		maps.Copy(mappings, fxTemplateOverrides)
 	}
 
 	if td, ok := data.(*TemplateData); ok && IsSupportedInertiaAdapter(td.Inertia) {
@@ -587,12 +584,8 @@ func processTemplatedFiles(
 			delete(mappings, "deprecated_controllers_pages.tmpl")
 			mappings["deprecated_controllers_pages_inertia.tmpl"] = inertiaTemplateOverrides["deprecated_controllers_pages_inertia.tmpl"]
 		}
-		for k, v := range inertiaSharedTemplateMappings {
-			mappings[k] = v
-		}
-		for k, v := range inertiaAdapterTemplateMappings(td.Inertia) {
-			mappings[k] = v
-		}
+		maps.Copy(mappings, inertiaSharedTemplateMappings)
+		maps.Copy(mappings, inertiaAdapterTemplateMappings(td.Inertia))
 	}
 
 	for templateFile, targetPath := range mappings {
@@ -891,6 +884,14 @@ func registerBuiltinExtensions() error {
 	})
 
 	return registerBuiltinErr
+}
+
+// AvailableExtensionNames returns the sorted names of built-in extensions.
+func AvailableExtensionNames() ([]string, error) {
+	if err := registerBuiltinExtensions(); err != nil {
+		return nil, err
+	}
+	return extensions.Names(), nil
 }
 
 func resolveExtensions(names []string) ([]extensions.Extension, error) {

--- a/layout/upgrade/orchestrator.go
+++ b/layout/upgrade/orchestrator.go
@@ -100,15 +100,19 @@ func (u *Upgrader) Execute() (*UpgradeReport, error) {
 		fmt.Printf("\n[DRY RUN] Would replace:\n")
 		for path := range renderedTemplates {
 			fmt.Printf("  • %s\n", path)
+			report.ReplacedFiles = append(report.ReplacedFiles, path)
 		}
+		report.FilesReplaced = len(report.ReplacedFiles)
 
 		obsoleteInternalFiles := u.obsoleteManagedInternalFiles()
 		if len(obsoleteInternalFiles) > 0 {
 			fmt.Printf("\n[DRY RUN] Would remove obsolete internal package files:\n")
 			for _, path := range obsoleteInternalFiles {
 				fmt.Printf("  - %s\n", path)
+				report.RemovedFiles = append(report.RemovedFiles, path)
 			}
 		}
+		report.FilesRemoved = len(report.RemovedFiles)
 
 		// Preview tool changes
 		fmt.Printf("\n[DRY RUN] Tool changes:\n")
@@ -118,18 +122,24 @@ func (u *Upgrader) Execute() (*UpgradeReport, error) {
 			for _, tool := range toolSyncPreview.Added {
 				fmt.Printf("    + %s\n", tool)
 			}
+			report.AddedTools = toolSyncPreview.Added
+			report.ToolsAdded = len(toolSyncPreview.Added)
 		}
 		if len(toolSyncPreview.Updated) > 0 {
 			fmt.Printf("  Would update:\n")
 			for _, tool := range toolSyncPreview.Updated {
 				fmt.Printf("    ↑ %s\n", tool)
 			}
+			report.UpdatedTools = toolSyncPreview.Updated
+			report.ToolsUpdated = len(toolSyncPreview.Updated)
 		}
 		if len(toolSyncPreview.Removed) > 0 {
 			fmt.Printf("  Would remove:\n")
 			for _, tool := range toolSyncPreview.Removed {
 				fmt.Printf("    - %s\n", tool)
 			}
+			report.RemovedTools = toolSyncPreview.Removed
+			report.ToolsRemoved = len(toolSyncPreview.Removed)
 		}
 
 		report.Success = true

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mbvlabs/andurel/cli"
+	"github.com/mbvlabs/andurel/cli/output"
 )
 
 var (
@@ -34,6 +35,7 @@ func main() {
 	rootCmd := cli.NewRootCommand(getVersion(), date)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
-		os.Exit(1)
+		_ = output.RenderError(rootCmd, err)
+		os.Exit(output.ExitCode(err))
 	}
 }

--- a/skills/andurel/SKILL.md
+++ b/skills/andurel/SKILL.md
@@ -1,0 +1,41 @@
+# Andurel
+
+Use this skill when working in an Andurel project or generating Andurel code.
+
+## Agent Invariants
+
+- Prefer `andurel --agent --help` and `andurel commands --json` for discovery.
+- Run `andurel project info --json` before generation.
+- Use `--json` or `--jq` when extracting data.
+- Use `--dry-run --json` before mutating commands when intent is uncertain.
+- Inspect returned artifact arrays before assuming which files changed.
+- Follow the repository rules for verification.
+
+## Common Workflows
+
+Inspect a project:
+
+```bash
+andurel project info --json
+andurel routes --json
+andurel models --json
+andurel migrations --json
+```
+
+Preview scaffold generation:
+
+```bash
+andurel generate scaffold Product --dry-run --json
+```
+
+Generate and review artifacts:
+
+```bash
+andurel generate scaffold Product --json
+```
+
+Check project health:
+
+```bash
+andurel doctor --json
+```

--- a/skills/assets.go
+++ b/skills/assets.go
@@ -1,0 +1,6 @@
+package skills
+
+import _ "embed"
+
+//go:embed andurel/SKILL.md
+var AndurelSkill string


### PR DESCRIPTION
## Summary

- Add shared CLI output infrastructure for agent-friendly modes, including `--json`, `--agent`, `--md`, `--quiet`, `--jq`, stable success/error envelopes, typed error codes, and structured help rendering.
- Add discovery and introspection commands so tools can inspect the CLI and project state: `commands`, `project info`, `routes`, `models`, `migrations`, `controllers`, `views`, `jobs`, `tool list`, `extension list --available`, and the embedded `skill` command.
- Add mutation artifact reporting for project creation, generators, extension installs, and upgrades, including `--dry-run`, optional `--diff`, created/updated/deleted file lists, route detection, breadcrumbs, and quieter structured output.
- Add agent config support across user, project, and cache scopes, plus structured `doctor` output with categorized checks, hints, and blocking status.
- Update command-surface/output contract coverage, embed the Andurel skill docs, expose available extension names, and remove stale README references to the old `llm` command.

## Notes

- The follow-up review commit tightens optional config handling, structured doctor failure behavior, `--jq` mode selection, and shared quiet/structured-output suppression logic.