### PR TITLE
feat(skill): support harness-aware installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,10 @@ The embedded agent skill is available from the binary:
 andurel skill show
 andurel skill show --json
 andurel skill install
+andurel skill install --harness claude,pi
 ```
 
-`skill install` writes the Andurel skill into the current project at `.codex/skills/andurel/`, including the framework-specific layer-placement reference.
+In human mode, `skill install` prompts for one or more harnesses. Automation must pass one or more `--harness` values; the flag may be repeated or contain comma-separated values. Each selection receives the complete embedded skill, including the framework-specific layer-placement reference.
 
 ### Mutation previews
 
@@ -604,7 +605,7 @@ andurel config unset KEY [--scope project|user|cache]
 
 Project config is stored at `.andurel/config.json`. User config uses the OS config directory under `andurel/config.json`, and cache config uses the OS cache directory under `andurel/config.json`.
 
-### `andurel skill` — Embedded agent skill
+### `andurel skill` - Embedded agent skill
 
 Shows or installs the Andurel agent skill with CLI recipes, invariants, and framework layer-placement guidance.
 
@@ -612,9 +613,19 @@ Shows or installs the Andurel agent skill with CLI recipes, invariants, and fram
 andurel skill show
 andurel skill show --json
 andurel skill install
+andurel skill install --harness codex,claude
+andurel skill install --harness pi --harness crush
 ```
 
-`andurel skill install` copies the embedded skill into `.codex/skills/andurel/` for the current project.
+Without `--harness`, human mode displays a numbered multi-select prompt with no default. JSON, agent, Markdown, and quiet modes require `--harness` so automation never waits for input.
+
+| Harness | Project path |
+|---|---|
+| Codex | `.codex/skills/andurel/` |
+| Claude | `.claude/skills/andurel/` |
+| Pi | `.pi/skills/andurel/` |
+| OpenCode | `.opencode/skills/andurel/` |
+| Crush | `.crush/skills/andurel/` |
 
 ---
 

--- a/cli/skill.go
+++ b/cli/skill.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/mbvlabs/andurel/cli/output"
@@ -11,10 +14,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type skillInstallation struct {
+	Harness string `json:"harness"`
+	Path    string `json:"path"`
+}
+
 type skillReport struct {
-	Name string `json:"name"`
-	Path string `json:"path,omitempty"`
-	Body string `json:"body,omitempty"`
+	Name          string              `json:"name"`
+	Path          string              `json:"path,omitempty"`
+	Installations []skillInstallation `json:"installations,omitempty"`
+	Body          string              `json:"body,omitempty"`
+}
+
+type skillHarness struct {
+	name      string
+	label     string
+	directory string
+}
+
+var skillHarnesses = []skillHarness{
+	{name: "codex", label: "Codex", directory: ".codex/skills/andurel"},
+	{name: "claude", label: "Claude", directory: ".claude/skills/andurel"},
+	{name: "pi", label: "Pi", directory: ".pi/skills/andurel"},
+	{name: "opencode", label: "OpenCode", directory: ".opencode/skills/andurel"},
+	{name: "crush", label: "Crush", directory: ".crush/skills/andurel"},
 }
 
 func newSkillCommand() *cobra.Command {
@@ -51,31 +74,153 @@ func newSkillCommand() *cobra.Command {
 		},
 	})
 
-	cmd.AddCommand(&cobra.Command{
+	var requestedHarnesses []string
+	installCmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the embedded Andurel skill into the current project",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target, err := projectCodexSkillPath()
+			harnesses, err := selectSkillHarnesses(cmd, requestedHarnesses)
 			if err != nil {
 				return err
 			}
-			if err := installAndurelSkill(filepath.Dir(target)); err != nil {
+			rootDir, err := findGoModRoot()
+			if err != nil {
 				return err
 			}
-			return output.OK(cmd, skillReport{Name: "andurel", Path: target}, "Installed Andurel skill")
+
+			installations := make([]skillInstallation, 0, len(harnesses))
+			labels := make([]string, 0, len(harnesses))
+			for _, harness := range harnesses {
+				target := filepath.Join(rootDir, filepath.FromSlash(harness.directory), "SKILL.md")
+				if err := installAndurelSkill(filepath.Dir(target)); err != nil {
+					return fmt.Errorf("install Andurel skill for %s: %w", harness.label, err)
+				}
+				installations = append(installations, skillInstallation{Harness: harness.name, Path: target})
+				labels = append(labels, harness.label)
+			}
+
+			report := skillReport{Name: "andurel", Installations: installations}
+			if len(installations) == 1 {
+				report.Path = installations[0].Path
+			}
+			return output.OK(cmd, report, "Installed Andurel skill for "+strings.Join(labels, ", "))
 		},
-	})
+	}
+	installCmd.Flags().StringSliceVar(
+		&requestedHarnesses,
+		"harness",
+		nil,
+		"Harnesses to install for: codex, claude, pi, opencode, crush (comma-separated or repeated)",
+	)
+	cmd.AddCommand(installCmd)
 
 	return cmd
 }
 
-func projectCodexSkillPath() (string, error) {
-	rootDir, err := findGoModRoot()
-	if err != nil {
-		return "", err
+func selectSkillHarnesses(cmd *cobra.Command, requested []string) ([]skillHarness, error) {
+	if len(requested) > 0 {
+		return parseSkillHarnessNames(requested)
 	}
-	return filepath.Join(rootDir, ".codex", "skills", "andurel", "SKILL.md"), nil
+
+	opts, err := output.ParseOptions(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if output.UsesStructuredOutput(opts) || opts.Quiet {
+		return nil, skillHarnessError(
+			"harness selection is required in non-interactive output modes",
+			"Use --harness with one or more of: "+validSkillHarnessNames()+".",
+		)
+	}
+
+	return promptSkillHarnesses(cmd)
+}
+
+func promptSkillHarnesses(cmd *cobra.Command) ([]skillHarness, error) {
+	writer := cmd.OutOrStdout()
+	if _, err := fmt.Fprintln(writer, "Select harnesses (comma-separated numbers):"); err != nil {
+		return nil, err
+	}
+	for index, harness := range skillHarnesses {
+		if _, err := fmt.Fprintf(writer, "  %d) %s\n", index+1, harness.label); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := fmt.Fprint(writer, "Selection: "); err != nil {
+		return nil, err
+	}
+
+	selection, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil {
+		if err == io.EOF {
+			return nil, skillHarnessError("harness selection was cancelled", "Run the command again and select at least one harness.")
+		}
+		return nil, fmt.Errorf("read harness selection: %w", err)
+	}
+	selection = strings.TrimSpace(selection)
+	if selection == "" {
+		return nil, skillHarnessError("select at least one harness", "Enter one or more comma-separated numbers from the list.")
+	}
+
+	names := make([]string, 0, len(skillHarnesses))
+	for value := range strings.SplitSeq(selection, ",") {
+		number, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil || number < 1 || number > len(skillHarnesses) {
+			return nil, skillHarnessError(
+				fmt.Sprintf("invalid harness selection %q", strings.TrimSpace(value)),
+				fmt.Sprintf("Enter comma-separated numbers from 1 to %d.", len(skillHarnesses)),
+			)
+		}
+		names = append(names, skillHarnesses[number-1].name)
+	}
+	return parseSkillHarnessNames(names)
+}
+
+func parseSkillHarnessNames(names []string) ([]skillHarness, error) {
+	selected := make([]skillHarness, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, value := range names {
+		name := strings.ToLower(strings.TrimSpace(value))
+		if name == "" {
+			return nil, skillHarnessError("harness name cannot be empty", "Choose one or more of: "+validSkillHarnessNames()+".")
+		}
+		if seen[name] {
+			continue
+		}
+
+		found := false
+		for _, harness := range skillHarnesses {
+			if harness.name == name {
+				selected = append(selected, harness)
+				seen[name] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, skillHarnessError(
+				fmt.Sprintf("unknown harness %q", value),
+				"Choose one or more of: "+validSkillHarnessNames()+".",
+			)
+		}
+	}
+	if len(selected) == 0 {
+		return nil, skillHarnessError("select at least one harness", "Choose one or more of: "+validSkillHarnessNames()+".")
+	}
+	return selected, nil
+}
+
+func validSkillHarnessNames() string {
+	names := make([]string, len(skillHarnesses))
+	for index, harness := range skillHarnesses {
+		names[index] = harness.name
+	}
+	return strings.Join(names, ", ")
+}
+
+func skillHarnessError(message, hint string) error {
+	return output.NewError(output.CodeUsage, message, output.ExitUsage, hint)
 }
 
 func installAndurelSkill(targetDir string) error {

--- a/cli/skill_test.go
+++ b/cli/skill_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/mbvlabs/andurel/cli/output"
 	"github.com/mbvlabs/andurel/skills"
 )
 
@@ -45,66 +47,190 @@ func TestSkillShowJSONIncludesEmbeddedSkill(t *testing.T) {
 	}
 }
 
-func TestSkillInstallWritesProjectLocalSkill(t *testing.T) {
+func TestSkillInstallPromptsForHarnesses(t *testing.T) {
+	result := runSkillCommandTest(t, "2,3,5\n", "skill", "install")
+	if result.err != nil {
+		t.Fatalf("skill install failed: %v\nstderr:\n%s", result.err, result.stderr)
+	}
+	for _, option := range []string{"1) Codex", "2) Claude", "3) Pi", "4) OpenCode", "5) Crush", "Selection:"} {
+		if !strings.Contains(result.stdout, option) {
+			t.Fatalf("interactive output missing %q:\n%s", option, result.stdout)
+		}
+	}
+
+	for _, harness := range []string{"claude", "pi", "crush"} {
+		assertInstalledSkill(t, result.rootDir, harnessSkillDirectories[harness])
+	}
+	for _, harness := range []string{"codex", "opencode"} {
+		assertSkillNotInstalled(t, result.rootDir, harnessSkillDirectories[harness])
+	}
+}
+
+func TestSkillInstallHarnessFlagWritesEachHarness(t *testing.T) {
+	for harness, directory := range harnessSkillDirectories {
+		t.Run(harness, func(t *testing.T) {
+			result := runSkillCommandTest(t, "", "skill", "install", "--harness", harness, "--json")
+			if result.err != nil {
+				t.Fatalf("skill install failed: %v\nstderr:\n%s", result.err, result.stderr)
+			}
+
+			var envelope struct {
+				OK   bool `json:"ok"`
+				Data struct {
+					Path          string `json:"path"`
+					Installations []struct {
+						Harness string `json:"harness"`
+						Path    string `json:"path"`
+					} `json:"installations"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+				t.Fatalf("decode skill install output: %v\nstdout:\n%s", err, result.stdout)
+			}
+			expectedPath := filepath.Join(result.rootDir, filepath.FromSlash(directory), "SKILL.md")
+			if !envelope.OK || envelope.Data.Path != expectedPath {
+				t.Fatalf("unexpected install envelope: %#v", envelope)
+			}
+			if len(envelope.Data.Installations) != 1 ||
+				envelope.Data.Installations[0].Harness != harness ||
+				envelope.Data.Installations[0].Path != expectedPath {
+				t.Fatalf("unexpected installations: %#v", envelope.Data.Installations)
+			}
+			assertInstalledSkill(t, result.rootDir, directory)
+		})
+	}
+}
+
+func TestSkillInstallHarnessFlagSupportsMultipleSelections(t *testing.T) {
+	result := runSkillCommandTest(
+		t,
+		"",
+		"skill", "install",
+		"--harness", "Claude,pi",
+		"--harness", "crush,claude",
+		"--json",
+	)
+	if result.err != nil {
+		t.Fatalf("skill install failed: %v\nstderr:\n%s", result.err, result.stderr)
+	}
+
+	var envelope struct {
+		Data struct {
+			Path          string `json:"path"`
+			Installations []struct {
+				Harness string `json:"harness"`
+				Path    string `json:"path"`
+			} `json:"installations"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+		t.Fatalf("decode skill install output: %v\nstdout:\n%s", err, result.stdout)
+	}
+	if envelope.Data.Path != "" {
+		t.Fatalf("multi-harness install should omit singular path, got %q", envelope.Data.Path)
+	}
+	want := []string{"claude", "pi", "crush"}
+	if len(envelope.Data.Installations) != len(want) {
+		t.Fatalf("installations = %#v, want %v", envelope.Data.Installations, want)
+	}
+	for index, harness := range want {
+		if envelope.Data.Installations[index].Harness != harness {
+			t.Fatalf("installation %d = %#v, want harness %q", index, envelope.Data.Installations[index], harness)
+		}
+		assertInstalledSkill(t, result.rootDir, harnessSkillDirectories[harness])
+	}
+}
+
+func TestSkillInstallRejectsInvalidSelectionsBeforeWriting(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		args  []string
+	}{
+		{name: "blank prompt", input: "\n", args: []string{"skill", "install"}},
+		{name: "out of range prompt", input: "6\n", args: []string{"skill", "install"}},
+		{name: "unknown flag", args: []string{"skill", "install", "--harness", "other", "--json"}},
+		{name: "structured without flag", args: []string{"skill", "install", "--json"}},
+		{name: "quiet without flag", args: []string{"skill", "install", "--quiet"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := runSkillCommandTest(t, test.input, test.args...)
+			if result.err == nil {
+				t.Fatalf("expected skill install to fail\nstdout:\n%s", result.stdout)
+			}
+			if fail := output.Fail(result.err); fail.Code != output.CodeUsage {
+				t.Fatalf("error code = %q, want %q: %v", fail.Code, output.CodeUsage, result.err)
+			}
+			for _, directory := range harnessSkillDirectories {
+				assertSkillNotInstalled(t, result.rootDir, directory)
+			}
+		})
+	}
+}
+
+type skillCommandTestResult struct {
+	rootDir string
+	stdout  string
+	stderr  string
+	err     error
+}
+
+var harnessSkillDirectories = map[string]string{
+	"codex":    ".codex/skills/andurel",
+	"claude":   ".claude/skills/andurel",
+	"pi":       ".pi/skills/andurel",
+	"opencode": ".opencode/skills/andurel",
+	"crush":    ".crush/skills/andurel",
+}
+
+func runSkillCommandTest(t *testing.T, input string, args ...string) skillCommandTestResult {
+	t.Helper()
 	resetCLITestSeams(t)
 
 	rootDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(rootDir, "go.mod"), []byte("module example.com/app\n"), 0o644); err != nil {
 		t.Fatalf("write go.mod: %v", err)
 	}
-	findGoModRoot = func() (string, error) {
-		return rootDir, nil
-	}
+	findGoModRoot = func() (string, error) { return rootDir, nil }
 
 	var stdout, stderr bytes.Buffer
 	cmd := NewRootCommand("test", "test-date")
+	cmd.SetIn(strings.NewReader(input))
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"skill", "install", "--json"})
+	cmd.SetArgs(args)
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("skill install failed: %v\nstderr:\n%s", err, stderr.String())
+	err := cmd.Execute()
+	return skillCommandTestResult{
+		rootDir: rootDir,
+		stdout:  stdout.String(),
+		stderr:  stderr.String(),
+		err:     err,
 	}
+}
 
-	var envelope struct {
-		OK   bool        `json:"ok"`
-		Data skillReport `json:"data"`
+func assertInstalledSkill(t *testing.T, rootDir, directory string) {
+	t.Helper()
+	if err := skills.WalkAndurelSkillFiles(func(path string, expected []byte) error {
+		installed, err := os.ReadFile(filepath.Join(rootDir, filepath.FromSlash(directory), filepath.FromSlash(path)))
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(installed, expected) {
+			return fmt.Errorf("installed %s does not match embedded asset", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("verify installed skill at %s: %v", directory, err)
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
-		t.Fatalf("decode skill install output: %v\nstdout:\n%s", err, stdout.String())
-	}
-	if !envelope.OK {
-		t.Fatalf("expected ok envelope: %#v", envelope)
-	}
+}
 
-	expectedPath := filepath.Join(rootDir, ".codex", "skills", "andurel", "SKILL.md")
-	if envelope.Data.Path != expectedPath {
-		t.Fatalf("expected project-local skill path %q, got %q", expectedPath, envelope.Data.Path)
-	}
-
-	data, err := os.ReadFile(envelope.Data.Path)
-	if err != nil {
-		t.Fatalf("read installed skill: %v", err)
-	}
-	if string(data) != skills.AndurelSkill {
-		t.Fatalf("installed skill content does not match embedded skill")
-	}
-
-	referencePath := filepath.Join(rootDir, ".codex", "skills", "andurel", "references", "layer-placement.md")
-	referenceData, err := os.ReadFile(referencePath)
-	if err != nil {
-		t.Fatalf("read installed layer placement reference: %v", err)
-	}
-	if !strings.Contains(string(referenceData), "# Layer Placement") {
-		t.Fatalf("installed layer placement reference has unexpected content:\n%s", referenceData)
-	}
-
-	agentPath := filepath.Join(rootDir, ".codex", "skills", "andurel", "agents", "openai.yaml")
-	agentData, err := os.ReadFile(agentPath)
-	if err != nil {
-		t.Fatalf("read installed OpenAI agent metadata: %v", err)
-	}
-	if !strings.Contains(string(agentData), `display_name: "Andurel"`) {
-		t.Fatalf("installed OpenAI agent metadata has unexpected content:\n%s", agentData)
+func assertSkillNotInstalled(t *testing.T, rootDir, directory string) {
+	t.Helper()
+	path := filepath.Join(rootDir, filepath.FromSlash(directory))
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("unselected skill path %s exists or could not be inspected: %v", path, err)
 	}
 }

--- a/contracts/cli-v1.json
+++ b/contracts/cli-v1.json
@@ -979,6 +979,11 @@
       "use": "install",
       "flags": [
         {
+          "name": "harness",
+          "type": "stringSlice",
+          "default": "[]"
+        },
+        {
           "name": "help",
           "shorthand": "h",
           "type": "bool",
@@ -1712,6 +1717,19 @@
       ]
     },
     {
+      "type": "github.com/mbvlabs/andurel/cli.skillInstallation",
+      "fields": [
+        {
+          "go_name": "Harness",
+          "json_name": "harness"
+        },
+        {
+          "go_name": "Path",
+          "json_name": "path"
+        }
+      ]
+    },
+    {
       "type": "github.com/mbvlabs/andurel/cli.skillReport",
       "fields": [
         {
@@ -1721,6 +1739,11 @@
         {
           "go_name": "Path",
           "json_name": "path",
+          "omitempty": true
+        },
+        {
+          "go_name": "Installations",
+          "json_name": "installations",
           "omitempty": true
         },
         {
@@ -2117,6 +2140,11 @@
         {
           "go_name": "Inertia",
           "json_name": "inertia",
+          "omitempty": true
+        },
+        {
+          "go_name": "InertiaRoot",
+          "json_name": "inertiaRoot",
           "omitempty": true
         },
         {


### PR DESCRIPTION
## Summary

- prompt human users to select one or more skill harnesses with no default
- support repeatable and comma-separated `--harness` values for automation
- install the embedded skill for Codex, Claude, Pi, OpenCode, and Crush
- document and contract-test the new behavior

## Note

Contract regeneration also records the existing `inertiaRoot` response field that was missing from the fixture.