### PR TITLE
fix(release): validate contracts before merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Download dependencies
       run: go mod download
 
+    - name: Check public API and CLI contracts
+      run: ./scripts/check-contracts.sh
+
     - name: Install tools
       run: |
         go install github.com/a-h/templ/cmd/templ

--- a/cli/command_surface_test.go
+++ b/cli/command_surface_test.go
@@ -722,7 +722,7 @@ func TestRunUpgradeStructuredAndHumanBranches(t *testing.T) {
 			RemovedFiles:  []string{"internal/old.go"},
 			ToolsUpdated:  1,
 			ManualActions: []upgrade.ManualAction{{
-				ID:           "session-cookie-recovery-v1.5.3",
+				ID:           "session-cookie-recovery-v1.5.4",
 				Title:        "Update application-owned session handling",
 				Instructions: "Create router/cookies/session.go",
 			}},
@@ -748,7 +748,7 @@ func TestRunUpgradeStructuredAndHumanBranches(t *testing.T) {
 	if !strings.Contains(out.String(), "dry run only") ||
 		!strings.Contains(out.String(), "controllers/controller.go") ||
 		!strings.Contains(out.String(), `"manual_actions"`) ||
-		!strings.Contains(out.String(), "session-cookie-recovery-v1.5.3") {
+		!strings.Contains(out.String(), "session-cookie-recovery-v1.5.4") {
 		t.Fatalf("structured upgrade output missing report data:\n%s", out.String())
 	}
 

--- a/contracts/cli-v1.json
+++ b/contracts/cli-v1.json
@@ -2228,6 +2228,33 @@
           "json_name": "diff"
         }
       ]
+    },
+    {
+      "type": "github.com/mbvlabs/andurel/layout/upgrade.ManualAction",
+      "fields": [
+        {
+          "go_name": "ID",
+          "json_name": "id"
+        },
+        {
+          "go_name": "Title",
+          "json_name": "title"
+        },
+        {
+          "go_name": "Instructions",
+          "json_name": "instructions"
+        }
+      ]
+    },
+    {
+      "type": "github.com/mbvlabs/andurel/layout/upgrade.UpgradeReport",
+      "fields": [
+        {
+          "go_name": "ManualActions",
+          "json_name": "manual_actions",
+          "omitempty": true
+        }
+      ]
     }
   ],
   "success_envelope": {

--- a/contracts/public-api.txt
+++ b/contracts/public-api.txt
@@ -2466,6 +2466,14 @@ func (g *GitAnalyzer) GetModifiedFiles() (map[string]bool, error)
 func (g *GitAnalyzer) IsClean() (bool, error)
     IsClean reports whether clean.
 
+type ManualAction struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	Instructions string `json:"instructions"`
+}
+    ManualAction describes an application-owned change that an upgrade cannot
+    apply without risking user code.
+
 type TemplateGenerator struct {
 	// Has unexported fields.
 }
@@ -2515,6 +2523,7 @@ type UpgradeReport struct {
 	ReplacedFiles       []string
 	RemovedFiles        []string
 	Diffs               []FileDiff
+	ManualActions       []ManualAction `json:"manual_actions,omitempty"`
 	DirtyWorktree       bool
 	AlreadyCurrent      bool
 	RepairAvailable     bool

--- a/docs/generated-files-and-upgrades.md
+++ b/docs/generated-files-and-upgrades.md
@@ -10,7 +10,7 @@ The Inertia root embedding migration is another narrow boundary. It moves `views
 
 The `router/*` tree is application-owned, so `andurel upgrade` does not install session-cookie decode recovery into an existing project. New projects include the recovery automatically. Existing projects should reconcile only these declarations against a fresh scaffold created with the target Andurel version:
 
-When an upgrade crosses from a version before `v1.5.3` to `v1.5.3` or later, `andurel upgrade` prints this complete migration with the project's module path already rendered. The same manual action is included in dry-run and structured JSON output. Projects starting on `v1.5.3` or later do not receive the note.
+When an upgrade crosses from a version before `v1.5.4` to `v1.5.4` or later, `andurel upgrade` prints this complete migration with the project's module path already rendered. The same manual action is included in dry-run and structured JSON output. Projects starting on `v1.5.4` or later do not receive the note.
 
 1. Add `router/cookies/session.go` from [`router_cookies_session.tmpl`](../layout/templates/router_cookies_session.tmpl), replacing the template module import with the project's module path.
 2. In `router/cookies/cookies.go` and `router/cookies/flash.go`, replace calls to Echo's `session.Get` with the shared `getSession` helper and remove the now-unused Echo session imports.

--- a/layout/upgrade/orchestrator_test.go
+++ b/layout/upgrade/orchestrator_test.go
@@ -95,9 +95,9 @@ func TestUpgradePresentationIncludesManualActions(t *testing.T) {
 
 	report := &UpgradeReport{
 		FromVersion: "v1.5.2",
-		ToVersion:   "v1.5.3",
+		ToVersion:   "v1.5.4",
 		ManualActions: []ManualAction{{
-			ID:           "session-cookie-recovery-v1.5.3",
+			ID:           "session-cookie-recovery-v1.5.4",
 			Title:        "Update application-owned session handling",
 			Instructions: "Create router/cookies/session.go with the rendered recovery helper.",
 		}},

--- a/layout/upgrade/transactional_upgrade_test.go
+++ b/layout/upgrade/transactional_upgrade_test.go
@@ -239,7 +239,7 @@ func TestSessionRecoveryManualActionDoesNotPlanRouterMutations(t *testing.T) {
 	}
 	commitUpgradeTree(t, root, "add user-owned router files")
 
-	upgrader, err := NewUpgrader(root, UpgradeOptions{DryRun: true, TargetVersion: "v1.5.3"})
+	upgrader, err := NewUpgrader(root, UpgradeOptions{DryRun: true, TargetVersion: "v1.5.4"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layout/upgrade/upgrade_notes.go
+++ b/layout/upgrade/upgrade_notes.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const sessionCookieRecoveryVersion = "v1.5.3"
+const sessionCookieRecoveryVersion = "v1.5.4"
 
 // ManualAction describes an application-owned change that an upgrade cannot
 // apply without risking user code.
@@ -51,7 +51,7 @@ func manualActionsForUpgrade(fromVersion, toVersion, modulePath string) ([]Manua
 	instructions.WriteString("go fix ./...\ngo vet ./...\n```\n")
 
 	return []ManualAction{{
-		ID:           "session-cookie-recovery-v1.5.3",
+		ID:           "session-cookie-recovery-v1.5.4",
 		Title:        "Update application-owned session handling",
 		Instructions: instructions.String(),
 	}}, nil

--- a/layout/upgrade/upgrade_notes_test.go
+++ b/layout/upgrade/upgrade_notes_test.go
@@ -12,11 +12,12 @@ func TestSessionRecoveryManualActionVersionGate(t *testing.T) {
 		to   string
 		want bool
 	}{
-		{name: "first affected upgrade", from: "v1.5.2", to: "v1.5.3", want: true},
+		{name: "first affected upgrade", from: "v1.5.2", to: "v1.5.4", want: true},
 		{name: "skips directly over release", from: "v1.4.0", to: "v1.6.0", want: true},
-		{name: "already received note", from: "v1.5.3", to: "v1.6.0", want: false},
+		{name: "already received note", from: "v1.5.4", to: "v1.6.0", want: false},
+		{name: "target predates release", from: "v1.5.2", to: "v1.5.3", want: false},
 		{name: "target predates note", from: "v1.5.1", to: "v1.5.2", want: false},
-		{name: "development version", from: "dev", to: "v1.5.3", want: false},
+		{name: "development version", from: "dev", to: "v1.5.4", want: false},
 	}
 
 	for _, test := range tests {
@@ -33,7 +34,7 @@ func TestSessionRecoveryManualActionVersionGate(t *testing.T) {
 			}
 
 			action := actions[0]
-			if action.ID != "session-cookie-recovery-v1.5.3" {
+			if action.ID != "session-cookie-recovery-v1.5.4" {
 				t.Fatalf("manual action ID = %q", action.ID)
 			}
 			for _, want := range []string{


### PR DESCRIPTION
## What

Adds contract validation to pull-request CI, refreshes the public API and CLI contract fixtures, and aligns the session recovery migration with v1.5.4.
