### PR TITLE
fix(cli): plan model dry runs in memory

### DIFF
--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/mbvlabs/andurel/generator"
+	"github.com/mbvlabs/andurel/pkg/cache"
 	"github.com/spf13/cobra"
 )
 
@@ -117,14 +119,18 @@ func runDryMutation(cmd *cobra.Command, outOpts output.Options, opts mutationOpt
 		return err
 	}
 	originalFindGoModRoot := findGoModRoot
+	defer func() {
+		findGoModRoot = originalFindGoModRoot
+		_ = os.Chdir(oldWD)
+		cache.ClearFileSystemCache()
+	}()
 	findGoModRoot = func() (string, error) {
 		return tempRoot, nil
 	}
+	cache.ClearFileSystemCache()
 	runErr := runWithOptionalStdoutSilence(output.SuppressesHumanOutput(outOpts), func() error {
 		return opts.Run(tempRoot)
 	})
-	findGoModRoot = originalFindGoModRoot
-	_ = os.Chdir(oldWD)
 	if runErr != nil {
 		return runErr
 	}
@@ -217,6 +223,38 @@ func mutationSummary(report mutationReport) string {
 		return fmt.Sprintf("%s completed with no file changes", report.Action)
 	}
 	return fmt.Sprintf("%s %d files for %s", verb, total, report.Action)
+}
+
+func buildModelPlanMutationReport(rootDir, resourceName string, plan *generator.ModelGenerationPlan, includeDiff bool) mutationReport {
+	before := make(fileSnapshot)
+	after := make(fileSnapshot)
+	if plan != nil {
+		for _, file := range plan.Files {
+			relativePath, err := filepath.Rel(rootDir, file.Path)
+			if err != nil {
+				relativePath = file.Path
+			}
+			relativePath = filepath.ToSlash(relativePath)
+			if file.Exists {
+				before[relativePath] = plannedFileState(file.OldContent)
+			}
+			after[relativePath] = plannedFileState(file.NewContent)
+		}
+	}
+	report := buildMutationReport(mutationOptions{
+		Action:   "generate model",
+		Resource: resourceName,
+		DryRun:   true,
+		Diff:     includeDiff,
+	}, before, after)
+	report.DryRun = true
+	report.Warnings = append(report.Warnings, "dry run only; no files were changed")
+	return report
+}
+
+func plannedFileState(content string) fileState {
+	data := []byte(content)
+	return fileState{Hash: sha256.Sum256(data), Content: data}
 }
 
 func isRoutePath(path string) bool {

--- a/cli/command_behavior_test.go
+++ b/cli/command_behavior_test.go
@@ -109,6 +109,58 @@ func TestGenerateModelMapsPrimaryKeyToGenerator(t *testing.T) {
 	}
 }
 
+func TestGenerateModelMapsModeToGenerator(t *testing.T) {
+	resetCLITestSeams(t)
+	fake := installFakeGenerator(t)
+
+	result := executeCLITest(t, "generate", "model", "AuditLog", "--mode", "read-only", "--primary-key", "event_id")
+	if result.err != nil {
+		t.Fatalf("generate read-only model failed: %v", result.err)
+	}
+	want := []modelModeCall{{
+		name:       "AuditLog",
+		primaryKey: "event_id",
+		mode:       generator.ModelModeReadOnly,
+	}}
+	if !reflect.DeepEqual(fake.modelModeCalls, want) {
+		t.Fatalf("model mode calls: expected %#v, got %#v", want, fake.modelModeCalls)
+	}
+	if len(fake.modelCalls) != 0 || len(fake.modelWithPKCalls) != 0 {
+		t.Fatalf("mode generation used legacy calls: models=%#v with_pk=%#v", fake.modelCalls, fake.modelWithPKCalls)
+	}
+}
+
+func TestGenerateModelRejectsInvalidMode(t *testing.T) {
+	result := runCLITest(t, "generate", "model", "AuditLog", "--mode", "immutable")
+	if result.err == nil || !strings.Contains(result.err.Error(), "invalid model mode") {
+		t.Fatalf("expected invalid model mode error, got %v", result.err)
+	}
+}
+
+func TestGenerateModelDryRunUsesGenerationPlan(t *testing.T) {
+	resetCLITestSeams(t)
+	fake := installFakeGenerator(t)
+	fake.modelPlan = &generator.ModelGenerationPlan{}
+
+	result := executeCLITest(t, "generate", "model", "ServerSSHCredential", "--dry-run", "--json", "--mode", "read-only", "--primary-key", "credential_id")
+	if result.err != nil {
+		t.Fatalf("generate model dry run failed: %v", result.err)
+	}
+	want := []modelPlanCall{{
+		name: "ServerSSHCredential",
+		options: generator.ModelGenerationOptions{
+			PrimaryKeyColumn: "credential_id",
+			Mode:             generator.ModelModeReadOnly,
+		},
+	}}
+	if !reflect.DeepEqual(fake.modelPlanCalls, want) {
+		t.Fatalf("model plan calls: expected %#v, got %#v", want, fake.modelPlanCalls)
+	}
+	if len(fake.modelCalls) != 0 || len(fake.modelWithPKCalls) != 0 || len(fake.modelModeCalls) != 0 {
+		t.Fatalf("dry run invoked writing generation methods: %#v", fake)
+	}
+}
+
 func TestGenerateModelUpdateMapsYesFlag(t *testing.T) {
 	resetCLITestSeams(t)
 	var gotName string

--- a/cli/command_behavior_test.go
+++ b/cli/command_behavior_test.go
@@ -161,6 +161,49 @@ func TestGenerateModelDryRunUsesGenerationPlan(t *testing.T) {
 	}
 }
 
+func TestGenerateModelDryRunReportsHumanSummary(t *testing.T) {
+	resetCLITestSeams(t)
+	fake := installFakeGenerator(t)
+	fake.modelPlan = &generator.ModelGenerationPlan{Files: []generator.PlannedFile{
+		{
+			Path:       "models/model.go",
+			Exists:     true,
+			OldContent: "package models\n",
+			NewContent: "package models\n\nvar Product product\n",
+		},
+		{
+			Path:       "models/product.go",
+			NewContent: "package models\n",
+		},
+	}}
+
+	result := executeCLITest(t, "generate", "model", "Product", "--dry-run")
+	if result.err != nil {
+		t.Fatalf("generate model dry run failed: %v", result.err)
+	}
+	for _, want := range []string{
+		"Dry run: Would change 2 files for generate model",
+		"  create models/product.go",
+		"  update models/model.go",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, result.stdout)
+		}
+	}
+}
+
+func TestGenerateModelDryRunReturnsPlanningError(t *testing.T) {
+	resetCLITestSeams(t)
+	fake := installFakeGenerator(t)
+	wantErr := errors.New("plan model")
+	fake.modelPlanErr = wantErr
+
+	result := executeCLITest(t, "generate", "model", "Product", "--dry-run")
+	if !errors.Is(result.err, wantErr) {
+		t.Fatalf("generate model dry run error = %v, want %v", result.err, wantErr)
+	}
+}
+
 func TestGenerateModelUpdateMapsYesFlag(t *testing.T) {
 	resetCLITestSeams(t)
 	var gotName string

--- a/cli/command_test_helper_test.go
+++ b/cli/command_test_helper_test.go
@@ -192,6 +192,10 @@ func stubLatestAndurelVersion(t *testing.T, version string, err error) {
 type fakeGenerator struct {
 	modelCalls       []modelCall
 	modelWithPKCalls []modelWithPKCall
+	modelModeCalls   []modelModeCall
+	modelPlanCalls   []modelPlanCall
+	modelPlan        *generator.ModelGenerationPlan
+	modelPlanErr     error
 	scaffoldCalls    []scaffoldCall
 	controllerCalls  []controllerCall
 	factoryCalls     []factoryCall
@@ -218,6 +222,19 @@ type modelWithPKCall struct {
 	tableName   string
 	skipFactory bool
 	primaryKey  string
+}
+
+type modelModeCall struct {
+	name        string
+	tableName   string
+	skipFactory bool
+	primaryKey  string
+	mode        generator.ModelMode
+}
+
+type modelPlanCall struct {
+	name    string
+	options generator.ModelGenerationOptions
 }
 
 type scaffoldCall struct {
@@ -265,6 +282,22 @@ func (f *fakeGenerator) GenerateModelWithPK(resourceName string, tableNameOverri
 		primaryKey:  primaryKeyColumn,
 	})
 	return f.err
+}
+
+func (f *fakeGenerator) GenerateModelWithMode(resourceName string, tableNameOverride string, skipFactory bool, primaryKeyColumn string, mode generator.ModelMode) error {
+	f.modelModeCalls = append(f.modelModeCalls, modelModeCall{
+		name:        resourceName,
+		tableName:   tableNameOverride,
+		skipFactory: skipFactory,
+		primaryKey:  primaryKeyColumn,
+		mode:        mode,
+	})
+	return f.err
+}
+
+func (f *fakeGenerator) PlanModel(resourceName string, options generator.ModelGenerationOptions) (*generator.ModelGenerationPlan, error) {
+	f.modelPlanCalls = append(f.modelPlanCalls, modelPlanCall{name: resourceName, options: options})
+	return f.modelPlan, f.modelPlanErr
 }
 
 func (f *fakeGenerator) GenerateControllerWithActions(resourceName, namespace, tableName string, actions []string, inertia string, isAPI bool) error {

--- a/cli/generate_model.go
+++ b/cli/generate_model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/mbvlabs/andurel/cli/output"
+	"github.com/mbvlabs/andurel/generator"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,7 @@ func newGenerateModelCommand() *cobra.Command {
 		primaryKeyColumn string
 		dryRun           bool
 		diff             bool
+		modelMode        string
 	)
 
 	cmd := &cobra.Command{
@@ -66,10 +68,24 @@ update also syncs the matching factory unless --skip-factory is passed.`,
 				return fmt.Errorf("too many arguments: model takes exactly 1 argument (the model name)")
 			}
 			name := args[0]
+			mode := generator.ModelMode(modelMode)
+			switch mode {
+			case generator.ModelModeCRUD, generator.ModelModeReadOnly, generator.ModelModeCreateOnly:
+			default:
+				return fmt.Errorf("invalid model mode %q: expected crud, read-only, or create-only", modelMode)
+			}
 
 			rootDir, err := findGoModRoot()
 			if err != nil {
 				return err
+			}
+			if dryRun && !updateModel {
+				return runModelGenerationDryRun(cmd, rootDir, name, generator.ModelGenerationOptions{
+					TableNameOverride: tableName,
+					SkipFactory:       skipFactory,
+					PrimaryKeyColumn:  primaryKeyColumn,
+					Mode:              mode,
+				}, diff)
 			}
 
 			return runMutation(cmd, mutationOptions{
@@ -90,6 +106,9 @@ update also syncs the matching factory unless --skip-factory is passed.`,
 						if err != nil {
 							return err
 						}
+						if mode != generator.ModelModeCRUD {
+							return gen.GenerateModelWithMode(name, tableName, skipFactory, primaryKeyColumn, mode)
+						}
 						if primaryKeyColumn != "" {
 							return gen.GenerateModelWithPK(name, tableName, skipFactory, primaryKeyColumn)
 						}
@@ -107,6 +126,40 @@ update also syncs the matching factory unless --skip-factory is passed.`,
 	cmd.Flags().StringVar(&primaryKeyColumn, "primary-key", "", "Specify the primary key column (skips interactive detection)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview file changes without applying")
 	cmd.Flags().BoolVar(&diff, "diff", false, "Include a text diff preview in structured output")
+	cmd.Flags().StringVar(&modelMode, "mode", string(generator.ModelModeCRUD), "Generated operation mode: crud, read-only, or create-only")
 
 	return cmd
+}
+
+func runModelGenerationDryRun(cmd *cobra.Command, rootDir, resourceName string, options generator.ModelGenerationOptions, includeDiff bool) error {
+	outOpts, err := output.ParseOptions(cmd)
+	if err != nil {
+		return err
+	}
+	gen, err := newGenerator()
+	if err != nil {
+		return err
+	}
+	plan, err := gen.PlanModel(resourceName, options)
+	if err != nil {
+		return err
+	}
+	report := buildModelPlanMutationReport(rootDir, resourceName, plan, includeDiff)
+	if outOpts.Mode == output.ModeHuman && !outOpts.Quiet {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Dry run: %s\n", mutationSummary(report)); err != nil {
+			return err
+		}
+		for _, path := range report.FilesCreated {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  create %s\n", path); err != nil {
+				return err
+			}
+		}
+		for _, path := range report.FilesUpdated {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  update %s\n", path); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return output.OK(cmd, report, mutationSummary(report), output.Breadcrumb{Command: "andurel doctor", Description: "Verify generated model health"})
 }

--- a/cli/generate_model_dry_run_test.go
+++ b/cli/generate_model_dry_run_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/mbvlabs/andurel/generator"
+	"github.com/mbvlabs/andurel/pkg/cache"
+)
+
+func TestBuildModelPlanMutationReportUsesPlannedStrings(t *testing.T) {
+	root := t.TempDir()
+	plan := &generator.ModelGenerationPlan{Files: []generator.PlannedFile{
+		{
+			Path:       filepath.Join(root, "models", "model.go"),
+			Exists:     true,
+			OldContent: "package models\n",
+			NewContent: "package models\n\nvar Product product\n",
+		},
+		{
+			Path:       filepath.Join(root, "models", "product.go"),
+			NewContent: "package models\n\ntype ProductEntity struct{}\n",
+		},
+	}}
+
+	report := buildModelPlanMutationReport(root, "Product", plan, true)
+	if !slices.Equal(report.FilesCreated, []string{"models/product.go"}) {
+		t.Fatalf("created files = %#v", report.FilesCreated)
+	}
+	if !slices.Equal(report.FilesUpdated, []string{"models/model.go"}) {
+		t.Fatalf("updated files = %#v", report.FilesUpdated)
+	}
+	for _, want := range []string{"diff --git a/models/model.go", "+var Product product", "diff --git a/models/product.go", "+type ProductEntity struct{}"} {
+		if !strings.Contains(report.Diff, want) {
+			t.Fatalf("planned diff missing %q:\n%s", want, report.Diff)
+		}
+	}
+}
+
+func TestGenerateModelDryRunReportsFactoryWithoutMutatingProject(t *testing.T) {
+	resetCLITestSeams(t)
+
+	rootDir := t.TempDir()
+	writeCLITestFile(t, rootDir, "go.mod", "module example.com/app\n\ngo 1.26.5\n")
+	writeCLITestFile(t, rootDir, "models/model.go", "package models\n\ntype (\n)\n\nvar (\n)\n")
+	writeCLITestFile(t, rootDir, "database/migrations/000100_create_products.sql", `-- +goose Up
+CREATE TABLE products (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- +goose Down
+DROP TABLE products;
+`)
+
+	modelRegistryPath := filepath.Join(rootDir, "models", "model.go")
+	registryBefore, err := os.ReadFile(modelRegistryPath)
+	if err != nil {
+		t.Fatalf("read model registry before dry run: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("change to project root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+		cache.ClearFileSystemCache()
+	})
+	cache.ClearFileSystemCache()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand("test", "test-date")
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"generate", "model", "Product", "--dry-run", "--json", "--primary-key", "id"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("generate model dry run: %v", err)
+	}
+
+	var response struct {
+		Data mutationReport `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("decode dry-run response: %v\n%s", err, stdout.String())
+	}
+	for _, want := range []string{"models/product.go", "models/factories/product.go"} {
+		if !slices.Contains(response.Data.FilesCreated, want) {
+			t.Fatalf("dry-run files_created missing %q: %#v", want, response.Data.FilesCreated)
+		}
+	}
+	if !slices.Contains(response.Data.FilesUpdated, "models/model.go") {
+		t.Fatalf("dry-run files_updated missing model registry: %#v", response.Data.FilesUpdated)
+	}
+
+	assertCLITestFileMissing(t, rootDir, "models/product.go")
+	assertCLITestFileMissing(t, rootDir, "models/factories/product.go")
+	registryAfter, err := os.ReadFile(modelRegistryPath)
+	if err != nil {
+		t.Fatalf("read model registry after dry run: %v", err)
+	}
+	if !bytes.Equal(registryBefore, registryAfter) {
+		t.Fatalf("dry run changed models/model.go\nbefore:\n%s\nafter:\n%s", registryBefore, registryAfter)
+	}
+}

--- a/cli/seams.go
+++ b/cli/seams.go
@@ -8,6 +8,8 @@ import (
 type cliGenerator interface {
 	GenerateModel(resourceName string, tableNameOverride string, skipFactory bool) error
 	GenerateModelWithPK(resourceName string, tableNameOverride string, skipFactory bool, primaryKeyColumn string) error
+	GenerateModelWithMode(resourceName string, tableNameOverride string, skipFactory bool, primaryKeyColumn string, mode generator.ModelMode) error
+	PlanModel(resourceName string, options generator.ModelGenerationOptions) (*generator.ModelGenerationPlan, error)
 	GenerateControllerWithActions(resourceName, namespace, tableName string, actions []string, inertia string, isAPI bool) error
 	GenerateControllerWithActionsForModel(resourceName, namespace, modelName, tableName string, actions []string, inertia string, isAPI bool) error
 	GenerateScaffold(resourceName, namespace, tableName string, skipFactory bool, primaryKeyColumn string, inertia string, isAPI bool) error

--- a/contracts/cli-v1.json
+++ b/contracts/cli-v1.json
@@ -736,6 +736,11 @@
           "default": "false"
         },
         {
+          "name": "mode",
+          "type": "string",
+          "default": "crud"
+        },
+        {
           "name": "primary-key",
           "type": "string",
           "default": ""

--- a/contracts/public-api.txt
+++ b/contracts/public-api.txt
@@ -171,6 +171,14 @@ package generator // import "github.com/mbvlabs/andurel/generator"
 
 Package generator orchestrates model, controller, view, and scaffold generation.
 
+CONSTANTS
+
+const (
+	ModelModeCRUD       = models.ModelModeCRUD
+	ModelModeReadOnly   = models.ModelModeReadOnly
+	ModelModeCreateOnly = models.ModelModeCreateOnly
+)
+
 FUNCTIONS
 
 func BuildModelPath(modelsDir, resourceName string) string
@@ -394,6 +402,9 @@ type Generator struct {
 func New() (Generator, error)
     New creates a generator with the default project managers.
 
+func (g *Generator) ApplyModelPlan(plan *ModelGenerationPlan) error
+    ApplyModelPlan writes the exact files returned by PlanModel.
+
 func (g *Generator) ApplyModelUpdate(result *UpdateModelResult) error
     ApplyModelUpdate writes a previously computed model update.
 
@@ -418,6 +429,9 @@ func (g *Generator) GenerateControllerWithActionsForModel(resourceName, namespac
 func (g *Generator) GenerateModel(resourceName string, tableNameOverride string, skipFactory bool) error
     GenerateModel generates a model and optional factory for a resource.
 
+func (g *Generator) GenerateModelWithMode(resourceName, tableNameOverride string, skipFactory bool, primaryKeyColumn string, mode ModelMode) error
+    GenerateModelWithMode generates a model using a persisted operation mode.
+
 func (g *Generator) GenerateModelWithPK(resourceName string, tableNameOverride string, skipFactory bool, primaryKeyColumn string) error
     GenerateModelWithPK generates a model using an explicit primary key column.
 
@@ -433,6 +447,9 @@ func (g *Generator) GenerateViewFromModel(resourceName string, withController bo
 
 func (g *Generator) GetModulePath() string
     GetModulePath returns the current project's Go module path.
+
+func (g *Generator) PlanModel(resourceName string, options ModelGenerationOptions) (*ModelGenerationPlan, error)
+    PlanModel computes model generation output without writing files.
 
 func (g *Generator) SetControllerPKResolver(resolver PrimaryKeyResolver)
     SetControllerPKResolver overrides primary key resolution for controller
@@ -499,6 +516,20 @@ type ModelConfig struct {
 }
     ModelConfig configures model.
 
+type ModelGenerationOptions struct {
+	TableNameOverride string
+	SkipFactory       bool
+	PrimaryKeyColumn  string
+	Mode              ModelMode
+}
+    ModelGenerationOptions controls pure model generation planning.
+
+type ModelGenerationPlan struct {
+	ResourceName string
+	Files        []PlannedFile
+}
+    ModelGenerationPlan contains every file produced by model generation.
+
 type ModelManager struct {
 	// Has unexported fields.
 }
@@ -514,6 +545,9 @@ func NewModelManager(
 ) *ModelManager
     NewModelManager creates a new model manager.
 
+func (m *ModelManager) ApplyModelPlan(plan *ModelGenerationPlan) error
+    ApplyModelPlan writes the exact content returned by PlanModel.
+
 func (m *ModelManager) ApplyModelUpdate(result *UpdateModelResult) error
     ApplyModelUpdate writes the updated model and factory file content and runs
     the Go formatter.
@@ -525,6 +559,18 @@ func (m *ModelManager) GenerateModel(
 	primaryKeyColumn string,
 ) error
     GenerateModel generates model files for a resource from project migrations.
+
+func (m *ModelManager) GenerateModelWithMode(
+	resourceName string,
+	tableNameOverride string,
+	skipFactory bool,
+	primaryKeyColumn string,
+	mode models.ModelMode,
+) error
+    GenerateModelWithMode generates model files with a persisted operation mode.
+
+func (m *ModelManager) PlanModel(resourceName string, options ModelGenerationOptions) (*ModelGenerationPlan, error)
+    PlanModel computes every model generation output without writing files.
 
 func (m *ModelManager) SetPrimaryKeyResolver(resolver PrimaryKeyResolver)
     SetPrimaryKeyResolver overrides primary key resolution during model
@@ -540,6 +586,9 @@ func (m *ModelManager) UpdateModel(resourceName string) (*UpdateModelResult, err
     UpdateModel inspects the existing model file for resourceName, rebuilds the
     Entity struct from migrations (preserving custom field types), and returns a
     result describing the change without writing anything.
+
+type ModelMode = models.ModelMode
+    ModelMode controls which persistence operations are generated for a model.
 
 type ModelPaths struct {
 	Models string `json:"models"`
@@ -564,6 +613,14 @@ type PathConfig struct {
 	Database    string `yaml:"database"`
 }
     PathConfig contains path configurations
+
+type PlannedFile struct {
+	Path       string
+	OldContent string
+	NewContent string
+	Exists     bool
+}
+    PlannedFile describes one complete file transformation.
 
 type PrimaryKeyInfo struct {
 	ColumnName      string // SQL column name (e.g., "id", "user_id")

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,6 +1,17 @@
 // Package generator orchestrates model, controller, view, and scaffold generation.
 package generator
 
+import "github.com/mbvlabs/andurel/generator/models"
+
+// ModelMode controls which persistence operations are generated for a model.
+type ModelMode = models.ModelMode
+
+const (
+	ModelModeCRUD       = models.ModelModeCRUD
+	ModelModeReadOnly   = models.ModelModeReadOnly
+	ModelModeCreateOnly = models.ModelModeCreateOnly
+)
+
 // Generator is the high-level facade for Andurel code generation.
 type Generator struct {
 	coordinator Coordinator
@@ -26,6 +37,21 @@ func (g *Generator) GenerateModel(resourceName string, tableNameOverride string,
 // GenerateModelWithPK generates a model using an explicit primary key column.
 func (g *Generator) GenerateModelWithPK(resourceName string, tableNameOverride string, skipFactory bool, primaryKeyColumn string) error {
 	return g.coordinator.ModelManager.GenerateModel(resourceName, tableNameOverride, skipFactory, primaryKeyColumn)
+}
+
+// GenerateModelWithMode generates a model using a persisted operation mode.
+func (g *Generator) GenerateModelWithMode(resourceName, tableNameOverride string, skipFactory bool, primaryKeyColumn string, mode ModelMode) error {
+	return g.coordinator.ModelManager.GenerateModelWithMode(resourceName, tableNameOverride, skipFactory, primaryKeyColumn, mode)
+}
+
+// PlanModel computes model generation output without writing files.
+func (g *Generator) PlanModel(resourceName string, options ModelGenerationOptions) (*ModelGenerationPlan, error) {
+	return g.coordinator.ModelManager.PlanModel(resourceName, options)
+}
+
+// ApplyModelPlan writes the exact files returned by PlanModel.
+func (g *Generator) ApplyModelPlan(plan *ModelGenerationPlan) error {
+	return g.coordinator.ModelManager.ApplyModelPlan(plan)
 }
 
 // GenerateController generates controller and route files for a resource.

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -52,6 +52,18 @@ func TestGenerator_MethodsExist(t *testing.T) {
 			},
 		},
 		{
+			name: "GenerateModelWithMode",
+			fn: func() error {
+				return gen.GenerateModelWithMode("", "", false, "", ModelModeReadOnly)
+			},
+		},
+		{
+			name: "ApplyModelPlan",
+			fn: func() error {
+				return gen.ApplyModelPlan(nil)
+			},
+		},
+		{
 			name: "GenerateController",
 			fn: func() error {
 				return gen.GenerateController("", "", "", "", false)

--- a/generator/model_manager.go
+++ b/generator/model_manager.go
@@ -2,7 +2,7 @@ package generator
 
 import (
 	"fmt"
-	"os"
+	"go/format"
 	"path/filepath"
 	"strings"
 
@@ -23,6 +23,28 @@ type ModelManager struct {
 	config           *UnifiedConfig
 	pkResolver       PrimaryKeyResolver
 	factoryValidator func(rootDir, factoryPath, content string) error
+}
+
+// ModelGenerationOptions controls pure model generation planning.
+type ModelGenerationOptions struct {
+	TableNameOverride string
+	SkipFactory       bool
+	PrimaryKeyColumn  string
+	Mode              ModelMode
+}
+
+// PlannedFile describes one complete file transformation.
+type PlannedFile struct {
+	Path       string
+	OldContent string
+	NewContent string
+	Exists     bool
+}
+
+// ModelGenerationPlan contains every file produced by model generation.
+type ModelGenerationPlan struct {
+	ResourceName string
+	Files        []PlannedFile
 }
 
 type modelSetupContext struct {
@@ -91,7 +113,11 @@ func (m *ModelManager) setupModelContext(
 	modelFileName.Grow(len(resourceName) + 3)
 	modelFileName.WriteString(naming.ToSnakeCase(resourceName))
 	modelFileName.WriteString(".go")
-	modelPath := filepath.Join(m.config.Paths.Models, modelFileName.String())
+	modelsPath := m.config.Paths.Models
+	if !filepath.IsAbs(modelsPath) {
+		modelsPath = filepath.Join(rootDir, modelsPath)
+	}
+	modelPath := filepath.Join(modelsPath, modelFileName.String())
 
 	return &modelSetupContext{
 		ModulePath:   modulePath,
@@ -110,6 +136,40 @@ func (m *ModelManager) GenerateModel(
 	skipFactory bool,
 	primaryKeyColumn string,
 ) error {
+	return m.GenerateModelWithMode(resourceName, tableNameOverride, skipFactory, primaryKeyColumn, models.ModelModeCRUD)
+}
+
+// GenerateModelWithMode generates model files with a persisted operation mode.
+func (m *ModelManager) GenerateModelWithMode(
+	resourceName string,
+	tableNameOverride string,
+	skipFactory bool,
+	primaryKeyColumn string,
+	mode models.ModelMode,
+) error {
+	plan, err := m.PlanModel(resourceName, ModelGenerationOptions{
+		TableNameOverride: tableNameOverride,
+		SkipFactory:       skipFactory,
+		PrimaryKeyColumn:  primaryKeyColumn,
+		Mode:              mode,
+	})
+	if err != nil {
+		return err
+	}
+	if err := m.ApplyModelPlan(plan); err != nil {
+		return err
+	}
+
+	if !skipFactory {
+		fmt.Printf("✓ Generated factory: models/factories/%s.go\n", naming.ToSnakeCase(resourceName))
+	}
+	fmt.Printf("Successfully generated complete model for %s with database functions\n", resourceName)
+	return nil
+}
+
+// PlanModel computes every model generation output without writing files.
+func (m *ModelManager) PlanModel(resourceName string, options ModelGenerationOptions) (*ModelGenerationPlan, error) {
+	tableNameOverride := options.TableNameOverride
 	tableName := tableNameOverride
 	if tableName == "" {
 		tableName = naming.DeriveTableName(resourceName)
@@ -117,64 +177,132 @@ func (m *ModelManager) GenerateModel(
 
 	if tableNameOverride != "" {
 		if err := m.validator.ValidateTableNameOverride(resourceName, tableNameOverride); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	ctx, err := m.setupModelContext(resourceName, tableName, tableNameOverride != "")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := m.fileManager.ValidateFileNotExists(ctx.ModelPath); err != nil {
-		return err
+		return nil, err
 	}
 
-	cat, err := m.migrationManager.BuildCatalogFromMigrations(ctx.TableName, m.config)
+	planningConfig := *m.config
+	planningConfig.Database = m.config.Database
+	planningConfig.Database.MigrationDirs = append([]string(nil), m.config.Database.MigrationDirs...)
+	for index, migrationDir := range planningConfig.Database.MigrationDirs {
+		if !filepath.IsAbs(migrationDir) {
+			planningConfig.Database.MigrationDirs[index] = filepath.Join(ctx.RootDir, migrationDir)
+		}
+	}
+	cat, err := m.migrationManager.BuildCatalogFromMigrations(ctx.TableName, &planningConfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Resolve primary key
 	var pkInfo PrimaryKeyInfo
-	if primaryKeyColumn != "" {
+	if options.PrimaryKeyColumn != "" {
 		pkInfo = PrimaryKeyInfo{
-			ColumnName: primaryKeyColumn,
+			ColumnName: options.PrimaryKeyColumn,
 			Found:      true,
-			IsNamedID:  primaryKeyColumn == "id",
+			IsNamedID:  options.PrimaryKeyColumn == "id",
 		}
 	} else {
 		var err error
 		pkInfo, err = m.resolvePrimaryKey(cat, ctx.TableName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	nullType := m.readNullType(ctx.RootDir)
-
-	if err := m.modelGenerator.GenerateModel(cat, ctx.ResourceName, ctx.TableName, ctx.ModelPath, ctx.ModulePath, tableNameOverride, nullType, pkInfo.ColumnName, !pkInfo.Found); err != nil {
-		return fmt.Errorf("failed to generate model: %w", err)
+	mode := options.Mode
+	if mode == "" {
+		mode = models.ModelModeCRUD
+	}
+	genModel, modelContent, err := m.modelGenerator.PlanModelSource(cat, ctx.ResourceName, ctx.TableName, ctx.ModulePath, tableNameOverride, nullType, pkInfo.ColumnName, !pkInfo.Found, mode)
+	if err != nil {
+		return nil, fmt.Errorf("plan model source: %w", err)
+	}
+	plan := &ModelGenerationPlan{
+		ResourceName: resourceName,
+		Files: []PlannedFile{{
+			Path:       ctx.ModelPath,
+			NewContent: modelContent,
+		}},
 	}
 
-	if err := m.registerNamespace(ctx.ResourceName); err != nil {
-		return fmt.Errorf("failed to register namespace in models/model.go: %w", err)
-	}
-
-	// Generate factory (unless skipped)
-	if !skipFactory {
-		if err := m.generateFactory(cat, ctx, pkInfo); err != nil {
-			// Log the error but don't fail the entire generation
-			fmt.Printf("Warning: failed to generate factory: %v\n", err)
-		} else {
-			fmt.Printf("✓ Generated factory: models/factories/%s.go\n", strings.ToLower(ctx.ResourceName))
+	registryPath := filepath.Join(filepath.Dir(ctx.ModelPath), "model.go")
+	if m.fileManager.FileExists(registryPath) {
+		registryContent, readErr := m.fileManager.ReadFile(registryPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read model registry: %w", readErr)
+		}
+		updatedRegistry, formatErr := planNamespaceRegistration(resourceName, registryContent)
+		if formatErr != nil {
+			return nil, fmt.Errorf("plan model registry: %w", formatErr)
+		}
+		if updatedRegistry != registryContent {
+			plan.Files = append(plan.Files, PlannedFile{
+				Path:       registryPath,
+				OldContent: registryContent,
+				NewContent: updatedRegistry,
+				Exists:     true,
+			})
 		}
 	}
 
-	fmt.Printf(
-		"Successfully generated complete model for %s with database functions\n",
-		ctx.ResourceName,
-	)
+	if !options.SkipFactory {
+		genFactory, buildErr := m.modelGenerator.BuildFactory(cat, models.Config{
+			TableName:         ctx.TableName,
+			ResourceName:      ctx.ResourceName,
+			PackageName:       "factories",
+			DatabaseType:      m.config.Database.Type,
+			ModulePath:        ctx.ModulePath,
+			NullType:          nullType,
+			PrimaryKeyColumn:  pkInfo.ColumnName,
+			GenerateWithoutPK: !pkInfo.Found,
+			ModelMode:         mode,
+		}, genModel)
+		if buildErr != nil {
+			return nil, fmt.Errorf("plan factory metadata: %w", buildErr)
+		}
+		factoryContent, renderErr := m.modelGenerator.PlanFactorySource(genFactory)
+		if renderErr != nil {
+			return nil, fmt.Errorf("plan factory source: %w", renderErr)
+		}
+		factoryPath := filepath.Join(filepath.Dir(ctx.ModelPath), "factories", naming.ToSnakeCase(resourceName)+".go")
+		plannedFactory := PlannedFile{Path: factoryPath, NewContent: factoryContent}
+		if m.fileManager.FileExists(factoryPath) {
+			oldFactory, readErr := m.fileManager.ReadFile(factoryPath)
+			if readErr != nil {
+				return nil, fmt.Errorf("read existing factory: %w", readErr)
+			}
+			plannedFactory.Exists = true
+			plannedFactory.OldContent = oldFactory
+		}
+		if !plannedFactory.Exists || plannedFactory.OldContent != plannedFactory.NewContent {
+			plan.Files = append(plan.Files, plannedFactory)
+		}
+	}
+
+	return plan, nil
+}
+
+// ApplyModelPlan writes the exact content returned by PlanModel.
+func (m *ModelManager) ApplyModelPlan(plan *ModelGenerationPlan) error {
+	if plan == nil {
+		return fmt.Errorf("model generation plan is required")
+	}
+	for _, file := range plan.Files {
+		if err := m.fileManager.WriteFile(file.Path, file.NewContent); err != nil {
+			return fmt.Errorf("write planned file %s: %w", file.Path, err)
+		}
+	}
 	return nil
 }
 
@@ -205,82 +333,15 @@ func (m *ModelManager) resolvePrimaryKey(cat *catalog.Catalog, tableName string)
 	return pkInfo, nil
 }
 
-// generateFactory creates a factory file for the model
-func (m *ModelManager) generateFactory(cat *catalog.Catalog, ctx *modelSetupContext, pkInfo PrimaryKeyInfo) error {
-	// Get root directory
-	rootDir, err := m.fileManager.FindGoModRoot()
-	if err != nil {
-		return fmt.Errorf("failed to find go.mod root: %w", err)
-	}
-
-	nullType := m.readNullType(rootDir)
-
-	// Build the model first
-	genModel, err := m.modelGenerator.Build(cat, models.Config{
-		TableName:         ctx.TableName,
-		ResourceName:      ctx.ResourceName,
-		PackageName:       "models",
-		DatabaseType:      m.config.Database.Type,
-		ModulePath:        ctx.ModulePath,
-		NullType:          nullType,
-		PrimaryKeyColumn:  pkInfo.ColumnName,
-		GenerateWithoutPK: !pkInfo.Found,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to build model for factory: %w", err)
-	}
-
-	// Build factory metadata
-	genFactory, err := m.modelGenerator.BuildFactory(cat, models.Config{
-		TableName:         ctx.TableName,
-		ResourceName:      ctx.ResourceName,
-		PackageName:       "factories",
-		DatabaseType:      m.config.Database.Type,
-		ModulePath:        ctx.ModulePath,
-		NullType:          nullType,
-		PrimaryKeyColumn:  pkInfo.ColumnName,
-		GenerateWithoutPK: !pkInfo.Found,
-	}, genModel)
-	if err != nil {
-		return fmt.Errorf("failed to build factory: %w", err)
-	}
-
-	// Write factory file
-	if err := m.modelGenerator.WriteFactoryFile(genFactory, rootDir); err != nil {
-		return fmt.Errorf("failed to write factory: %w", err)
-	}
-
-	return nil
-}
-
-// registerNamespace ensures the project's models/model.go declares the
-// `<type> struct{}` and `<Var> <type>` entries for the new resource so
-// per-resource files (which only define methods on the namespace type)
-// compile.
-func (m *ModelManager) registerNamespace(resourceName string) error {
-	modelGoPath := filepath.Join(m.config.Paths.Models, "model.go")
-
-	src, err := os.ReadFile(modelGoPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	namespaceVar := resourceName
+func planNamespaceRegistration(resourceName, source string) (string, error) {
 	namespaceType := naming.ToLowerCamelCaseFromAny(resourceName)
-	typeEntry := "\t" + namespaceType + " struct{}"
-	varEntry := "\t" + namespaceVar + " " + namespaceType
-
-	updated := ensureLineInBlock(string(src), "type (", typeEntry)
-	updated = ensureLineInBlock(updated, "var (", varEntry)
-
-	if updated == string(src) {
-		return nil
+	updated := ensureLineInBlock(source, "type (", "\t"+namespaceType+" struct{}")
+	updated = ensureLineInBlock(updated, "var (", "\t"+resourceName+" "+namespaceType)
+	formatted, err := format.Source([]byte(updated))
+	if err != nil {
+		return "", err
 	}
-
-	return os.WriteFile(modelGoPath, []byte(updated), 0o644)
+	return string(formatted), nil
 }
 
 // ensureLineInBlock inserts entry as a new line just before the `)` that

--- a/generator/model_manager_test.go
+++ b/generator/model_manager_test.go
@@ -3,9 +3,11 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/mbvlabs/andurel/generator/models"
 	"github.com/mbvlabs/andurel/pkg/cache"
 )
 
@@ -108,4 +110,146 @@ func TestSetupModelContext(t *testing.T) {
 			t.Errorf("Expected accounts, got %s", ctx.TableName)
 		}
 	})
+}
+
+func TestPlanModelReturnsCompleteFormattedOutputWithoutWriting(t *testing.T) {
+	manager, cleanup := setupModelManagerTest(t)
+	defer cleanup()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	writeModelPlanningFixture(t, root)
+	originalRegistry, err := os.ReadFile(filepath.Join(root, "models", "model.go"))
+	if err != nil {
+		t.Fatalf("read original registry: %v", err)
+	}
+	originalWorkingDirectory := root
+	t.Setenv("PATH", "")
+
+	plan, err := manager.PlanModel("ServerSSHCredential", ModelGenerationOptions{PrimaryKeyColumn: "id"})
+	if err != nil {
+		t.Fatalf("plan model: %v", err)
+	}
+
+	wantPaths := []string{
+		filepath.Join(root, "models", "server_ssh_credential.go"),
+		filepath.Join(root, "models", "factories", "server_ssh_credential.go"),
+		filepath.Join(root, "models", "model.go"),
+	}
+	gotPaths := make([]string, 0, len(plan.Files))
+	for _, file := range plan.Files {
+		gotPaths = append(gotPaths, file.Path)
+		if file.NewContent == "" {
+			t.Fatalf("planned file %s has empty content", file.Path)
+		}
+	}
+	for _, want := range wantPaths {
+		if !slices.Contains(gotPaths, want) {
+			t.Fatalf("planned paths %#v do not contain %q", gotPaths, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "models", "server_ssh_credential.go")); !os.IsNotExist(err) {
+		t.Fatalf("planning wrote model file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "models", "factories")); !os.IsNotExist(err) {
+		t.Fatalf("planning created factory directory: %v", err)
+	}
+	registryAfter, err := os.ReadFile(filepath.Join(root, "models", "model.go"))
+	if err != nil {
+		t.Fatalf("read registry after planning: %v", err)
+	}
+	if string(registryAfter) != string(originalRegistry) {
+		t.Fatalf("planning changed registry\nbefore:\n%s\nafter:\n%s", originalRegistry, registryAfter)
+	}
+	workingDirectoryAfter, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory after planning: %v", err)
+	}
+	if workingDirectoryAfter != originalWorkingDirectory {
+		t.Fatalf("planning changed working directory from %q to %q", originalWorkingDirectory, workingDirectoryAfter)
+	}
+}
+
+func TestGenerateModelAppliesExactlyThePlannedContent(t *testing.T) {
+	manager, cleanup := setupModelManagerTest(t)
+	defer cleanup()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	writeModelPlanningFixture(t, root)
+	options := ModelGenerationOptions{PrimaryKeyColumn: "id", Mode: models.ModelModeCRUD}
+	plan, err := manager.PlanModel("ServerSSHCredential", options)
+	if err != nil {
+		t.Fatalf("plan model: %v", err)
+	}
+
+	if err := manager.GenerateModelWithMode("ServerSSHCredential", "", false, "id", models.ModelModeCRUD); err != nil {
+		t.Fatalf("generate model: %v", err)
+	}
+	for _, file := range plan.Files {
+		content, err := os.ReadFile(file.Path)
+		if err != nil {
+			t.Fatalf("read applied file %s: %v", file.Path, err)
+		}
+		if string(content) != file.NewContent {
+			t.Fatalf("applied content differs from plan for %s\nplanned:\n%s\napplied:\n%s", file.Path, file.NewContent, content)
+		}
+	}
+}
+
+func TestPlanModelFailureDoesNotApplyPartialChanges(t *testing.T) {
+	manager, cleanup := setupModelManagerTest(t)
+	defer cleanup()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "models", "model.go"), []byte("package models\n\ntype (\n)\n\nvar (\n)\n"), 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	registryBefore, err := os.ReadFile(filepath.Join(root, "models", "model.go"))
+	if err != nil {
+		t.Fatalf("read registry: %v", err)
+	}
+
+	if _, err := manager.PlanModel("Missing", ModelGenerationOptions{PrimaryKeyColumn: "id"}); err == nil {
+		t.Fatal("expected planning failure for missing migration table")
+	}
+	if _, err := os.Stat(filepath.Join(root, "models", "missing.go")); !os.IsNotExist(err) {
+		t.Fatalf("failed plan wrote model: %v", err)
+	}
+	registryAfter, err := os.ReadFile(filepath.Join(root, "models", "model.go"))
+	if err != nil {
+		t.Fatalf("read registry after failure: %v", err)
+	}
+	if string(registryAfter) != string(registryBefore) {
+		t.Fatalf("failed plan changed registry\nbefore:\n%s\nafter:\n%s", registryBefore, registryAfter)
+	}
+}
+
+func writeModelPlanningFixture(t *testing.T, root string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, "models", "model.go"), []byte("package models\n\ntype (\n)\n\nvar (\n)\n"), 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	migration := `-- +goose Up
+CREATE TABLE server_ssh_credentials (
+    id UUID PRIMARY KEY,
+    url TEXT NOT NULL,
+    cidr TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- +goose Down
+DROP TABLE server_ssh_credentials;
+`
+	if err := os.WriteFile(filepath.Join(root, "database", "migrations", "001_create_server_ssh_credentials.sql"), []byte(migration), 0o644); err != nil {
+		t.Fatalf("write migration: %v", err)
+	}
 }

--- a/generator/model_manager_test.go
+++ b/generator/model_manager_test.go
@@ -172,6 +172,47 @@ func TestPlanModelReturnsCompleteFormattedOutputWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestPlanModelIncludesExistingFactoryContent(t *testing.T) {
+	manager, cleanup := setupModelManagerTest(t)
+	defer cleanup()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	writeModelPlanningFixture(t, root)
+	factoryDir := filepath.Join(root, "models", "factories")
+	if err := os.MkdirAll(factoryDir, 0o755); err != nil {
+		t.Fatalf("create factory directory: %v", err)
+	}
+	factoryPath := filepath.Join(factoryDir, "server_ssh_credential.go")
+	oldContent := "package factories\n"
+	if err := os.WriteFile(factoryPath, []byte(oldContent), 0o644); err != nil {
+		t.Fatalf("write existing factory: %v", err)
+	}
+
+	plan, err := manager.PlanModel("ServerSSHCredential", ModelGenerationOptions{PrimaryKeyColumn: "id"})
+	if err != nil {
+		t.Fatalf("plan model: %v", err)
+	}
+	for _, file := range plan.Files {
+		if file.Path != factoryPath {
+			continue
+		}
+		if !file.Exists {
+			t.Fatal("existing factory was planned as a new file")
+		}
+		if file.OldContent != oldContent {
+			t.Fatalf("factory old content = %q, want %q", file.OldContent, oldContent)
+		}
+		if file.NewContent == oldContent {
+			t.Fatal("factory plan did not replace stale content")
+		}
+		return
+	}
+	t.Fatalf("plan did not include existing factory %q", factoryPath)
+}
+
 func TestGenerateModelAppliesExactlyThePlannedContent(t *testing.T) {
 	manager, cleanup := setupModelManagerTest(t)
 	defer cleanup()

--- a/generator/testdata/golden/scaffold/array_fields/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/array_fields/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token    struct{}
+	user     struct{}
 	document struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token    token
+	User     user
 	Document document
 )

--- a/generator/testdata/golden/scaffold/custom_primary_key/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token     struct{}
+	user      struct{}
 	warehouse struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token     token
+	User      user
 	Warehouse warehouse
 )

--- a/generator/testdata/golden/scaffold/full_crud/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token  struct{}
+	user   struct{}
 	widget struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token  token
+	User   user
 	Widget widget
 )

--- a/generator/testdata/golden/scaffold/full_crud_css_components/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token  struct{}
+	user   struct{}
 	widget struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token  token
+	User   user
 	Widget widget
 )

--- a/generator/testdata/golden/scaffold/irregular_plural/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token   struct{}
+	user    struct{}
 	company struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token   token
+	User    user
 	Company company
 )

--- a/generator/testdata/golden/scaffold/skip_factory/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/skip_factory/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token  struct{}
+	user   struct{}
 	widget struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token  token
+	User   user
 	Widget widget
 )

--- a/generator/testdata/golden/scaffold/table_name_override/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/table_name_override/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token         struct{}
+	user          struct{}
 	feedbackEntry struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token         token
+	User          user
 	FeedbackEntry feedbackEntry
 )

--- a/generator/testdata/golden/scaffold/vue/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/vue/models/model.go.golden
@@ -1,13 +1,13 @@
 package models
 
 type (
-	token struct{}
-	user  struct{}
+	token   struct{}
+	user    struct{}
 	project struct{}
 )
 
 var (
-	Token token
-	User  user
+	Token   token
+	User    user
 	Project project
 )


### PR DESCRIPTION
## Summary

- introduces a read-only model generation plan containing exact old and new file contents
- makes normal generation apply the same strings returned by the planner
- renders model and factory source in memory
- reports dry-run artifacts and diffs directly from the plan
- avoids project copies, directory creation, working-directory changes, writes, and formatter subprocesses during model planning
- wires model operation modes through the CLI

## Why

`andurel generate model NAME --dry-run` created factory files while reporting that no files changed. The previous mitigation copied the project to a temporary directory, which concealed side effects instead of giving generation a pure planning boundary.

## Relationship

This PR targets `master` directly.

Prerequisite: #705 (`fix/generated-api-semantics`)

## Validation

- `go fix ./...`
- `gofmt`
- `go vet ./...`
- `./scripts/check-contracts.sh`
- `git diff --check`

Repository instructions prohibit running `go test`, so tests were compiled by `go vet` but not executed locally.
