### PR TITLE
fix(scaffold): recover stale session cookies

### DIFF
--- a/cli/command_surface_test.go
+++ b/cli/command_surface_test.go
@@ -721,6 +721,11 @@ func TestRunUpgradeStructuredAndHumanBranches(t *testing.T) {
 			ReplacedFiles: []string{"controllers/controller.go"},
 			RemovedFiles:  []string{"internal/old.go"},
 			ToolsUpdated:  1,
+			ManualActions: []upgrade.ManualAction{{
+				ID:           "session-cookie-recovery-v1.5.3",
+				Title:        "Update application-owned session handling",
+				Instructions: "Create router/cookies/session.go",
+			}},
 		}}, nil
 	}
 
@@ -740,7 +745,10 @@ func TestRunUpgradeStructuredAndHumanBranches(t *testing.T) {
 	if !gotOpts.DryRun || gotOpts.TargetVersion != "v2.0.0" {
 		t.Fatalf("upgrade opts = %#v", gotOpts)
 	}
-	if !strings.Contains(out.String(), "dry run only") || !strings.Contains(out.String(), "controllers/controller.go") {
+	if !strings.Contains(out.String(), "dry run only") ||
+		!strings.Contains(out.String(), "controllers/controller.go") ||
+		!strings.Contains(out.String(), `"manual_actions"`) ||
+		!strings.Contains(out.String(), "session-cookie-recovery-v1.5.3") {
 		t.Fatalf("structured upgrade output missing report data:\n%s", out.String())
 	}
 

--- a/docs/generated-files-and-upgrades.md
+++ b/docs/generated-files-and-upgrades.md
@@ -6,6 +6,19 @@ Factory synchronization is one such narrow boundary. It regenerates the Andurel-
 
 The Inertia root embedding migration is another narrow boundary. It moves `views/root.go.html` to `assets/inertia/root.go.html` and replaces only the exact legacy `inertia.Init("views/root.go.html")` call in `cmd/app/main.go`. The upgrade stops without writing if that call is not present.
 
+## Manual session-cookie recovery migration
+
+The `router/*` tree is application-owned, so `andurel upgrade` does not install session-cookie decode recovery into an existing project. New projects include the recovery automatically. Existing projects should reconcile only these declarations against a fresh scaffold created with the target Andurel version:
+
+When an upgrade crosses from a version before `v1.5.3` to `v1.5.3` or later, `andurel upgrade` prints this complete migration with the project's module path already rendered. The same manual action is included in dry-run and structured JSON output. Projects starting on `v1.5.3` or later do not receive the note.
+
+1. Add `router/cookies/session.go` from [`router_cookies_session.tmpl`](../layout/templates/router_cookies_session.tmpl), replacing the template module import with the project's module path.
+2. In `router/cookies/cookies.go` and `router/cookies/flash.go`, replace calls to Echo's `session.Get` with the shared `getSession` helper and remove the now-unused Echo session imports.
+3. In `router/middleware/middleware.go`, call `cookies.RecoverInvalidSessions(c)` inside `ValidateSession`, after the assets and API bypass and before calling the next handler.
+4. Add `github.com/gorilla/securecookie v1.1.2` as a direct dependency, then run `gofmt`, `go fix ./...`, and `go vet ./...`.
+
+Do not replace the whole `router/*` tree. These changes preserve valid sessions, replace only cookies that fail secure-cookie decoding, and continue to return configuration, usage, internal, or save errors.
+
 ## Planning and preview
 
 Run a structured dry run before applying an upgrade:

--- a/e2e/testdata/golden/scaffolds/postgresql-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-aws-ses-css-components.golden
@@ -20458,3 +20458,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-aws-ses-css-components.golden
@@ -7570,6 +7570,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7635,7 +7636,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -12634,7 +12634,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -12654,7 +12653,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12667,7 +12666,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12677,7 +12676,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12698,7 +12697,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12713,7 +12712,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12752,7 +12751,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12787,7 +12785,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12803,7 +12801,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12820,6 +12818,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -13061,6 +13111,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -13286,12 +13339,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -13345,6 +13408,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -20121,4 +20458,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-aws-ses.golden
@@ -17349,3 +17349,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-aws-ses.golden
@@ -6100,6 +6100,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -6165,7 +6166,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11164,7 +11164,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11184,7 +11183,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11197,7 +11196,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11207,7 +11206,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -11228,7 +11227,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11243,7 +11242,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -11282,7 +11281,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -11317,7 +11315,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -11333,7 +11331,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -11350,6 +11348,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -11591,6 +11641,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -11816,12 +11869,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -11875,6 +11938,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -17012,4 +17349,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-css-components.golden
@@ -19779,3 +19779,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-css-components.golden
@@ -6932,6 +6932,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -6986,7 +6987,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11955,7 +11955,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11975,7 +11974,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11988,7 +11987,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11998,7 +11997,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12019,7 +12018,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12034,7 +12033,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12073,7 +12072,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12108,7 +12106,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12124,7 +12122,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12141,6 +12139,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -12382,6 +12432,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -12607,12 +12660,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -12666,6 +12729,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -19442,4 +19779,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses-css-components.golden
@@ -20535,3 +20535,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses-css-components.golden
@@ -7647,6 +7647,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7712,7 +7713,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -12711,7 +12711,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -12731,7 +12730,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12744,7 +12743,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12754,7 +12753,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12775,7 +12774,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12790,7 +12789,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12829,7 +12828,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12864,7 +12862,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12880,7 +12878,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12897,6 +12895,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -13138,6 +13188,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -13363,12 +13416,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -13422,6 +13485,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -20198,4 +20535,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses.golden
@@ -17426,3 +17426,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses.golden
@@ -6177,6 +6177,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -6242,7 +6243,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11241,7 +11241,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11261,7 +11260,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11274,7 +11273,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11284,7 +11283,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -11305,7 +11304,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11320,7 +11319,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -11359,7 +11358,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -11394,7 +11392,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -11410,7 +11408,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -11427,6 +11425,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -11668,6 +11718,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -11893,12 +11946,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -11952,6 +12015,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -17089,4 +17426,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-css-components.golden
@@ -7009,6 +7009,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7063,7 +7064,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -12032,7 +12032,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -12052,7 +12051,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12065,7 +12064,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12075,7 +12074,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12096,7 +12095,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12111,7 +12110,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12150,7 +12149,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12185,7 +12183,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12201,7 +12199,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12218,6 +12216,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -12459,6 +12509,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -12684,12 +12737,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -12743,6 +12806,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -19519,4 +19856,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-css-components.golden
@@ -19856,3 +19856,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker.golden
@@ -5539,6 +5539,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -5593,7 +5594,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -10562,7 +10562,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -10582,7 +10581,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -10595,7 +10594,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -10605,7 +10604,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -10626,7 +10625,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -10641,7 +10640,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -10680,7 +10679,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -10715,7 +10713,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -10731,7 +10729,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -10748,6 +10746,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -10989,6 +11039,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -11214,12 +11267,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -11273,6 +11336,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -16410,4 +16747,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker.golden
@@ -16747,3 +16747,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
@@ -20085,3 +20085,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
@@ -7638,6 +7638,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7704,7 +7705,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -13355,7 +13355,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -13375,7 +13374,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -13388,7 +13387,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -13398,7 +13397,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -13419,7 +13418,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -13434,7 +13433,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -13473,7 +13472,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -13508,7 +13506,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -13524,7 +13522,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -13541,6 +13539,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -13782,6 +13832,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -14007,12 +14060,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -14066,6 +14129,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -19748,4 +20085,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
@@ -16976,3 +16976,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
@@ -6168,6 +6168,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -6234,7 +6235,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11885,7 +11885,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11905,7 +11904,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11918,7 +11917,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11928,7 +11927,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -11949,7 +11948,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11964,7 +11963,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12003,7 +12002,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12038,7 +12036,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12054,7 +12052,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12071,6 +12069,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -12312,6 +12362,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -12537,12 +12590,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -12596,6 +12659,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -16639,4 +16976,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
@@ -7000,6 +7000,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7055,7 +7056,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -12676,7 +12676,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -12696,7 +12695,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12709,7 +12708,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12719,7 +12718,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12740,7 +12739,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12755,7 +12754,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12794,7 +12793,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12829,7 +12827,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12845,7 +12843,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12862,6 +12860,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -13103,6 +13153,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -13328,12 +13381,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -13387,6 +13450,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -19069,4 +19406,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
@@ -19406,3 +19406,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
@@ -7715,6 +7715,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7781,7 +7782,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -13432,7 +13432,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -13452,7 +13451,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -13465,7 +13464,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -13475,7 +13474,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -13496,7 +13495,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -13511,7 +13510,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -13550,7 +13549,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -13585,7 +13583,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -13601,7 +13599,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -13618,6 +13616,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -13859,6 +13909,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -14084,12 +14137,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -14143,6 +14206,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -19825,4 +20162,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
@@ -20162,3 +20162,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
@@ -17053,3 +17053,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
@@ -6245,6 +6245,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -6311,7 +6312,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11962,7 +11962,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11982,7 +11981,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11995,7 +11994,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12005,7 +12004,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12026,7 +12025,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12041,7 +12040,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12080,7 +12079,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12115,7 +12113,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12131,7 +12129,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12148,6 +12146,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -12389,6 +12439,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -12614,12 +12667,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -12673,6 +12736,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -16716,4 +17053,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
@@ -7077,6 +7077,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -7132,7 +7133,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -12753,7 +12753,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -12773,7 +12772,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12786,7 +12785,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12796,7 +12795,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -12817,7 +12816,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -12832,7 +12831,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -12871,7 +12870,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -12906,7 +12904,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -12922,7 +12920,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -12939,6 +12937,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -13180,6 +13230,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -13405,12 +13458,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -13464,6 +13527,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -19146,4 +19483,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
@@ -19483,3 +19483,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
@@ -16374,3 +16374,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
@@ -5607,6 +5607,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -5662,7 +5663,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11283,7 +11283,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11303,7 +11302,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11316,7 +11315,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11326,7 +11325,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -11347,7 +11346,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11362,7 +11361,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -11401,7 +11400,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -11436,7 +11434,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -11452,7 +11450,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -11469,6 +11467,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -11710,6 +11760,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -11935,12 +11988,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -11994,6 +12057,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -16037,4 +16374,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
@@ -5523,6 +5523,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -5578,7 +5579,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -11199,7 +11199,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -11219,7 +11218,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11232,7 +11231,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11242,7 +11241,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -11263,7 +11262,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -11278,7 +11277,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -11317,7 +11316,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -11352,7 +11350,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -11368,7 +11366,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -11385,6 +11383,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -11626,6 +11676,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -11851,12 +11904,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -11910,6 +11973,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -15953,4 +16290,3 @@ export default defineConfig({
   },
 })
 ```
-

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
@@ -16290,3 +16290,4 @@ export default defineConfig({
   },
 })
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql.golden
@@ -16663,3 +16663,4 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
+

--- a/e2e/testdata/golden/scaffolds/postgresql.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql.golden
@@ -5455,6 +5455,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -5509,7 +5510,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -10478,7 +10478,6 @@ import (
 	"testapp/config"
 	"testapp/models"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -10498,7 +10497,7 @@ type App struct {
 }
 
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -10511,7 +10510,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -10521,7 +10520,7 @@ func DestroyAppSession(c *echo.Context) error {
 }
 
 func ExtractFromCookieApp(c *echo.Context) App {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return App{}
 	}
@@ -10542,7 +10541,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -10557,7 +10556,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}
@@ -10596,7 +10595,6 @@ import (
 	"testapp/config"
 	"testapp/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -10631,7 +10629,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -10647,7 +10645,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}
@@ -10664,6 +10662,58 @@ func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
 	}
 
 	return flashMessages, nil
+}
+```
+
+file -----------rw-r--r-- router/cookies/session.go
+```
+package cookies
+
+import (
+	"errors"
+
+	"testapp/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
 }
 ```
 
@@ -10905,6 +10955,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -11130,12 +11183,22 @@ file -----------rw-r--r-- router/middleware/middleware_test.go
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"testapp/config"
+	requestmeta "testapp/internal/request"
+	"testapp/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -11189,6 +11252,280 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}
 ```
 
 file -----------rw-r--r-- router/router.go
@@ -16326,4 +16663,3 @@ func consoleLine(label string, value string) templ.Component {
 
 var _ = templruntime.GeneratedTemplate
 ```
-

--- a/layout/generated_application_templates_test.go
+++ b/layout/generated_application_templates_test.go
@@ -149,6 +149,56 @@ func TestGeneratedRateLimiterAndLifecycleTemplates(t *testing.T) {
 	}
 }
 
+func TestGeneratedSessionRecoveryTemplates(t *testing.T) {
+	root := t.TempDir()
+	if err := processTemplatedFiles(root, &TemplateData{ModuleName: "example.com/app"}); err != nil {
+		t.Fatalf("process templates: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "router/cookies/session.go")); err != nil {
+		t.Fatalf("generated shared session loader: %v", err)
+	}
+
+	sessionRecovery := readGeneratedApplicationTemplate(t, "router_cookies_session.tmpl")
+	for _, want := range []string{
+		"func RecoverInvalidSessions",
+		"securecookie.Error",
+		"decodeError.IsDecode()",
+		"decodeError.IsUsage()",
+		"decodeError.IsInternal()",
+		"clear(sess.Values)",
+		"sess.Save(c.Request(), c.Response())",
+		"func getSession",
+	} {
+		if !strings.Contains(sessionRecovery, want) {
+			t.Errorf("router_cookies_session.tmpl missing %q", want)
+		}
+	}
+
+	for _, templateName := range []string{"router_cookies_cookies.tmpl", "router_cookies_flash.tmpl"} {
+		content := readGeneratedApplicationTemplate(t, templateName)
+		if strings.Contains(content, "session.Get(") {
+			t.Errorf("%s bypasses the recoverable session loader", templateName)
+		}
+		if !strings.Contains(content, "getSession(") {
+			t.Errorf("%s does not use the recoverable session loader", templateName)
+		}
+	}
+
+	middleware := readGeneratedApplicationTemplate(t, "router_middleware_middleware.tmpl")
+	if !strings.Contains(middleware, "cookies.RecoverInvalidSessions(c)") {
+		t.Error("router_middleware_middleware.tmpl does not recover invalid session cookies")
+	}
+
+	if got := baseTemplateMappings["router_cookies_session.tmpl"]; got != "router/cookies/session.go" {
+		t.Fatalf("session recovery template target = %q, want router/cookies/session.go", got)
+	}
+
+	goMod := readGeneratedApplicationTemplate(t, "go_mod.tmpl")
+	if !strings.Contains(goMod, "github.com/gorilla/securecookie v1.1.2") {
+		t.Error("go_mod.tmpl does not declare securecookie as a direct dependency")
+	}
+}
+
 func readGeneratedApplicationTemplate(t *testing.T, name string) string {
 	t.Helper()
 	content, err := fs.ReadFile(layouttemplates.Files, name)

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -342,6 +342,7 @@ var baseTemplateMappings = map[TmplTarget]TmplTargetPath{
 	"router_router_test.tmpl":                "router/router_test.go",
 	"router_cookies_cookies.tmpl":            "router/cookies/cookies.go",
 	"router_cookies_flash.tmpl":              "router/cookies/flash.go",
+	"router_cookies_session.tmpl":            "router/cookies/session.go",
 	"router_middleware_middleware.tmpl":      "router/middleware/middleware.go",
 	"router_middleware_middleware_test.tmpl": "router/middleware/middleware_test.go",
 

--- a/layout/templates/go_mod.tmpl
+++ b/layout/templates/go_mod.tmpl
@@ -15,6 +15,7 @@ require (
 	github.com/exaring/otelpgx v0.11.1
 	github.com/go-faker/faker/v4 v4.9.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jackc/pgx/v5 v5.10.0

--- a/layout/templates/router_cookies_cookies.tmpl
+++ b/layout/templates/router_cookies_cookies.tmpl
@@ -8,7 +8,6 @@ import (
 	"{{.}}"
 {{- end}}
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 )
 
@@ -35,7 +34,7 @@ func CreateAppSession(c *echo.Context) error {
 {{- else}}
 func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 {{- end}}
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,7 @@ func CreateAppSession(c *echo.Context, user models.UserEntity) error {
 }
 
 func DestroyAppSession(c *echo.Context) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -59,9 +58,9 @@ func DestroyAppSession(c *echo.Context) error {
 
 func ExtractFromCookieApp(c *echo.Context) App {
 {{- if not (len .Blueprint.Cookies.SortedAppFields)}}
-	_, err := session.Get(config.AppCookieSessionName, c)
+	_, err := getSession(config.AppCookieSessionName, c)
 {{- else}}
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 {{- end}}
 	if err != nil {
 		return App{}
@@ -77,7 +76,7 @@ func ExtractFromCookieApp(c *echo.Context) App {
 }
 
 func SetReturnTo(c *echo.Context, returnTo string) error {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return err
 	}
@@ -92,7 +91,7 @@ func SetReturnTo(c *echo.Context, returnTo string) error {
 }
 
 func GetReturnTo(c *echo.Context) string {
-	sess, err := session.Get(config.AppCookieSessionName, c)
+	sess, err := getSession(config.AppCookieSessionName, c)
 	if err != nil {
 		return ""
 	}

--- a/layout/templates/router_cookies_flash.tmpl
+++ b/layout/templates/router_cookies_flash.tmpl
@@ -7,7 +7,6 @@ import (
 	"{{.ModuleName}}/config"
 	"{{.ModuleName}}/internal/server"
 
-	"github.com/labstack/echo-contrib/v5/session"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/xid"
 )
@@ -42,7 +41,7 @@ const (
 func AddFlash(
 	c *echo.Context, flashType FlashType, msg string,
 ) error {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return err
 	}
@@ -58,7 +57,7 @@ func AddFlash(
 }
 
 func ExtractFlashes(c *echo.Context) ([]FlashMessage, error) {
-	sess, err := session.Get(flashSession, c)
+	sess, err := getSession(flashSession, c)
 	if err != nil {
 		return nil, err
 	}

--- a/layout/templates/router_cookies_session.tmpl
+++ b/layout/templates/router_cookies_session.tmpl
@@ -1,0 +1,48 @@
+package cookies
+
+import (
+	"errors"
+
+	"{{.ModuleName}}/config"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
+)
+
+const recoveredSessionContextPrefix = "andurel/recovered-session/"
+
+func RecoverInvalidSessions(c *echo.Context) error {
+	for _, name := range []string{config.AppCookieSessionName, flashSession} {
+		sess, err := session.Get(name, c)
+		if err == nil {
+			continue
+		}
+
+		var decodeError securecookie.Error
+		if !errors.As(err, &decodeError) ||
+			!decodeError.IsDecode() ||
+			decodeError.IsUsage() ||
+			decodeError.IsInternal() {
+			return err
+		}
+
+		clear(sess.Values)
+		sess.IsNew = true
+		if err := sess.Save(c.Request(), c.Response()); err != nil {
+			return err
+		}
+		c.Set(recoveredSessionContextPrefix+name, true)
+	}
+
+	return nil
+}
+
+func getSession(name string, c *echo.Context) (*sessions.Session, error) {
+	sess, err := session.Get(name, c)
+	if err != nil && c.Get(recoveredSessionContextPrefix+name) != true {
+		return nil, err
+	}
+	return sess, nil
+}

--- a/layout/templates/router_middleware_middleware.tmpl
+++ b/layout/templates/router_middleware_middleware.tmpl
@@ -113,6 +113,9 @@ func ValidateSession(
 		if isAssetsPath(c.Request().URL.Path) || isAPIPath(c.Request().URL.Path) {
 			return next(c)
 		}
+		if err := cookies.RecoverInvalidSessions(c); err != nil {
+			return err
+		}
 
 		return next(c)
 	}
@@ -280,8 +283,8 @@ func CSRFMiddleware(cfg config.Config, csrfName string) (echo.MiddlewareFunc, er
 		Skipper: func(c *echo.Context) bool {
 			return mayBypassCSRF(c.Request())
 		},
-		TokenLookup:    tokenLookup,
-		CookiePath:     "/",
+		TokenLookup: tokenLookup,
+		CookiePath:  "/",
 		CookieDomain: func() string {
 			if config.Env == server.ProdEnvironment {
 				return config.Domain

--- a/layout/templates/router_middleware_middleware_test.tmpl
+++ b/layout/templates/router_middleware_middleware_test.tmpl
@@ -1,12 +1,22 @@
 package middleware
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"{{.ModuleName}}/config"
+	requestmeta "{{.ModuleName}}/internal/request"
+	"{{.ModuleName}}/router/cookies"
+
+	"github.com/gorilla/sessions"
+	echosession "github.com/labstack/echo-contrib/v5/session"
+	"github.com/labstack/echo/v5"
 )
+
+var registerFlashMessageOnce sync.Once
 
 func TestAPIPathBoundary(t *testing.T) {
 	tests := []struct {
@@ -60,3 +70,277 @@ func TestCSRFBypassRequiresBearerWithoutApplicationSession(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSessionRecoversStaleApplicationCookie(t *testing.T) {
+	oldStore := newTestCookieStore("old-application-session-auth-key")
+	newStore := newTestCookieStore("new-application-session-auth-key")
+	staleCookie := issueSessionCookie(t, oldStore, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(staleCookie)
+	called := false
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		called = true
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "" {
+			t.Fatalf("recovered return URL = %q, want empty", got)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if !called {
+		t.Fatal("downstream handler was not called")
+	}
+
+	replacement := responseCookie(t, recorder, config.AppCookieSessionName)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionRecoversStaleFlashCookie(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	oldStore := newTestCookieStore("old-flash-session-authentication-key")
+	newStore := newTestCookieStore("new-flash-session-authentication-key")
+	staleCookie := issueSessionCookie(t, oldStore, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashWarning, "stale warning")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(staleCookie)
+	recorder, err := serveSessionRequest(newStore, request, func(c *echo.Context) error {
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 0 {
+			t.Fatalf("recovered flashes = %v, want none", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+
+	replacement := responseCookie(t, recorder, staleCookie.Name)
+	assertEmptySessionCookie(t, newStore, replacement)
+}
+
+func TestValidateSessionPreservesValidSessions(t *testing.T) {
+	registerFlashMessageOnce.Do(func() {
+		gob.Register(cookies.FlashMessage{})
+	})
+
+	store := newTestCookieStore("valid-session-authentication-key")
+	appCookie := issueSessionCookie(t, store, config.AppCookieSessionName, func(c *echo.Context) error {
+		return cookies.SetReturnTo(c, "/account")
+	})
+	flashCookie := issueSessionCookie(t, store, "", func(c *echo.Context) error {
+		return cookies.AddFlash(c, cookies.FlashSuccess, "saved")
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.AddCookie(appCookie)
+	request.AddCookie(flashCookie)
+	recorder, err := serveSessionRequest(store, request, func(c *echo.Context) error {
+		if got := requestmeta.ExtractContext[string](c.Request().Context(), requestmeta.BackURLKey); got != "/account" {
+			t.Fatalf("return URL = %q, want %q", got, "/account")
+		}
+		flashes := requestmeta.ExtractContext[[]cookies.FlashMessage](
+			c.Request().Context(),
+			requestmeta.SessionFlashesKey,
+		)
+		if len(flashes) != 1 || flashes[0].Message != "saved" {
+			t.Fatalf("flashes = %v, want saved flash", flashes)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+	if err != nil {
+		t.Fatalf("ValidateSession returned an error: %v", err)
+	}
+	if hasResponseCookie(recorder, config.AppCookieSessionName) {
+		t.Fatal("valid application session was unexpectedly replaced")
+	}
+}
+
+func TestValidateSessionPropagatesNonDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		middleware echo.MiddlewareFunc
+		request    *http.Request
+	}{
+		{
+			name:    "missing session middleware",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+		{
+			name:       "usage error",
+			middleware: echosession.Middleware(sessions.NewCookieStore()),
+			request: requestWithCookie(&http.Cookie{
+				Name:  config.AppCookieSessionName,
+				Value: "configured-without-codecs",
+			}),
+		},
+		{
+			name:       "internal error",
+			middleware: echosession.Middleware(classifiedErrorStore{}),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := ValidateSession(func(c *echo.Context) error {
+				called = true
+				return nil
+			})
+			if test.middleware != nil {
+				handler = test.middleware(handler)
+			}
+
+			recorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(test.request, recorder)
+			if err := handler(ctx); err == nil {
+				t.Fatal("expected session validation error")
+			}
+			if called {
+				t.Fatal("downstream handler was called")
+			}
+		})
+	}
+}
+
+func newTestCookieStore(authKey string) *sessions.CookieStore {
+	return sessions.NewCookieStore(
+		[]byte(authKey),
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+}
+
+func issueSessionCookie(
+	t *testing.T,
+	store sessions.Store,
+	wantName string,
+	handler echo.HandlerFunc,
+) *http.Cookie {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	if err := echosession.Middleware(store)(handler)(ctx); err != nil {
+		t.Fatalf("issue session cookie: %v", err)
+	}
+
+	cookies := recorder.Result().Cookies()
+	if wantName == "" {
+		if len(cookies) != 1 {
+			t.Fatalf("issued cookies = %d, want 1", len(cookies))
+		}
+		return cookies[0]
+	}
+	for _, cookie := range cookies {
+		if cookie.Name == wantName {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain cookie %q", wantName)
+	return nil
+}
+
+func serveSessionRequest(
+	store sessions.Store,
+	request *http.Request,
+	handler echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	recorder := httptest.NewRecorder()
+	ctx := echo.New().NewContext(request, recorder)
+	chain := echosession.Middleware(store)(ValidateSession(RegisterRequestMeta(handler)))
+	return recorder, chain(ctx)
+}
+
+func responseCookie(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	name string,
+) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+
+	t.Fatalf("response did not contain replacement cookie %q", name)
+	return nil
+}
+
+func hasResponseCookie(recorder *httptest.ResponseRecorder, name string) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertEmptySessionCookie(
+	t *testing.T,
+	store *sessions.CookieStore,
+	cookie *http.Cookie,
+) {
+	t.Helper()
+
+	request := requestWithCookie(cookie)
+	sess, err := store.New(request, cookie.Name)
+	if err != nil {
+		t.Fatalf("replacement cookie cannot be decoded: %v", err)
+	}
+	if len(sess.Values) != 0 {
+		t.Fatalf("replacement cookie values = %v, want empty", sess.Values)
+	}
+}
+
+func requestWithCookie(cookie *http.Cookie) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(cookie)
+	return request
+}
+
+type classifiedErrorStore struct{}
+
+func (classifiedErrorStore) Get(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) New(*http.Request, string) (*sessions.Session, error) {
+	return nil, internalSessionError{}
+}
+
+func (classifiedErrorStore) Save(*http.Request, http.ResponseWriter, *sessions.Session) error {
+	return nil
+}
+
+type internalSessionError struct{}
+
+func (internalSessionError) Error() string    { return "internal session error" }
+func (internalSessionError) IsUsage() bool    { return false }
+func (internalSessionError) IsDecode() bool   { return false }
+func (internalSessionError) IsInternal() bool { return true }
+func (internalSessionError) Cause() error     { return nil }
+
+var _ interface {
+	error
+	IsUsage() bool
+	IsDecode() bool
+	IsInternal() bool
+	Cause() error
+} = internalSessionError{}

--- a/layout/upgrade/orchestrator.go
+++ b/layout/upgrade/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/mbvlabs/andurel/layout"
 	"golang.org/x/mod/semver"
@@ -48,6 +49,7 @@ type UpgradeReport struct {
 	ReplacedFiles       []string
 	RemovedFiles        []string
 	Diffs               []FileDiff
+	ManualActions       []ManualAction `json:"manual_actions,omitempty"`
 	DirtyWorktree       bool
 	AlreadyCurrent      bool
 	RepairAvailable     bool
@@ -237,6 +239,7 @@ func printUpgradeSuccess(writer io.Writer, report *UpgradeReport) {
 	if lockChanged {
 		output.println("✓ Updated andurel.lock")
 	}
+	printManualActions(output, report.ManualActions)
 	if len(report.ReplacedFiles) == 0 && len(report.RemovedFiles) == 0 && !lockChanged {
 		output.println("✓ Project is already up to date")
 		return
@@ -264,6 +267,18 @@ func printUpgradeDryRun(writer io.Writer, report *UpgradeReport) {
 	printToolChanges(output, report, true)
 	if report.FromVersion != report.ToVersion || hasToolChanges(report) {
 		output.println("\n[DRY RUN] Would update andurel.lock")
+	}
+	printManualActions(output, report.ManualActions)
+}
+
+func printManualActions(output *presentationWriter, actions []ManualAction) {
+	if len(actions) == 0 {
+		return
+	}
+
+	output.println("\nManual action required after this upgrade:")
+	for _, action := range actions {
+		output.printf("\n%s\n\n%s\n", action.Title, strings.TrimSpace(action.Instructions))
 	}
 }
 

--- a/layout/upgrade/orchestrator_test.go
+++ b/layout/upgrade/orchestrator_test.go
@@ -90,6 +90,46 @@ func TestUpgradeDryRunPresentationOmitsEmptySections(t *testing.T) {
 	}
 }
 
+func TestUpgradePresentationIncludesManualActions(t *testing.T) {
+	t.Parallel()
+
+	report := &UpgradeReport{
+		FromVersion: "v1.5.2",
+		ToVersion:   "v1.5.3",
+		ManualActions: []ManualAction{{
+			ID:           "session-cookie-recovery-v1.5.3",
+			Title:        "Update application-owned session handling",
+			Instructions: "Create router/cookies/session.go with the rendered recovery helper.",
+		}},
+	}
+
+	for _, render := range []struct {
+		name string
+		call func(*bytes.Buffer, *UpgradeReport)
+	}{
+		{name: "upgrade", call: func(output *bytes.Buffer, report *UpgradeReport) {
+			printUpgradeSuccess(output, report)
+		}},
+		{name: "dry run", call: func(output *bytes.Buffer, report *UpgradeReport) {
+			printUpgradeDryRun(output, report)
+		}},
+	} {
+		t.Run(render.name, func(t *testing.T) {
+			var output bytes.Buffer
+			render.call(&output, report)
+			for _, want := range []string{
+				"Manual action required",
+				"Update application-owned session handling",
+				"Create router/cookies/session.go",
+			} {
+				if !strings.Contains(output.String(), want) {
+					t.Fatalf("manual action presentation missing %q:\n%s", want, output.String())
+				}
+			}
+		})
+	}
+}
+
 func TestUpgradeAlreadyCurrentPresentation(t *testing.T) {
 	t.Parallel()
 

--- a/layout/upgrade/plan.go
+++ b/layout/upgrade/plan.go
@@ -33,12 +33,13 @@ type plannedFile struct {
 }
 
 type upgradePlan struct {
-	fromVersion string
-	toVersion   string
-	dirty       bool
-	files       []plannedFile
-	toolChanges ToolSyncResult
-	diffs       []FileDiff
+	fromVersion   string
+	toVersion     string
+	dirty         bool
+	files         []plannedFile
+	toolChanges   ToolSyncResult
+	diffs         []FileDiff
+	manualActions []ManualAction
 }
 
 func (p *upgradePlan) cloneReport() *UpgradeReport {
@@ -51,6 +52,7 @@ func (p *upgradePlan) cloneReport() *UpgradeReport {
 		UpdatedTools:        slices.Clone(p.toolChanges.Updated),
 		ToolMetadataChanges: slices.Clone(p.toolChanges.Metadata),
 		Diffs:               slices.Clone(p.diffs),
+		ManualActions:       slices.Clone(p.manualActions),
 	}
 	report.ToolsAdded = len(report.AddedTools)
 	report.ToolsRemoved = len(report.RemovedTools)
@@ -79,6 +81,20 @@ func (u *Upgrader) buildPlan(dirty bool) (*upgradePlan, error) {
 		fromVersion: u.lock.Version,
 		toVersion:   u.opts.TargetVersion,
 		dirty:       dirty,
+	}
+	if crossesVersion(plan.fromVersion, plan.toVersion, sessionCookieRecoveryVersion) {
+		modulePath, err := resolveModulePath(u.projectRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve module path for manual actions: %w", err)
+		}
+		plan.manualActions, err = manualActionsForUpgrade(
+			plan.fromVersion,
+			plan.toVersion,
+			modulePath,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	toolChanges, err := syncTools(lock)

--- a/layout/upgrade/transactional_upgrade_test.go
+++ b/layout/upgrade/transactional_upgrade_test.go
@@ -227,6 +227,44 @@ func TestDryRunIsDeterministicAndByteReadOnlyOnSameInstance(t *testing.T) {
 	}
 }
 
+func TestSessionRecoveryManualActionDoesNotPlanRouterMutations(t *testing.T) {
+	root := newUpgradeFixtureProject(t)
+	routerFiles := map[string][]byte{
+		"router/cookies/cookies.go":       []byte("package cookies\n\nconst UserOwnedCookies = true\n"),
+		"router/cookies/flash.go":         []byte("package cookies\n\nconst UserOwnedFlashes = true\n"),
+		"router/middleware/middleware.go": []byte("package middleware\n\nconst UserOwnedMiddleware = true\n"),
+	}
+	for path, content := range routerFiles {
+		mustWriteTestFile(t, root, path, content)
+	}
+	commitUpgradeTree(t, root, "add user-owned router files")
+
+	upgrader, err := NewUpgrader(root, UpgradeOptions{DryRun: true, TargetVersion: "v1.5.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := upgrader.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.ManualActions) != 1 {
+		t.Fatalf("manual actions = %#v, want one", report.ManualActions)
+	}
+	if !strings.Contains(report.ManualActions[0].Instructions, `"testapp/config"`) {
+		t.Fatalf("manual action does not use project module:\n%s", report.ManualActions[0].Instructions)
+	}
+	for _, path := range append(slices.Clone(report.ReplacedFiles), report.RemovedFiles...) {
+		if strings.HasPrefix(path, "router/") {
+			t.Fatalf("manual action planned router mutation %q", path)
+		}
+	}
+	for path, want := range routerFiles {
+		if got := mustReadProjectFile(t, root, path); !bytes.Equal(got, want) {
+			t.Fatalf("dry run changed %s:\n%s", path, got)
+		}
+	}
+}
+
 func TestVersionedInertiaUpgradeEmbedsExistingRoot(t *testing.T) {
 	root := newUpgradeFixtureProjectWithConfig(t, layout.ScaffoldConfig{
 		ProjectName: "testapp",

--- a/layout/upgrade/upgrade_notes.go
+++ b/layout/upgrade/upgrade_notes.go
@@ -1,0 +1,79 @@
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mbvlabs/andurel/layout"
+	layouttemplates "github.com/mbvlabs/andurel/layout/templates"
+	"golang.org/x/mod/semver"
+)
+
+const sessionCookieRecoveryVersion = "v1.5.3"
+
+// ManualAction describes an application-owned change that an upgrade cannot
+// apply without risking user code.
+type ManualAction struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	Instructions string `json:"instructions"`
+}
+
+func manualActionsForUpgrade(fromVersion, toVersion, modulePath string) ([]ManualAction, error) {
+	if !crossesVersion(fromVersion, toVersion, sessionCookieRecoveryVersion) {
+		return nil, nil
+	}
+
+	sessionSource, err := renderTemplateToBytes(
+		"router_cookies_session.tmpl",
+		layouttemplates.Files,
+		&layout.TemplateData{ModuleName: modulePath},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("render session-cookie recovery instructions: %w", err)
+	}
+
+	var instructions strings.Builder
+	instructions.WriteString("The router tree is application-owned, so Andurel did not change it automatically.\n")
+	instructions.WriteString("If this recovery is already present, no action is required.\n\n")
+	instructions.WriteString("1. Create router/cookies/session.go:\n\n```go\n")
+	instructions.Write(sessionSource)
+	instructions.WriteString("```\n\n")
+	instructions.WriteString("2. In router/cookies/cookies.go and router/cookies/flash.go:\n")
+	instructions.WriteString("   - Replace calls to session.Get with getSession.\n")
+	instructions.WriteString("   - Remove the now-unused github.com/labstack/echo-contrib/v5/session imports.\n\n")
+	instructions.WriteString("3. In router/middleware/middleware.go, add this inside ValidateSession after the assets and API bypass and before calling the next handler:\n\n")
+	instructions.WriteString("```go\nif err := cookies.RecoverInvalidSessions(c); err != nil {\n\treturn err\n}\n```\n\n")
+	instructions.WriteString("4. Add this direct requirement to go.mod:\n\n")
+	instructions.WriteString("```go\ngithub.com/gorilla/securecookie v1.1.2\n```\n\n")
+	instructions.WriteString("5. Format and verify the migration:\n\n```text\n")
+	instructions.WriteString("gofmt -w router/cookies/session.go router/cookies/cookies.go router/cookies/flash.go router/middleware/middleware.go\n")
+	instructions.WriteString("go fix ./...\ngo vet ./...\n```\n")
+
+	return []ManualAction{{
+		ID:           "session-cookie-recovery-v1.5.3",
+		Title:        "Update application-owned session handling",
+		Instructions: instructions.String(),
+	}}, nil
+}
+
+func crossesVersion(fromVersion, toVersion, boundary string) bool {
+	from, fromOK := canonicalUpgradeVersion(fromVersion)
+	to, toOK := canonicalUpgradeVersion(toVersion)
+	boundary, boundaryOK := canonicalUpgradeVersion(boundary)
+	return fromOK && toOK && boundaryOK &&
+		semver.Compare(from, boundary) < 0 &&
+		semver.Compare(to, boundary) >= 0
+}
+
+func canonicalUpgradeVersion(version string) (string, bool) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "", false
+	}
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	version = semver.Canonical(version)
+	return version, version != ""
+}

--- a/layout/upgrade/upgrade_notes_test.go
+++ b/layout/upgrade/upgrade_notes_test.go
@@ -1,0 +1,57 @@
+package upgrade
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSessionRecoveryManualActionVersionGate(t *testing.T) {
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want bool
+	}{
+		{name: "first affected upgrade", from: "v1.5.2", to: "v1.5.3", want: true},
+		{name: "skips directly over release", from: "v1.4.0", to: "v1.6.0", want: true},
+		{name: "already received note", from: "v1.5.3", to: "v1.6.0", want: false},
+		{name: "target predates note", from: "v1.5.1", to: "v1.5.2", want: false},
+		{name: "development version", from: "dev", to: "v1.5.3", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actions, err := manualActionsForUpgrade(test.from, test.to, "example.com/acme")
+			if err != nil {
+				t.Fatalf("manualActionsForUpgrade returned an error: %v", err)
+			}
+			if got := len(actions) > 0; got != test.want {
+				t.Fatalf("manual action present = %t, want %t: %#v", got, test.want, actions)
+			}
+			if !test.want {
+				return
+			}
+
+			action := actions[0]
+			if action.ID != "session-cookie-recovery-v1.5.3" {
+				t.Fatalf("manual action ID = %q", action.ID)
+			}
+			for _, want := range []string{
+				"Create router/cookies/session.go",
+				`"example.com/acme/config"`,
+				"cookies.RecoverInvalidSessions(c)",
+				"github.com/gorilla/securecookie v1.1.2",
+				"session.Get",
+			} {
+				if !strings.Contains(action.Instructions, want) {
+					t.Errorf("manual action missing %q:\n%s", want, action.Instructions)
+				}
+			}
+			for _, unwanted := range []string{"{{.ModuleName}}", "https://"} {
+				if strings.Contains(action.Instructions, unwanted) {
+					t.Errorf("manual action contains %q:\n%s", unwanted, action.Instructions)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- recover stale or differently signed application and flash cookies as empty sessions
- keep configuration, usage, internal, and save errors fatal
- show a one-time inline migration note when upgrading across v1.5.3

## Issue

Session cookies signed with an earlier server secret can survive a rebuild. Gorilla reports a decode error for those cookies, and the generated session helpers currently propagate it, turning an authentication recovery case into an HTTP 500 response.