### PR TITLE
fix(generator): correct generated API semantics

### DIFF
--- a/contracts/public-api.txt
+++ b/contracts/public-api.txt
@@ -1100,6 +1100,7 @@ type Config struct {
 	CustomTypes       []types.TypeOverride
 	PrimaryKeyColumn  string // Override PK column name (empty = auto-detect)
 	GenerateWithoutPK bool   // Force generation without PK handling
+	ModelMode         ModelMode
 }
     Config controls model generation for a database table.
 
@@ -1175,6 +1176,7 @@ type GeneratedModel struct {
 	ReceiverName        string // s (for the namespace methods)
 	HasCreatedAt        bool
 	HasUpdatedAt        bool
+	Mode                ModelMode
 }
     GeneratedModel contains the template data for a generated model file.
 
@@ -1214,12 +1216,48 @@ func (g *Generator) GenerateModel(
 func (g *Generator) GenerateModelFile(model *GeneratedModel, templateStr string) (string, error)
     GenerateModelFile renders model template data into Go source.
 
+func (g *Generator) GenerateModelWithMode(
+	cat *catalog.Catalog,
+	resourceName string,
+	pluralName string,
+	modelPath string,
+	modulePath string,
+	tableNameOverride string,
+	nullType string,
+	primaryKeyColumn string,
+	generateWithoutPK bool,
+	mode ModelMode,
+) error
+    GenerateModelWithMode renders and writes a model with a restricted operation
+    surface.
+
 func (g *Generator) PlanFactorySource(factory *GeneratedFactory) (string, error)
     PlanFactorySource renders formatted factory source without writing files.
+
+func (g *Generator) PlanModelSource(
+	cat *catalog.Catalog,
+	resourceName string,
+	pluralName string,
+	modulePath string,
+	tableNameOverride string,
+	nullType string,
+	primaryKeyColumn string,
+	generateWithoutPK bool,
+	mode ModelMode,
+) (*GeneratedModel, string, error)
+    PlanModelSource renders formatted model source without writing files.
 
 func (g *Generator) WriteFactoryFile(factory *GeneratedFactory, outputDir string) error
     WriteFactoryFile writes a factory file to disk
 
+type ModelMode string
+    ModelMode controls which persistence operations are generated for a model.
+
+const (
+	ModelModeCRUD       ModelMode = "crud"
+	ModelModeReadOnly   ModelMode = "read-only"
+	ModelModeCreateOnly ModelMode = "create-only"
+)
 
 ## github.com/mbvlabs/andurel/generator/templates
 package templates // import "github.com/mbvlabs/andurel/generator/templates"
@@ -2915,9 +2953,9 @@ func ToKebabCase(s string) string
     ToKebabCase converts a snake_case identifier into kebab-case.
 
 func ToLowerCamelCase(s string) string
-    ToLowerCamelCase converts a PascalCase identifier into camelCase by
-    lowercasing the first character. Examples: "NewUser" -> "newUser",
-    "AdminUser" -> "adminUser", "User" -> "user"
+    ToLowerCamelCase converts a PascalCase identifier into camelCase while
+    preserving word boundaries encoded by a leading uppercase run. Examples:
+    "NewUser" -> "newUser", "SSHCredential" -> "sshCredential".
 
 func ToLowerCamelCaseFromAny(s string) string
     ToLowerCamelCaseFromAny converts snake_case or PascalCase into lower

--- a/generator/internal/types/type_mapper.go
+++ b/generator/internal/types/type_mapper.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/mbvlabs/andurel/generator/internal/catalog"
+	"github.com/mbvlabs/andurel/pkg/naming"
 )
 
 // TypeOverride lets users map a SQL database type to a custom Go type.
@@ -223,27 +224,12 @@ func normalizeSQLType(sqlType string) string {
 
 // FormatFieldName formats field name.
 func FormatFieldName(dbColumnName string) string {
+	// The conventional primary-key column is the only structural exception.
+	// All other schema vocabulary is converted mechanically.
 	if dbColumnName == "id" {
 		return "ID"
 	}
-
-	parts := strings.Split(dbColumnName, "_")
-
-	var builder strings.Builder
-	builder.Grow(len(dbColumnName))
-
-	for _, part := range parts {
-		if len(part) > 0 && part == "id" {
-			builder.WriteString(strings.ToUpper(part))
-		}
-
-		if len(part) > 0 && part != "id" {
-			builder.WriteString(strings.ToUpper(part[:1]))
-			builder.WriteString(strings.ToLower(part[1:]))
-		}
-	}
-
-	return builder.String()
+	return naming.ToPascalCase(dbColumnName)
 }
 
 // FormatDisplayName formats display name.

--- a/generator/internal/types/type_mapper_test.go
+++ b/generator/internal/types/type_mapper_test.go
@@ -81,6 +81,21 @@ func TestMapSQLTypeToGo_NonNullableTypes(t *testing.T) {
 	}
 }
 
+func TestFormatFieldNameUsesMechanicalSchemaCasing(t *testing.T) {
+	tests := map[string]string{
+		"id":                       "ID",
+		"url":                      "Url",
+		"cidr":                     "Cidr",
+		"server_ssh_credential_id": "ServerSshCredentialId",
+		"wireguard_peer_id":        "WireguardPeerId",
+	}
+	for input, want := range tests {
+		if got := FormatFieldName(input); got != want {
+			t.Fatalf("FormatFieldName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func TestMapSQLTypeToGo_NullableTypes_Pointer(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/generator/models/generator.go
+++ b/generator/models/generator.go
@@ -12,7 +12,6 @@ import (
 	"text/template"
 
 	"github.com/jinzhu/inflection"
-	"github.com/mbvlabs/andurel/generator/files"
 	"github.com/mbvlabs/andurel/generator/internal/catalog"
 	"github.com/mbvlabs/andurel/generator/internal/ddl"
 	"github.com/mbvlabs/andurel/generator/internal/migrations"
@@ -63,7 +62,17 @@ type GeneratedModel struct {
 	ReceiverName        string // s (for the namespace methods)
 	HasCreatedAt        bool
 	HasUpdatedAt        bool
+	Mode                ModelMode
 }
+
+// ModelMode controls which persistence operations are generated for a model.
+type ModelMode string
+
+const (
+	ModelModeCRUD       ModelMode = "crud"
+	ModelModeReadOnly   ModelMode = "read-only"
+	ModelModeCreateOnly ModelMode = "create-only"
+)
 
 // Config controls model generation for a database table.
 type Config struct {
@@ -76,6 +85,7 @@ type Config struct {
 	CustomTypes       []types.TypeOverride
 	PrimaryKeyColumn  string // Override PK column name (empty = auto-detect)
 	GenerateWithoutPK bool   // Force generation without PK handling
+	ModelMode         ModelMode
 }
 
 // BunModelConfig holds configuration for bun model generation
@@ -156,16 +166,14 @@ func (g *Generator) Build(cat *catalog.Catalog, config Config) (*GeneratedModel,
 		IDFieldName:     config.PrimaryKeyColumn,
 		IDGoFieldName:   "",
 		HasPrimaryKey:   false,
+		Mode:            normalizeModelMode(config.ModelMode),
 	}
 
 	importSet := make(map[string]bool)
 	importSet["context"] = true
-	importSet["errors"] = true
-	importSet["time"] = true
 	importSet["github.com/uptrace/bun"] = true
 	if config.ModulePath != "" {
 		importSet[config.ModulePath+"/internal/storage"] = true
-		importSet[config.ModulePath+"/internal/validation"] = true
 	}
 
 	for _, col := range table.Columns {
@@ -235,6 +243,16 @@ func (g *Generator) Build(cat *catalog.Catalog, config Config) (*GeneratedModel,
 
 	if model.HasPrimaryKey && model.IDType == "uuid.UUID" {
 		importSet["github.com/google/uuid"] = true
+	}
+	if model.Mode != ModelModeReadOnly {
+		importSet["errors"] = true
+		if config.ModulePath != "" {
+			importSet[config.ModulePath+"/internal/validation"] = true
+		}
+	}
+	if model.HasPrimaryKey && model.Mode != ModelModeCreateOnly {
+		importSet["errors"] = true
+		importSet["database/sql"] = true
 	}
 
 	stdImports, extImports := groupAndSortImports(importSet)
@@ -355,6 +373,46 @@ func (g *Generator) GenerateModel(
 	primaryKeyColumn string,
 	generateWithoutPK bool,
 ) error {
+	return g.GenerateModelWithMode(cat, resourceName, pluralName, modelPath, modulePath, tableNameOverride, nullType, primaryKeyColumn, generateWithoutPK, ModelModeCRUD)
+}
+
+// GenerateModelWithMode renders and writes a model with a restricted operation surface.
+func (g *Generator) GenerateModelWithMode(
+	cat *catalog.Catalog,
+	resourceName string,
+	pluralName string,
+	modelPath string,
+	modulePath string,
+	tableNameOverride string,
+	nullType string,
+	primaryKeyColumn string,
+	generateWithoutPK bool,
+	mode ModelMode,
+) error {
+	_, modelContent, err := g.PlanModelSource(cat, resourceName, pluralName, modulePath, tableNameOverride, nullType, primaryKeyColumn, generateWithoutPK, mode)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(modelPath, []byte(modelContent), constants.FilePermissionPrivate); err != nil {
+		return fmt.Errorf("failed to write model file: %w", err)
+	}
+
+	return nil
+}
+
+// PlanModelSource renders formatted model source without writing files.
+func (g *Generator) PlanModelSource(
+	cat *catalog.Catalog,
+	resourceName string,
+	pluralName string,
+	modulePath string,
+	tableNameOverride string,
+	nullType string,
+	primaryKeyColumn string,
+	generateWithoutPK bool,
+	mode ModelMode,
+) (*GeneratedModel, string, error) {
 	tableName := pluralName
 	if tableNameOverride != "" {
 		tableName = tableNameOverride
@@ -369,39 +427,37 @@ func (g *Generator) GenerateModel(
 		NullType:          nullType,
 		PrimaryKeyColumn:  primaryKeyColumn,
 		GenerateWithoutPK: generateWithoutPK,
+		ModelMode:         normalizeModelMode(mode),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to build model: %w", err)
+		return nil, "", fmt.Errorf("failed to build model: %w", err)
 	}
 
 	model.TableNameOverride = tableNameOverride
 	model.TableNameOverridden = tableNameOverride != ""
-	// When table name is overridden, don't pluralize the resource name for function names
-	if tableNameOverride != "" {
-		model.PluralName = resourceName
-	} else {
-		model.PluralName = inflection.Plural(resourceName)
-	}
+	model.PluralName = inflection.Plural(resourceName)
 
 	templateContent, err := templates.Files.ReadFile("model.tmpl")
 	if err != nil {
-		return fmt.Errorf("failed to read model template: %w", err)
+		return nil, "", fmt.Errorf("failed to read model template: %w", err)
 	}
 
 	modelContent, err := g.GenerateModelFile(model, string(templateContent))
 	if err != nil {
-		return fmt.Errorf("failed to render model file: %w", err)
+		return nil, "", fmt.Errorf("failed to render model file: %w", err)
 	}
-
-	if err := os.WriteFile(modelPath, []byte(modelContent), constants.FilePermissionPrivate); err != nil {
-		return fmt.Errorf("failed to write model file: %w", err)
+	formatted, err := format.Source([]byte(modelContent))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to format model source: %w", err)
 	}
+	return model, string(formatted), nil
+}
 
-	if err := files.FormatGoFile(modelPath); err != nil {
-		return fmt.Errorf("failed to format model file: %w", err)
+func normalizeModelMode(mode ModelMode) ModelMode {
+	if mode == "" {
+		return ModelModeCRUD
 	}
-
-	return nil
+	return mode
 }
 
 // GeneratedFactory represents a factory for a model

--- a/generator/models/generator_test.go
+++ b/generator/models/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mbvlabs/andurel/generator/internal/catalog"
+	"github.com/mbvlabs/andurel/pkg/naming"
 )
 
 func TestBuildUUIDImports(t *testing.T) {
@@ -174,6 +175,229 @@ func TestGeneratorFactoryDefaultsAndZeroValues(t *testing.T) {
 	}
 }
 
+func TestGenerateModelUpsertRequiresExplicitPrimaryKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		resource   string
+		tableName  string
+		primaryKey *catalog.Column
+		idType     string
+		receiver   string
+	}{
+		{
+			name:       "uuid primary key",
+			resource:   "Product",
+			tableName:  "products",
+			primaryKey: catalog.NewColumn("id", "uuid").SetPrimaryKey(),
+			idType:     "uuid.UUID",
+			receiver:   "p",
+		},
+		{
+			name:       "serial primary key",
+			resource:   "Event",
+			tableName:  "events",
+			primaryKey: catalog.NewColumn("id", "bigserial").SetPrimaryKey(),
+			idType:     "int64",
+			receiver:   "e",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			cat := catalog.NewCatalog("public")
+			table := tableWithColumns(t, tt.tableName,
+				tt.primaryKey,
+				catalog.NewColumn("name", "text").SetNotNull(),
+			)
+			if err := cat.AddTable("public", table); err != nil {
+				t.Fatalf("add table: %v", err)
+			}
+
+			modelPath := filepath.Join(root, strings.ToLower(tt.resource)+".go")
+			if err := NewGenerator("postgresql").GenerateModel(cat, tt.resource, tt.tableName, modelPath, "example.com/app", "", "sql.Null", "id", false); err != nil {
+				t.Fatalf("generate model: %v", err)
+			}
+			content, err := os.ReadFile(modelPath)
+			if err != nil {
+				t.Fatalf("read generated model: %v", err)
+			}
+			generated := string(content)
+			signature := "func (" + tt.receiver + " " + strings.ToLower(tt.resource) + ") Upsert(ctx context.Context, db storage.Executor, id " + tt.idType + ", data Create" + tt.resource + "Data)"
+			upsertStart := strings.Index(generated, signature)
+			if upsertStart < 0 {
+				t.Fatalf("generated model missing explicit-ID Upsert signature %q:\n%s", signature, generated)
+			}
+			upsert := generated[upsertStart:]
+			if !strings.Contains(upsert, "ID: id,") {
+				t.Fatalf("generated Upsert does not assign the supplied primary key:\n%s", upsert)
+			}
+			if strings.Contains(upsert, "uuid.New()") {
+				t.Fatalf("generated Upsert replaces the supplied primary key:\n%s", upsert)
+			}
+		})
+	}
+}
+
+func TestGenerateModelPaginationPluralizesAcronymResourcesWithTableOverrides(t *testing.T) {
+	tests := map[string]string{
+		"ServerSSHCredential": "ServerSSHCredentials",
+		"WireGuardPeer":       "WireGuardPeers",
+		"WireGuardPeerStatus": "WireGuardPeerStatuses",
+	}
+	for resourceName, pluralName := range tests {
+		t.Run(resourceName, func(t *testing.T) {
+			root := t.TempDir()
+			tableName := "legacy_" + naming.ToSnakeCase(resourceName)
+			cat := catalog.NewCatalog("public")
+			table := tableWithColumns(t, tableName,
+				catalog.NewColumn("id", "uuid").SetPrimaryKey(),
+				catalog.NewColumn("name", "text").SetNotNull(),
+			)
+			if err := cat.AddTable("public", table); err != nil {
+				t.Fatalf("add table: %v", err)
+			}
+
+			modelPath := filepath.Join(root, naming.ToSnakeCase(resourceName)+".go")
+			if err := NewGenerator("postgresql").GenerateModel(cat, resourceName, naming.DeriveTableName(resourceName), modelPath, "example.com/app", tableName, "sql.Null", "id", false); err != nil {
+				t.Fatalf("generate model: %v", err)
+			}
+			content, err := os.ReadFile(modelPath)
+			if err != nil {
+				t.Fatalf("read generated model: %v", err)
+			}
+			generated := string(content)
+			for _, want := range []string{
+				"type Paginated" + pluralName + " struct",
+				pluralName + " []" + resourceName + "Entity",
+				") (Paginated" + pluralName + ", error)",
+			} {
+				if !strings.Contains(generated, want) {
+					t.Fatalf("generated pagination missing %q:\n%s", want, generated)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateModelCRUDUsesRepositoryNotFoundAndTimestampSemantics(t *testing.T) {
+	root := t.TempDir()
+	cat := catalog.NewCatalog("public")
+	table := tableWithColumns(t, "products",
+		catalog.NewColumn("id", "uuid").SetPrimaryKey(),
+		catalog.NewColumn("name", "text").SetNotNull(),
+		catalog.NewColumn("created_at", "timestamptz").SetNotNull(),
+		catalog.NewColumn("updated_at", "timestamptz").SetNotNull(),
+	)
+	if err := cat.AddTable("public", table); err != nil {
+		t.Fatalf("add table: %v", err)
+	}
+
+	modelPath := filepath.Join(root, "product.go")
+	if err := NewGenerator("postgresql").GenerateModel(cat, "Product", "products", modelPath, "example.com/app", "", "sql.Null", "id", false); err != nil {
+		t.Fatalf("generate model: %v", err)
+	}
+	content, err := os.ReadFile(modelPath)
+	if err != nil {
+		t.Fatalf("read generated model: %v", err)
+	}
+	generated := string(content)
+	if count := strings.Count(generated, "if errors.Is(err, sql.ErrNoRows) {"); count != 3 {
+		t.Fatalf("expected Find, Update, and Destroy not-found translation, got %d:\n%s", count, generated)
+	}
+	if count := strings.Count(generated, "return ProductEntity{}, ErrNotFound"); count != 2 {
+		t.Fatalf("expected Find and Update to return ErrNotFound, got %d:\n%s", count, generated)
+	}
+	destroyStart := strings.Index(generated, "func (p product) Destroy(")
+	allStart := strings.Index(generated, "func (p product) All(")
+	if destroyStart < 0 || allStart <= destroyStart {
+		t.Fatalf("could not isolate generated Destroy method:\n%s", generated)
+	}
+	destroy := generated[destroyStart:allStart]
+	if !strings.Contains(destroy, `Returning("*")`) || !strings.Contains(destroy, "Scan(ctx)") {
+		t.Fatalf("Destroy does not use DELETE RETURNING:\n%s", destroy)
+	}
+	if !strings.Contains(destroy, "return ErrNotFound") {
+		t.Fatalf("Destroy does not translate a missing row:\n%s", destroy)
+	}
+
+	updateDataStart := strings.Index(generated, "type UpdateProductData struct {")
+	updateMethodStart := strings.Index(generated, "func (p product) Update(")
+	if updateDataStart < 0 || updateMethodStart <= updateDataStart {
+		t.Fatalf("could not isolate generated UpdateProductData:\n%s", generated)
+	}
+	updateData := generated[updateDataStart:updateMethodStart]
+	if strings.Contains(updateData, "UpdatedAt") {
+		t.Fatalf("UpdateProductData exposes ignored UpdatedAt input:\n%s", updateData)
+	}
+	if !strings.Contains(generated[updateMethodStart:], "UpdatedAt: time.Now(),") {
+		t.Fatalf("Update does not manage UpdatedAt internally:\n%s", generated[updateMethodStart:])
+	}
+}
+
+func TestGenerateModelModesPersistAndRestrictGeneratedOperations(t *testing.T) {
+	tests := []struct {
+		mode    ModelMode
+		present []string
+		absent  []string
+	}{
+		{
+			mode:    ModelModeCRUD,
+			present: []string{" Find(", " Create(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert("},
+		},
+		{
+			mode:    ModelModeReadOnly,
+			present: []string{" Find(", " All(", " Paginate("},
+			absent:  []string{" Create(", " Update(", " Destroy(", " Upsert(", "type CreateProductData", "type UpdateProductData"},
+		},
+		{
+			mode:    ModelModeCreateOnly,
+			present: []string{" Create(", "type CreateProductData"},
+			absent:  []string{" Find(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert(", "type UpdateProductData"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			root := t.TempDir()
+			cat := catalog.NewCatalog("public")
+			table := tableWithColumns(t, "products",
+				catalog.NewColumn("id", "uuid").SetPrimaryKey(),
+				catalog.NewColumn("name", "text").SetNotNull(),
+			)
+			if err := cat.AddTable("public", table); err != nil {
+				t.Fatalf("add table: %v", err)
+			}
+
+			modelPath := filepath.Join(root, "product.go")
+			if err := NewGenerator("postgresql").GenerateModelWithMode(cat, "Product", "products", modelPath, "example.com/app", "", "sql.Null", "id", false, tt.mode); err != nil {
+				t.Fatalf("generate model: %v", err)
+			}
+			content, err := os.ReadFile(modelPath)
+			if err != nil {
+				t.Fatalf("read generated model: %v", err)
+			}
+			generated := string(content)
+			if !strings.Contains(generated, "// andurel:model-mode "+string(tt.mode)) {
+				t.Fatalf("generated model does not persist mode %q:\n%s", tt.mode, generated)
+			}
+			if strings.Contains(generated, "func (e *ProductEntity) Validate() error") {
+				t.Fatalf("generated model contains an empty Validate method:\n%s", generated)
+			}
+			for _, want := range tt.present {
+				if !strings.Contains(generated, want) {
+					t.Fatalf("%s model missing %q:\n%s", tt.mode, want, generated)
+				}
+			}
+			for _, unwanted := range tt.absent {
+				if strings.Contains(generated, unwanted) {
+					t.Fatalf("%s model contains %q:\n%s", tt.mode, unwanted, generated)
+				}
+			}
+		})
+	}
+}
+
 func TestGeneratorTemplateRenderingAndImports(t *testing.T) {
 	g := NewGenerator("postgresql")
 	model := &GeneratedModel{Name: "Product", PluralName: "Products", Fields: []GeneratedField{{Name: "Sku", BunTag: "sku,notnull"}}}
@@ -336,7 +560,7 @@ func TestBuildModelPrimaryKeyOverridesAndImports(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build model: %v", err)
 	}
-	if !model.HasPrimaryKey || model.IDFieldName != "tenant_id" || model.IDGoFieldName != "TenantID" || model.IDType != "uuid.UUID" {
+	if !model.HasPrimaryKey || model.IDFieldName != "tenant_id" || model.IDGoFieldName != "TenantId" || model.IDType != "uuid.UUID" {
 		t.Fatalf("primary key override was not applied: %#v", model)
 	}
 	if !model.HasCreatedAt || !model.HasUpdatedAt {

--- a/generator/models/generator_test.go
+++ b/generator/models/generator_test.go
@@ -394,40 +394,74 @@ func TestGenerateModelCRUDUsesRepositoryNotFoundAndTimestampSemantics(t *testing
 
 func TestGenerateModelModesPersistAndRestrictGeneratedOperations(t *testing.T) {
 	tests := []struct {
-		mode    ModelMode
-		present []string
-		absent  []string
+		name              string
+		mode              ModelMode
+		wantMode          ModelMode
+		modulePath        string
+		hasPrimaryKey     bool
+		generateWithoutPK bool
+		present           []string
+		absent            []string
 	}{
 		{
-			mode:    ModelModeCRUD,
-			present: []string{" Find(", " Create(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert("},
+			name:          "crud",
+			mode:          ModelModeCRUD,
+			wantMode:      ModelModeCRUD,
+			modulePath:    "example.com/app",
+			hasPrimaryKey: true,
+			present:       []string{" Find(", " Create(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert("},
 		},
 		{
-			mode:    ModelModeReadOnly,
-			present: []string{" Find(", " All(", " Paginate("},
-			absent:  []string{" Create(", " Update(", " Destroy(", " Upsert(", "type CreateProductData", "type UpdateProductData"},
+			name:          "read-only",
+			mode:          ModelModeReadOnly,
+			wantMode:      ModelModeReadOnly,
+			modulePath:    "example.com/app",
+			hasPrimaryKey: true,
+			present:       []string{" Find(", " All(", " Paginate("},
+			absent:        []string{" Create(", " Update(", " Destroy(", " Upsert(", "type CreateProductData", "type UpdateProductData"},
 		},
 		{
-			mode:    ModelModeCreateOnly,
-			present: []string{" Create(", "type CreateProductData"},
-			absent:  []string{" Find(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert(", "type UpdateProductData"},
+			name:          "create-only",
+			mode:          ModelModeCreateOnly,
+			wantMode:      ModelModeCreateOnly,
+			modulePath:    "example.com/app",
+			hasPrimaryKey: true,
+			present:       []string{" Create(", "type CreateProductData"},
+			absent:        []string{" Find(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert(", "type UpdateProductData"},
+		},
+		{
+			name:          "default mode",
+			wantMode:      ModelModeCRUD,
+			modulePath:    "example.com/app",
+			hasPrimaryKey: true,
+			present:       []string{" Find(", " Create(", " Update(", " Destroy(", " All(", " Paginate(", " Upsert("},
+		},
+		{
+			name:              "read-only without primary key",
+			mode:              ModelModeReadOnly,
+			wantMode:          ModelModeReadOnly,
+			modulePath:        "example.com/app",
+			generateWithoutPK: true,
+			present:           []string{" All(", " Paginate("},
+			absent:            []string{" Find(", " Create(", " Update(", " Destroy(", " Upsert(", "type CreateProductData", "type UpdateProductData"},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(string(tt.mode), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
 			cat := catalog.NewCatalog("public")
-			table := tableWithColumns(t, "products",
-				catalog.NewColumn("id", "uuid").SetPrimaryKey(),
-				catalog.NewColumn("name", "text").SetNotNull(),
-			)
+			columns := []*catalog.Column{catalog.NewColumn("name", "text").SetNotNull()}
+			if tt.hasPrimaryKey {
+				columns = append([]*catalog.Column{catalog.NewColumn("id", "uuid").SetPrimaryKey()}, columns...)
+			}
+			table := tableWithColumns(t, "products", columns...)
 			if err := cat.AddTable("public", table); err != nil {
 				t.Fatalf("add table: %v", err)
 			}
 
 			modelPath := filepath.Join(root, "product.go")
-			if err := NewGenerator("postgresql").GenerateModelWithMode(cat, "Product", "products", modelPath, "example.com/app", "", "sql.Null", "id", false, tt.mode); err != nil {
+			if err := NewGenerator("postgresql").GenerateModelWithMode(cat, "Product", "products", modelPath, tt.modulePath, "", "sql.Null", "id", tt.generateWithoutPK, tt.mode); err != nil {
 				t.Fatalf("generate model: %v", err)
 			}
 			content, err := os.ReadFile(modelPath)
@@ -435,8 +469,8 @@ func TestGenerateModelModesPersistAndRestrictGeneratedOperations(t *testing.T) {
 				t.Fatalf("read generated model: %v", err)
 			}
 			generated := string(content)
-			if !strings.Contains(generated, "// andurel:model-mode "+string(tt.mode)) {
-				t.Fatalf("generated model does not persist mode %q:\n%s", tt.mode, generated)
+			if !strings.Contains(generated, "// andurel:model-mode "+string(tt.wantMode)) {
+				t.Fatalf("generated model does not persist mode %q:\n%s", tt.wantMode, generated)
 			}
 			if strings.Contains(generated, "func (e *ProductEntity) Validate() error") {
 				t.Fatalf("generated model contains an empty Validate method:\n%s", generated)
@@ -453,6 +487,85 @@ func TestGenerateModelModesPersistAndRestrictGeneratedOperations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildModelWithoutModulePathOmitsApplicationImports(t *testing.T) {
+	cat := catalog.NewCatalog("public")
+	table := tableWithColumns(t, "products",
+		catalog.NewColumn("id", "uuid").SetPrimaryKey(),
+		catalog.NewColumn("name", "text").SetNotNull(),
+	)
+	if err := cat.AddTable("public", table); err != nil {
+		t.Fatalf("add table: %v", err)
+	}
+
+	model, err := NewGenerator("postgresql").Build(cat, Config{
+		TableName:        "products",
+		ResourceName:     "Product",
+		PackageName:      "models",
+		DatabaseType:     "postgresql",
+		PrimaryKeyColumn: "id",
+	})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if model.Mode != ModelModeCRUD {
+		t.Fatalf("Build() mode = %q, want %q", model.Mode, ModelModeCRUD)
+	}
+	for _, applicationImport := range []string{"/internal/storage", "/internal/validation"} {
+		for _, modelImport := range model.ExternalImports {
+			if strings.HasSuffix(modelImport, applicationImport) {
+				t.Fatalf("Build() imports application package without a module path: %q", modelImport)
+			}
+		}
+	}
+}
+
+func TestGenerateModelWithModeReportsPlanningAndWriteFailures(t *testing.T) {
+	t.Run("planning failure", func(t *testing.T) {
+		err := NewGenerator("postgresql").GenerateModelWithMode(
+			catalog.NewCatalog("public"),
+			"Product",
+			"products",
+			filepath.Join(t.TempDir(), "product.go"),
+			"example.com/app",
+			"",
+			"sql.Null",
+			"id",
+			false,
+			ModelModeCRUD,
+		)
+		if err == nil || !strings.Contains(err.Error(), "failed to build model") {
+			t.Fatalf("GenerateModelWithMode() error = %v, want planning failure", err)
+		}
+	})
+
+	t.Run("write failure", func(t *testing.T) {
+		cat := catalog.NewCatalog("public")
+		table := tableWithColumns(t, "products",
+			catalog.NewColumn("id", "uuid").SetPrimaryKey(),
+			catalog.NewColumn("name", "text").SetNotNull(),
+		)
+		if err := cat.AddTable("public", table); err != nil {
+			t.Fatalf("add table: %v", err)
+		}
+
+		err := NewGenerator("postgresql").GenerateModelWithMode(
+			cat,
+			"Product",
+			"products",
+			filepath.Join(t.TempDir(), "missing", "product.go"),
+			"example.com/app",
+			"",
+			"sql.Null",
+			"id",
+			false,
+			ModelModeCRUD,
+		)
+		if err == nil || !strings.Contains(err.Error(), "failed to write model file") {
+			t.Fatalf("GenerateModelWithMode() error = %v, want write failure", err)
+		}
+	})
 }
 
 func TestGeneratorTemplateRenderingAndImports(t *testing.T) {

--- a/generator/models/generator_test.go
+++ b/generator/models/generator_test.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"slices"
@@ -229,7 +232,11 @@ func TestGenerateModelUpsertRequiresExplicitPrimaryKey(t *testing.T) {
 				t.Fatalf("generated model missing explicit-ID Upsert signature %q:\n%s", signature, generated)
 			}
 			upsert := generated[upsertStart:]
-			if !strings.Contains(upsert, "ID: id,") {
+			assignsPrimaryKey, err := functionCompositeLiteralAssignsIdentifier(generated, "Upsert", "entity", "ID", "id")
+			if err != nil {
+				t.Fatalf("parse generated model: %v", err)
+			}
+			if !assignsPrimaryKey {
 				t.Fatalf("generated Upsert does not assign the supplied primary key:\n%s", upsert)
 			}
 			if strings.Contains(upsert, "uuid.New()") {
@@ -237,6 +244,56 @@ func TestGenerateModelUpsertRequiresExplicitPrimaryKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func functionCompositeLiteralAssignsIdentifier(source, functionName, variableName, fieldName, identifierName string) (bool, error) {
+	file, err := parser.ParseFile(token.NewFileSet(), "", source, 0)
+	if err != nil {
+		return false, err
+	}
+
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != functionName || function.Body == nil {
+			continue
+		}
+
+		assigned := false
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			assignment, ok := node.(*ast.AssignStmt)
+			if !ok || len(assignment.Lhs) != 1 || len(assignment.Rhs) != 1 {
+				return true
+			}
+
+			variable, ok := assignment.Lhs[0].(*ast.Ident)
+			if !ok || variable.Name != variableName {
+				return true
+			}
+
+			literal, ok := assignment.Rhs[0].(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+
+			for _, element := range literal.Elts {
+				field, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, keyOK := field.Key.(*ast.Ident)
+				value, valueOK := field.Value.(*ast.Ident)
+				if keyOK && valueOK && key.Name == fieldName && value.Name == identifierName {
+					assigned = true
+					return false
+				}
+			}
+
+			return true
+		})
+		return assigned, nil
+	}
+
+	return false, nil
 }
 
 func TestGenerateModelPaginationPluralizesAcronymResourcesWithTableOverrides(t *testing.T) {

--- a/generator/pk_detection_test.go
+++ b/generator/pk_detection_test.go
@@ -38,7 +38,7 @@ func TestDetectPrimaryKey(t *testing.T) {
 			),
 			want: PrimaryKeyInfo{
 				ColumnName:  "order_id",
-				GoFieldName: "OrderID",
+				GoFieldName: "OrderId",
 				DataType:    "uuid",
 				GoType:      "uuid.UUID",
 				Found:       true,

--- a/generator/templates/controller_test.tmpl
+++ b/generator/templates/controller_test.tmpl
@@ -89,7 +89,7 @@ func Test{{Plural .ResourceName}}_Show(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.SetPathValues(echo.PathValues{{`{{`}}Name: "id", Value: {{.ResourceName | ToLowerCamelCase}}.ID.String(){{`}}`}})
+	c.SetPathValues(echo.PathValues{{`{{`}}Name: "id", Value: {{.ResourceName | ToLowerCamelCase}}.{{.IDGoFieldName}}.String(){{`}}`}})
 
 	err := controller.Show(c)
 	if err != nil {

--- a/generator/templates/css_components_resource_view.tmpl
+++ b/generator/templates/css_components_resource_view.tmpl
@@ -55,10 +55,10 @@ templ ({{$indexRecv}} {{.NamespacePascal}}{{.ResourceName}}Index) Page() {
 											{{end}}<td>
 												<div class="flex flex-wrap gap-3 text-sm">
 													{{if HasAction "show"}}
-													<a class="inline-link" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Show.URL({{$.ResourceName | ToLower}}.ID) }>View</a>
+													<a class="inline-link" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Show.URL({{$.ResourceName | ToLower}}.{{$.IDFieldName}}) }>View</a>
 													{{end}}
 													{{if HasAction "edit"}}
-													<a class="inline-link" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Edit.URL({{$.ResourceName | ToLower}}.ID) }>Edit</a>
+													<a class="inline-link" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Edit.URL({{$.ResourceName | ToLower}}.{{$.IDFieldName}}) }>Edit</a>
 													{{end}}
 												</div>
 											</td>
@@ -93,7 +93,7 @@ templ ({{$showRecv}} {{.NamespacePascal}}{{.ResourceName}}Show) Page() {
 						<h1 class="text-2xl font-semibold tracking-normal text-base-content">{{.ResourceName}} Details</h1>
 						<div class="flex flex-wrap items-center gap-3">
 							{{if HasAction "edit"}}
-							<a href={ routes.{{.NamespacePascal}}{{.ResourceName}}Edit.URL({{$showRecv}}.Item.ID) } class="btn btn-primary">Edit</a>
+							<a href={ routes.{{.NamespacePascal}}{{.ResourceName}}Edit.URL({{$showRecv}}.Item.{{.IDFieldName}}) } class="btn btn-primary">Edit</a>
 							{{end}}
 							{{if HasAction "index"}}
 							<a class="inline-link text-sm" href={ hypermedia.ResolveBackURL(ctx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL()) }>Back to List</a>
@@ -200,7 +200,7 @@ templ ({{$editRecv}} {{.NamespacePascal}}{{.ResourceName}}Edit) Page() {
 							<p class="card-description">Update the details for this {{.ResourceName | ToLower}}.</p>
 						</div>
 						<div class="card-content">
-							<form class="form" data-indicator:_submitting{{if HasAction "update"}} data-on:submit={ hypermedia.DataAction(http.MethodPut, routes.{{.NamespacePascal}}{{.ResourceName}}Update.URL({{$editRecv}}.Item.ID)) }{{end}}>
+							<form class="form" data-indicator:_submitting{{if HasAction "update"}} data-on:submit={ hypermedia.DataAction(http.MethodPut, routes.{{.NamespacePascal}}{{.ResourceName}}Update.URL({{$editRecv}}.Item.{{.IDFieldName}})) }{{end}}>
 								<fieldset class="fieldset" data-attr:disabled="$_submitting">
 									{{$itemRef := printf "%s.%s" $editRecv "Item"}}{{$itemDisplayRef := ViewDataRef $.NamespacePascal .ResourceName $itemRef (HasNullFields .Fields)}}
 									{{range .Fields}}{{if not .IsSystemField}}{{if eq .InputType "checkbox"}}<div class="radio-row">
@@ -236,7 +236,7 @@ templ ({{$editRecv}} {{.NamespacePascal}}{{.ResourceName}}Edit) Page() {
 								</fieldset>
 							</form>
 							{{if HasAction "destroy"}}<div class="separator my-6"></div>
-							<button type="button" class="btn btn-destructive btn-block" data-on:click={ hypermedia.DataAction(http.MethodDelete, routes.{{.NamespacePascal}}{{.ResourceName}}Destroy.URL({{$editRecv}}.Item.ID)) }>Destroy {{.ResourceName}}</button>
+							<button type="button" class="btn btn-destructive btn-block" data-on:click={ hypermedia.DataAction(http.MethodDelete, routes.{{.NamespacePascal}}{{.ResourceName}}Destroy.URL({{$editRecv}}.Item.{{.IDFieldName}})) }>Destroy {{.ResourceName}}</button>
 							{{end}}
 						</div>
 					</div>

--- a/generator/templates/model.tmpl
+++ b/generator/templates/model.tmpl
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode {{.Mode}}
+
 import (
 {{- range .StandardImports}}
 	"{{.}}"
@@ -19,17 +21,17 @@ type {{.EntityName}} struct {
 {{- end}}
 }
 
-func (e *{{.EntityName}}) Validate() error {
-	return nil
-}
-
-{{if .HasPrimaryKey}}
+{{if and .HasPrimaryKey (ne .Mode "create-only")}}
 func ({{.ReceiverName}} {{.NamespaceType}}) Find(ctx context.Context, db storage.Executor, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}) ({{.EntityName}}, error) {
 	var entity {{.EntityName}}
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("{{.IDFieldName}} = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return {{.EntityName}}{}, ErrNotFound
+		}
 		return {{.EntityName}}{}, err
 	}
 
@@ -37,6 +39,7 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Find(ctx context.Context, db storage
 }
 {{end}}
 
+{{if ne .Mode "read-only"}}
 type Create{{.Name}}Data struct {
 {{- range .Fields}}
 {{- if and (not .IsPrimaryKey) (ne .Name "CreatedAt") (ne .Name "UpdatedAt")}}
@@ -84,12 +87,13 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Create(ctx context.Context, db stora
 
 	return entity, nil
 }
+{{end}}
 
-{{if .HasPrimaryKey}}
+{{if and .HasPrimaryKey (eq .Mode "crud")}}
 type Update{{.Name}}Data struct {
 	{{.IDGoFieldName}} {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}
 {{- range .Fields}}
-{{- if and (not .IsPrimaryKey) (ne .Name "CreatedAt")}}
+{{- if and (not .IsPrimaryKey) (ne .Name "CreatedAt") (ne .Name "UpdatedAt")}}
 	{{.Name}} {{.Type}}
 {{- end}}
 {{- end}}
@@ -112,7 +116,7 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Update(ctx context.Context, db stora
 		return {{.EntityName}}{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 {{- range .Fields}}
 {{- if and (not .IsPrimaryKey) (ne .Name "CreatedAt")}}
@@ -121,7 +125,11 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Update(ctx context.Context, db stora
 {{- end}}
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return {{.EntityName}}{}, ErrNotFound
+		}
 		return {{.EntityName}}{}, err
 	}
 
@@ -129,15 +137,24 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Update(ctx context.Context, db stora
 }
 
 func ({{.ReceiverName}} {{.NamespaceType}}) Destroy(ctx context.Context, db storage.Executor, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}) error {
-	_, err := db.NewDelete().
-		Model((*{{.EntityName}})(nil)).
+	var entity {{.EntityName}}
+	err := db.NewDelete().
+		Model(&entity).
 		Where("{{.IDFieldName}} = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 {{end}}
 
+{{if ne .Mode "create-only"}}
 func ({{.ReceiverName}} {{.NamespaceType}}) All(ctx context.Context, db storage.Executor) ([]{{.EntityName}}, error) {
 	var entities []{{.EntityName}}
 	if err := db.NewSelect().
@@ -196,17 +213,12 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Paginate(ctx context.Context, db sto
 		TotalPages: totalPages,
 	}, nil
 }
+{{end}}
 
-{{if .HasPrimaryKey}}
-func ({{.ReceiverName}} {{.NamespaceType}}) Upsert(ctx context.Context, db storage.Executor, data Create{{.Name}}Data) ({{.EntityName}}, error) {
+{{if and .HasPrimaryKey (eq .Mode "crud")}}
+func ({{.ReceiverName}} {{.NamespaceType}}) Upsert(ctx context.Context, db storage.Executor, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}, data Create{{.Name}}Data) ({{.EntityName}}, error) {
 	entity := {{.EntityName}}{
-{{- if not .IsAutoIncrementID}}
-{{- if or (not .IDType) (eq .IDType "uuid.UUID")}}
-		{{.IDGoFieldName}}: uuid.New(),
-{{- else}}
-		{{.IDGoFieldName}}: data.{{.IDGoFieldName}},
-{{- end}}
-{{- end}}
+		{{.IDGoFieldName}}: id,
 {{- if .HasCreatedAt}}
 		CreatedAt: time.Now(),
 {{- end}}

--- a/generator/templates/resource_view.tmpl
+++ b/generator/templates/resource_view.tmpl
@@ -55,10 +55,10 @@ templ ({{$indexRecv}} {{.NamespacePascal}}{{.ResourceName}}Index) Page() {
 											{{end}}<td class="p-4 align-middle [&:has([role=checkbox])]:pr-0">
 												<div class="flex flex-wrap gap-3 text-sm">
 													{{if HasAction "show"}}
-													<a class="text-slate-300 hover:text-slate-100" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Show.URL({{$.ResourceName | ToLower}}.ID) }>View</a>
+													<a class="text-slate-300 hover:text-slate-100" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Show.URL({{$.ResourceName | ToLower}}.{{$.IDFieldName}}) }>View</a>
 													{{end}}
 													{{if HasAction "edit"}}
-													<a class="text-slate-300 hover:text-slate-100" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Edit.URL({{$.ResourceName | ToLower}}.ID) }>Edit</a>
+													<a class="text-slate-300 hover:text-slate-100" href={ routes.{{$.NamespacePascal}}{{$.ResourceName}}Edit.URL({{$.ResourceName | ToLower}}.{{$.IDFieldName}}) }>Edit</a>
 													{{end}}
 												</div>
 											</td>
@@ -93,7 +93,7 @@ templ ({{$showRecv}} {{.NamespacePascal}}{{.ResourceName}}Show) Page() {
 						<h1 class="text-2xl font-semibold text-slate-100">{{.ResourceName}} Details</h1>
 						<div class="flex flex-wrap items-center gap-3">
 							{{if HasAction "edit"}}
-							<a href={ routes.{{.NamespacePascal}}{{.ResourceName}}Edit.URL({{$showRecv}}.Item.ID) } class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40 disabled:opacity-60 disabled:cursor-not-allowed bg-cyan-400 text-slate-950 shadow-sm hover:bg-cyan-300 h-9 px-4 py-2 text-sm rounded">Edit</a>
+							<a href={ routes.{{.NamespacePascal}}{{.ResourceName}}Edit.URL({{$showRecv}}.Item.{{.IDFieldName}}) } class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40 disabled:opacity-60 disabled:cursor-not-allowed bg-cyan-400 text-slate-950 shadow-sm hover:bg-cyan-300 h-9 px-4 py-2 text-sm rounded">Edit</a>
 							{{end}}
 							{{if HasAction "index"}}
 							<a class="text-sm text-slate-300 hover:text-slate-100" href={ hypermedia.ResolveBackURL(ctx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL()) }>Back to List</a>
@@ -202,7 +202,7 @@ templ ({{$editRecv}} {{.NamespacePascal}}{{.ResourceName}}Edit) Page() {
 							<p class="text-sm text-slate-400">Update the details for this {{.ResourceName | ToLower}}.</p>
 						</div>
 						<div class="p-6 pt-0">
-							<form class="space-y-5" data-indicator:_submitting{{if HasAction "update"}} data-on:submit={ hypermedia.DataAction(http.MethodPut, routes.{{.NamespacePascal}}{{.ResourceName}}Update.URL({{$editRecv}}.Item.ID)) }{{end}}>
+							<form class="space-y-5" data-indicator:_submitting{{if HasAction "update"}} data-on:submit={ hypermedia.DataAction(http.MethodPut, routes.{{.NamespacePascal}}{{.ResourceName}}Update.URL({{$editRecv}}.Item.{{.IDFieldName}})) }{{end}}>
 								<fieldset data-attr:disabled="$_submitting">
 									<div class="space-y-4">
 										{{$itemRef := printf "%s.%s" $editRecv "Item"}}{{$itemDisplayRef := ViewDataRef $.NamespacePascal .ResourceName $itemRef (HasNullFields .Fields)}}
@@ -240,7 +240,7 @@ templ ({{$editRecv}} {{.NamespacePascal}}{{.ResourceName}}Edit) Page() {
 								</fieldset>
 							</form>
 							{{if HasAction "destroy"}}<div role="separator" class="my-6 shrink-0 bg-slate-800 h-px w-full"></div>
-							<button type="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40 disabled:opacity-60 disabled:cursor-not-allowed bg-red-600 text-white shadow-sm hover:bg-red-700 h-9 px-4 py-2 text-sm rounded w-full" data-on:click={ hypermedia.DataAction(http.MethodDelete, routes.{{.NamespacePascal}}{{.ResourceName}}Destroy.URL({{$editRecv}}.Item.ID)) }>Destroy {{.ResourceName}}</button>
+							<button type="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40 disabled:opacity-60 disabled:cursor-not-allowed bg-red-600 text-white shadow-sm hover:bg-red-700 h-9 px-4 py-2 text-sm rounded w-full" data-on:click={ hypermedia.DataAction(http.MethodDelete, routes.{{.NamespacePascal}}{{.ResourceName}}Destroy.URL({{$editRecv}}.Item.{{.IDFieldName}})) }>Destroy {{.ResourceName}}</button>
 							{{end}}
 						</div>
 					</div>

--- a/generator/testdata/golden/models/audit_log_no_pk.golden
+++ b/generator/testdata/golden/models/audit_log_no_pk.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"encoding/json"
@@ -14,33 +16,29 @@ import (
 
 type AuditLogEntity struct {
 	bun.BaseModel `bun:"table:audit_logs,alias:audit_logs"`
-	EventID       uuid.UUID       `bun:"event_id,type:uuid"`
+	EventId       uuid.UUID       `bun:"event_id,type:uuid"`
 	Action        string          `bun:"action"`
 	EntityType    string          `bun:"entity_type"`
-	EntityID      uuid.UUID       `bun:"entity_id,type:uuid"`
+	EntityId      uuid.UUID       `bun:"entity_id,type:uuid"`
 	Payload       json.RawMessage `bun:"payload,type:jsonb"`
 	OccurredAt    time.Time       `bun:"occurred_at"`
 }
 
-func (e *AuditLogEntity) Validate() error {
-	return nil
-}
-
 type CreateAuditLogData struct {
-	EventID    uuid.UUID
+	EventId    uuid.UUID
 	Action     string
 	EntityType string
-	EntityID   uuid.UUID
+	EntityId   uuid.UUID
 	Payload    json.RawMessage
 	OccurredAt time.Time
 }
 
 func (al auditLog) Create(ctx context.Context, db storage.Executor, data CreateAuditLogData) (AuditLogEntity, error) {
 	entity := AuditLogEntity{
-		EventID:    data.EventID,
+		EventId:    data.EventId,
 		Action:     data.Action,
 		EntityType: data.EntityType,
-		EntityID:   data.EntityID,
+		EntityId:   data.EntityId,
 		Payload:    data.Payload,
 		OccurredAt: data.OccurredAt,
 	}

--- a/generator/testdata/golden/models/event_metric_no_pk_no_uuid.golden
+++ b/generator/testdata/golden/models/event_metric_no_pk_no_uuid.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"errors"
@@ -17,10 +19,6 @@ type EventMetricEntity struct {
 	EventCount    int32     `bun:"event_count"`
 	Successful    bool      `bun:"successful"`
 	OccurredAt    time.Time `bun:"occurred_at"`
-}
-
-func (e *EventMetricEntity) Validate() error {
-	return nil
 }
 
 type CreateEventMetricData struct {

--- a/generator/testdata/golden/models/order_custom_pk.golden
+++ b/generator/testdata/golden/models/order_custom_pk.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"database/sql"
@@ -14,8 +16,8 @@ import (
 
 type OrderEntity struct {
 	bun.BaseModel `bun:"table:orders,alias:orders"`
-	OrderID       uuid.UUID    `bun:"order_id,pk,type:uuid"`
-	CustomerID    uuid.UUID    `bun:"customer_id,type:uuid"`
+	OrderId       uuid.UUID    `bun:"order_id,pk,type:uuid"`
+	CustomerId    uuid.UUID    `bun:"customer_id,type:uuid"`
 	Reference     string       `bun:"reference"`
 	TotalCents    int64        `bun:"total_cents"`
 	Status        string       `bun:"status"`
@@ -24,16 +26,16 @@ type OrderEntity struct {
 	UpdatedAt     time.Time    `bun:"updated_at"`
 }
 
-func (e *OrderEntity) Validate() error {
-	return nil
-}
-
 func (o order) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (OrderEntity, error) {
 	var entity OrderEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("order_id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return OrderEntity{}, ErrNotFound
+		}
 		return OrderEntity{}, err
 	}
 
@@ -41,7 +43,7 @@ func (o order) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (Ord
 }
 
 type CreateOrderData struct {
-	CustomerID uuid.UUID
+	CustomerId uuid.UUID
 	Reference  string
 	TotalCents int64
 	Status     string
@@ -50,10 +52,10 @@ type CreateOrderData struct {
 
 func (o order) Create(ctx context.Context, db storage.Executor, data CreateOrderData) (OrderEntity, error) {
 	entity := OrderEntity{
-		OrderID:    uuid.New(),
+		OrderId:    uuid.New(),
 		CreatedAt:  time.Now(),
 		UpdatedAt:  time.Now(),
-		CustomerID: data.CustomerID,
+		CustomerId: data.CustomerId,
 		Reference:  data.Reference,
 		TotalCents: data.TotalCents,
 		Status:     data.Status,
@@ -72,20 +74,19 @@ func (o order) Create(ctx context.Context, db storage.Executor, data CreateOrder
 }
 
 type UpdateOrderData struct {
-	OrderID    uuid.UUID
-	CustomerID uuid.UUID
+	OrderId    uuid.UUID
+	CustomerId uuid.UUID
 	Reference  string
 	TotalCents int64
 	Status     string
 	PlacedAt   sql.NullTime
-	UpdatedAt  time.Time
 }
 
 func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrderData) (OrderEntity, error) {
 	entity := OrderEntity{
-		OrderID:    data.OrderID,
+		OrderId:    data.OrderId,
 		UpdatedAt:  time.Now(),
-		CustomerID: data.CustomerID,
+		CustomerId: data.CustomerId,
 		Reference:  data.Reference,
 		TotalCents: data.TotalCents,
 		Status:     data.Status,
@@ -96,7 +97,7 @@ func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrder
 		return OrderEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("customer_id").
 		Column("reference").
@@ -106,7 +107,11 @@ func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrder
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return OrderEntity{}, ErrNotFound
+		}
 		return OrderEntity{}, err
 	}
 
@@ -114,12 +119,20 @@ func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrder
 }
 
 func (o order) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*OrderEntity)(nil)).
+	var entity OrderEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("order_id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (o order) All(ctx context.Context, db storage.Executor) ([]OrderEntity, error) {
@@ -180,12 +193,12 @@ func (o order) Paginate(ctx context.Context, db storage.Executor, page, pageSize
 	}, nil
 }
 
-func (o order) Upsert(ctx context.Context, db storage.Executor, data CreateOrderData) (OrderEntity, error) {
+func (o order) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateOrderData) (OrderEntity, error) {
 	entity := OrderEntity{
-		OrderID:    uuid.New(),
+		OrderId:    id,
 		CreatedAt:  time.Now(),
 		UpdatedAt:  time.Now(),
-		CustomerID: data.CustomerID,
+		CustomerId: data.CustomerId,
 		Reference:  data.Reference,
 		TotalCents: data.TotalCents,
 		Status:     data.Status,

--- a/generator/testdata/golden/models/product_initial.golden
+++ b/generator/testdata/golden/models/product_initial.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"database/sql"
@@ -31,16 +33,16 @@ type ProductEntity struct {
 	UpdatedAt     time.Time       `bun:"updated_at"`
 }
 
-func (e *ProductEntity) Validate() error {
-	return nil
-}
-
 func (p product) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (ProductEntity, error) {
 	var entity ProductEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProductEntity{}, ErrNotFound
+		}
 		return ProductEntity{}, err
 	}
 
@@ -103,7 +105,6 @@ type UpdateProductData struct {
 	Metadata    json.RawMessage
 	Attributes  json.RawMessage
 	LaunchedAt  sql.NullTime
-	UpdatedAt   time.Time
 }
 
 func (p product) Update(ctx context.Context, db storage.Executor, data UpdateProductData) (ProductEntity, error) {
@@ -127,7 +128,7 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("sku").
 		Column("name").
@@ -143,7 +144,11 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProductEntity{}, ErrNotFound
+		}
 		return ProductEntity{}, err
 	}
 
@@ -151,12 +156,20 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 }
 
 func (p product) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*ProductEntity)(nil)).
+	var entity ProductEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (p product) All(ctx context.Context, db storage.Executor) ([]ProductEntity, error) {
@@ -217,9 +230,9 @@ func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (p product) Upsert(ctx context.Context, db storage.Executor, data CreateProductData) (ProductEntity, error) {
+func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateProductData) (ProductEntity, error) {
 	entity := ProductEntity{
-		ID:          uuid.New(),
+		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 		Sku:         data.Sku,

--- a/generator/testdata/golden/models/product_updated.golden
+++ b/generator/testdata/golden/models/product_updated.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"database/sql"
@@ -33,16 +35,16 @@ type ProductEntity struct {
 	Rating      float64         `bun:"rating"`
 }
 
-func (e *ProductEntity) Validate() error {
-	return nil
-}
-
 func (p product) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (ProductEntity, error) {
 	var entity ProductEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProductEntity{}, ErrNotFound
+		}
 		return ProductEntity{}, err
 	}
 
@@ -105,7 +107,6 @@ type UpdateProductData struct {
 	Metadata    json.RawMessage
 	Attributes  json.RawMessage
 	LaunchedAt  sql.NullTime
-	UpdatedAt   time.Time
 }
 
 func (p product) Update(ctx context.Context, db storage.Executor, data UpdateProductData) (ProductEntity, error) {
@@ -129,7 +130,7 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("sku").
 		Column("name").
@@ -145,7 +146,11 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProductEntity{}, ErrNotFound
+		}
 		return ProductEntity{}, err
 	}
 
@@ -153,12 +158,20 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 }
 
 func (p product) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*ProductEntity)(nil)).
+	var entity ProductEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (p product) All(ctx context.Context, db storage.Executor) ([]ProductEntity, error) {
@@ -219,9 +232,9 @@ func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (p product) Upsert(ctx context.Context, db storage.Executor, data CreateProductData) (ProductEntity, error) {
+func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateProductData) (ProductEntity, error) {
 	entity := ProductEntity{
-		ID:          uuid.New(),
+		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 		Sku:         data.Sku,

--- a/generator/testdata/golden/scaffold/array_fields/models/document.go.golden
+++ b/generator/testdata/golden/scaffold/array_fields/models/document.go.golden
@@ -1,7 +1,10 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testapp/internal/storage"
 	"testapp/internal/validation"
@@ -23,16 +26,16 @@ type DocumentEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (e *DocumentEntity) Validate() error {
-	return nil
-}
-
 func (d document) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (DocumentEntity, error) {
 	var entity DocumentEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DocumentEntity{}, ErrNotFound
+		}
 		return DocumentEntity{}, err
 	}
 
@@ -77,7 +80,6 @@ type UpdateDocumentData struct {
 	PageNumbers []int32
 	ViewCount   int32
 	IsPublished bool
-	UpdatedAt   time.Time
 }
 
 func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDocumentData) (DocumentEntity, error) {
@@ -95,7 +97,7 @@ func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDo
 		return DocumentEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("title").
 		Column("tags").
@@ -105,7 +107,11 @@ func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDo
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DocumentEntity{}, ErrNotFound
+		}
 		return DocumentEntity{}, err
 	}
 
@@ -113,12 +119,20 @@ func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDo
 }
 
 func (d document) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*DocumentEntity)(nil)).
+	var entity DocumentEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (d document) All(ctx context.Context, db storage.Executor) ([]DocumentEntity, error) {
@@ -179,9 +193,9 @@ func (d document) Paginate(ctx context.Context, db storage.Executor, page, pageS
 	}, nil
 }
 
-func (d document) Upsert(ctx context.Context, db storage.Executor, data CreateDocumentData) (DocumentEntity, error) {
+func (d document) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateDocumentData) (DocumentEntity, error) {
 	entity := DocumentEntity{
-		ID:          uuid.New(),
+		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 		Title:       data.Title,

--- a/generator/testdata/golden/scaffold/custom_primary_key/models/warehouse.go.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/models/warehouse.go.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"database/sql"
@@ -20,16 +22,16 @@ type WarehouseEntity struct {
 	UpdatedAt     time.Time      `bun:"updated_at"`
 }
 
-func (e *WarehouseEntity) Validate() error {
-	return nil
-}
-
 func (w warehouse) Find(ctx context.Context, db storage.Executor, id string) (WarehouseEntity, error) {
 	var entity WarehouseEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("slug = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WarehouseEntity{}, ErrNotFound
+		}
 		return WarehouseEntity{}, err
 	}
 
@@ -63,10 +65,9 @@ func (w warehouse) Create(ctx context.Context, db storage.Executor, data CreateW
 }
 
 type UpdateWarehouseData struct {
-	Slug      string
-	Name      string
-	Location  sql.NullString
-	UpdatedAt time.Time
+	Slug     string
+	Name     string
+	Location sql.NullString
 }
 
 func (w warehouse) Update(ctx context.Context, db storage.Executor, data UpdateWarehouseData) (WarehouseEntity, error) {
@@ -81,14 +82,18 @@ func (w warehouse) Update(ctx context.Context, db storage.Executor, data UpdateW
 		return WarehouseEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("location").
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WarehouseEntity{}, ErrNotFound
+		}
 		return WarehouseEntity{}, err
 	}
 
@@ -96,12 +101,20 @@ func (w warehouse) Update(ctx context.Context, db storage.Executor, data UpdateW
 }
 
 func (w warehouse) Destroy(ctx context.Context, db storage.Executor, id string) error {
-	_, err := db.NewDelete().
-		Model((*WarehouseEntity)(nil)).
+	var entity WarehouseEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("slug = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (w warehouse) All(ctx context.Context, db storage.Executor) ([]WarehouseEntity, error) {
@@ -162,9 +175,9 @@ func (w warehouse) Paginate(ctx context.Context, db storage.Executor, page, page
 	}, nil
 }
 
-func (w warehouse) Upsert(ctx context.Context, db storage.Executor, data CreateWarehouseData) (WarehouseEntity, error) {
+func (w warehouse) Upsert(ctx context.Context, db storage.Executor, id string, data CreateWarehouseData) (WarehouseEntity, error) {
 	entity := WarehouseEntity{
-		Slug:      data.Slug,
+		Slug:      id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Name:      data.Name,

--- a/generator/testdata/golden/scaffold/custom_primary_key/views/warehouses_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/views/warehouses_resource.templ.golden
@@ -78,10 +78,10 @@ templ (wi WarehouseIndex) Page() {
 											<td class="p-4 align-middle [&:has([role=checkbox])]:pr-0">
 												<div class="flex flex-wrap gap-3 text-sm">
 													
-													<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseShow.URL(warehouse.ID) }>View</a>
+											<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseShow.URL(warehouse.Slug) }>View</a>
 													
 													
-													<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseEdit.URL(warehouse.ID) }>Edit</a>
+											<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseEdit.URL(warehouse.Slug) }>Edit</a>
 													
 												</div>
 											</td>
@@ -116,7 +116,7 @@ templ (ws WarehouseShow) Page() {
 						<h1 class="text-2xl font-semibold text-slate-100">Warehouse Details</h1>
 						<div class="flex flex-wrap items-center gap-3">
 							
-							<a href={ routes.WarehouseEdit.URL(ws.Item.ID) } class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40 disabled:opacity-60 disabled:cursor-not-allowed bg-cyan-400 text-slate-950 shadow-sm hover:bg-cyan-300 h-9 px-4 py-2 text-sm rounded">Edit</a>
+							<a href={ routes.WarehouseEdit.URL(ws.Item.Slug) } class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40 disabled:opacity-60 disabled:cursor-not-allowed bg-cyan-400 text-slate-950 shadow-sm hover:bg-cyan-300 h-9 px-4 py-2 text-sm rounded">Edit</a>
 							
 							
 							<a class="text-sm text-slate-300 hover:text-slate-100" href={ hypermedia.ResolveBackURL(ctx, routes.WarehouseIndex.URL()) }>Back to List</a>
@@ -222,7 +222,7 @@ templ (we WarehouseEdit) Page() {
 							<p class="text-sm text-slate-400">Update the details for this warehouse.</p>
 						</div>
 						<div class="p-6 pt-0">
-							<form class="space-y-5" data-indicator:_submitting data-on:submit={ hypermedia.DataAction(http.MethodPut, routes.WarehouseUpdate.URL(we.Item.ID)) }>
+							<form class="space-y-5" data-indicator:_submitting data-on:submit={ hypermedia.DataAction(http.MethodPut, routes.WarehouseUpdate.URL(we.Item.Slug)) }>
 								<fieldset data-attr:disabled="$_submitting">
 									<div class="space-y-4">
 										
@@ -245,7 +245,7 @@ templ (we WarehouseEdit) Page() {
 								</fieldset>
 							</form>
 							<div role="separator" class="my-6 shrink-0 bg-slate-800 h-px w-full"></div>
-							<button type="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40 disabled:opacity-60 disabled:cursor-not-allowed bg-red-600 text-white shadow-sm hover:bg-red-700 h-9 px-4 py-2 text-sm rounded w-full" data-on:click={ hypermedia.DataAction(http.MethodDelete, routes.WarehouseDestroy.URL(we.Item.ID)) }>Destroy Warehouse</button>
+							<button type="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40 disabled:opacity-60 disabled:cursor-not-allowed bg-red-600 text-white shadow-sm hover:bg-red-700 h-9 px-4 py-2 text-sm rounded w-full" data-on:click={ hypermedia.DataAction(http.MethodDelete, routes.WarehouseDestroy.URL(we.Item.Slug)) }>Destroy Warehouse</button>
 							
 						</div>
 					</div>
@@ -254,4 +254,3 @@ templ (we WarehouseEdit) Page() {
 		}
 	}
 }
-

--- a/generator/testdata/golden/scaffold/custom_primary_key/views/warehouses_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/views/warehouses_resource.templ.golden
@@ -78,10 +78,10 @@ templ (wi WarehouseIndex) Page() {
 											<td class="p-4 align-middle [&:has([role=checkbox])]:pr-0">
 												<div class="flex flex-wrap gap-3 text-sm">
 													
-											<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseShow.URL(warehouse.Slug) }>View</a>
+													<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseShow.URL(warehouse.Slug) }>View</a>
 													
 													
-											<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseEdit.URL(warehouse.Slug) }>Edit</a>
+													<a class="text-slate-300 hover:text-slate-100" href={ routes.WarehouseEdit.URL(warehouse.Slug) }>Edit</a>
 													
 												</div>
 											</td>
@@ -254,3 +254,4 @@ templ (we WarehouseEdit) Page() {
 		}
 	}
 }
+

--- a/generator/testdata/golden/scaffold/full_crud/models/widget.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud/models/widget.go.golden
@@ -1,7 +1,10 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testapp/internal/storage"
 	"testapp/internal/validation"
@@ -21,16 +24,16 @@ type WidgetEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (e *WidgetEntity) Validate() error {
-	return nil
-}
-
 func (w widget) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (WidgetEntity, error) {
 	var entity WidgetEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WidgetEntity{}, ErrNotFound
+		}
 		return WidgetEntity{}, err
 	}
 
@@ -65,11 +68,10 @@ func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidg
 }
 
 type UpdateWidgetData struct {
-	ID        uuid.UUID
-	Name      string
-	Quantity  int32
-	Active    bool
-	UpdatedAt time.Time
+	ID       uuid.UUID
+	Name     string
+	Quantity int32
+	Active   bool
 }
 
 func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidgetData) (WidgetEntity, error) {
@@ -85,7 +87,7 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("quantity").
@@ -93,7 +95,11 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WidgetEntity{}, ErrNotFound
+		}
 		return WidgetEntity{}, err
 	}
 
@@ -101,12 +107,20 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 }
 
 func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*WidgetEntity)(nil)).
+	var entity WidgetEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, error) {
@@ -167,9 +181,9 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 	}, nil
 }
 
-func (w widget) Upsert(ctx context.Context, db storage.Executor, data CreateWidgetData) (WidgetEntity, error) {
+func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateWidgetData) (WidgetEntity, error) {
 	entity := WidgetEntity{
-		ID:        uuid.New(),
+		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Name:      data.Name,

--- a/generator/testdata/golden/scaffold/full_crud_css_components/models/widget.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/models/widget.go.golden
@@ -1,7 +1,10 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testapp/internal/storage"
 	"testapp/internal/validation"
@@ -21,16 +24,16 @@ type WidgetEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (e *WidgetEntity) Validate() error {
-	return nil
-}
-
 func (w widget) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (WidgetEntity, error) {
 	var entity WidgetEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WidgetEntity{}, ErrNotFound
+		}
 		return WidgetEntity{}, err
 	}
 
@@ -65,11 +68,10 @@ func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidg
 }
 
 type UpdateWidgetData struct {
-	ID        uuid.UUID
-	Name      string
-	Quantity  int32
-	Active    bool
-	UpdatedAt time.Time
+	ID       uuid.UUID
+	Name     string
+	Quantity int32
+	Active   bool
 }
 
 func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidgetData) (WidgetEntity, error) {
@@ -85,7 +87,7 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("quantity").
@@ -93,7 +95,11 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WidgetEntity{}, ErrNotFound
+		}
 		return WidgetEntity{}, err
 	}
 
@@ -101,12 +107,20 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 }
 
 func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*WidgetEntity)(nil)).
+	var entity WidgetEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, error) {
@@ -167,9 +181,9 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 	}, nil
 }
 
-func (w widget) Upsert(ctx context.Context, db storage.Executor, data CreateWidgetData) (WidgetEntity, error) {
+func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateWidgetData) (WidgetEntity, error) {
 	entity := WidgetEntity{
-		ID:        uuid.New(),
+		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Name:      data.Name,

--- a/generator/testdata/golden/scaffold/irregular_plural/models/company.go.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/models/company.go.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"database/sql"
@@ -21,16 +23,16 @@ type CompanyEntity struct {
 	UpdatedAt     time.Time      `bun:"updated_at"`
 }
 
-func (e *CompanyEntity) Validate() error {
-	return nil
-}
-
 func (c company) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (CompanyEntity, error) {
 	var entity CompanyEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CompanyEntity{}, ErrNotFound
+		}
 		return CompanyEntity{}, err
 	}
 
@@ -63,10 +65,9 @@ func (c company) Create(ctx context.Context, db storage.Executor, data CreateCom
 }
 
 type UpdateCompanyData struct {
-	ID        uuid.UUID
-	Name      string
-	Industry  sql.NullString
-	UpdatedAt time.Time
+	ID       uuid.UUID
+	Name     string
+	Industry sql.NullString
 }
 
 func (c company) Update(ctx context.Context, db storage.Executor, data UpdateCompanyData) (CompanyEntity, error) {
@@ -81,14 +82,18 @@ func (c company) Update(ctx context.Context, db storage.Executor, data UpdateCom
 		return CompanyEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("industry").
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CompanyEntity{}, ErrNotFound
+		}
 		return CompanyEntity{}, err
 	}
 
@@ -96,12 +101,20 @@ func (c company) Update(ctx context.Context, db storage.Executor, data UpdateCom
 }
 
 func (c company) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*CompanyEntity)(nil)).
+	var entity CompanyEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (c company) All(ctx context.Context, db storage.Executor) ([]CompanyEntity, error) {
@@ -162,9 +175,9 @@ func (c company) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (c company) Upsert(ctx context.Context, db storage.Executor, data CreateCompanyData) (CompanyEntity, error) {
+func (c company) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateCompanyData) (CompanyEntity, error) {
 	entity := CompanyEntity{
-		ID:        uuid.New(),
+		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Name:      data.Name,

--- a/generator/testdata/golden/scaffold/skip_factory/models/widget.go.golden
+++ b/generator/testdata/golden/scaffold/skip_factory/models/widget.go.golden
@@ -1,7 +1,10 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testapp/internal/storage"
 	"testapp/internal/validation"
@@ -21,16 +24,16 @@ type WidgetEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (e *WidgetEntity) Validate() error {
-	return nil
-}
-
 func (w widget) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (WidgetEntity, error) {
 	var entity WidgetEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WidgetEntity{}, ErrNotFound
+		}
 		return WidgetEntity{}, err
 	}
 
@@ -65,11 +68,10 @@ func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidg
 }
 
 type UpdateWidgetData struct {
-	ID        uuid.UUID
-	Name      string
-	Quantity  int32
-	Active    bool
-	UpdatedAt time.Time
+	ID       uuid.UUID
+	Name     string
+	Quantity int32
+	Active   bool
 }
 
 func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidgetData) (WidgetEntity, error) {
@@ -85,7 +87,7 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("quantity").
@@ -93,7 +95,11 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WidgetEntity{}, ErrNotFound
+		}
 		return WidgetEntity{}, err
 	}
 
@@ -101,12 +107,20 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 }
 
 func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*WidgetEntity)(nil)).
+	var entity WidgetEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, error) {
@@ -167,9 +181,9 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 	}, nil
 }
 
-func (w widget) Upsert(ctx context.Context, db storage.Executor, data CreateWidgetData) (WidgetEntity, error) {
+func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateWidgetData) (WidgetEntity, error) {
 	entity := WidgetEntity{
-		ID:        uuid.New(),
+		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Name:      data.Name,

--- a/generator/testdata/golden/scaffold/table_name_override/models/feedback_entry.go.golden
+++ b/generator/testdata/golden/scaffold/table_name_override/models/feedback_entry.go.golden
@@ -1,5 +1,7 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
 	"database/sql"
@@ -23,16 +25,16 @@ type FeedbackEntryEntity struct {
 	UpdatedAt     time.Time     `bun:"updated_at"`
 }
 
-func (e *FeedbackEntryEntity) Validate() error {
-	return nil
-}
-
 func (fe feedbackEntry) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (FeedbackEntryEntity, error) {
 	var entity FeedbackEntryEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return FeedbackEntryEntity{}, ErrNotFound
+		}
 		return FeedbackEntryEntity{}, err
 	}
 
@@ -74,7 +76,6 @@ type UpdateFeedbackEntryData struct {
 	Feedback    string
 	Rating      sql.NullInt32
 	SubmittedAt sql.NullTime
-	UpdatedAt   time.Time
 }
 
 func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data UpdateFeedbackEntryData) (FeedbackEntryEntity, error) {
@@ -91,7 +92,7 @@ func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data Up
 		return FeedbackEntryEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("student_name").
 		Column("feedback").
@@ -100,7 +101,11 @@ func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data Up
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return FeedbackEntryEntity{}, ErrNotFound
+		}
 		return FeedbackEntryEntity{}, err
 	}
 
@@ -108,12 +113,20 @@ func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data Up
 }
 
 func (fe feedbackEntry) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*FeedbackEntryEntity)(nil)).
+	var entity FeedbackEntryEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (fe feedbackEntry) All(ctx context.Context, db storage.Executor) ([]FeedbackEntryEntity, error) {
@@ -127,15 +140,15 @@ func (fe feedbackEntry) All(ctx context.Context, db storage.Executor) ([]Feedbac
 	return entities, nil
 }
 
-type PaginatedFeedbackEntry struct {
-	FeedbackEntry []FeedbackEntryEntity
-	TotalCount    int64
-	Page          int64
-	PageSize      int64
-	TotalPages    int64
+type PaginatedFeedbackEntries struct {
+	FeedbackEntries []FeedbackEntryEntity
+	TotalCount      int64
+	Page            int64
+	PageSize        int64
+	TotalPages      int64
 }
 
-func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedFeedbackEntry, error) {
+func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedFeedbackEntries, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -151,7 +164,7 @@ func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page,
 	totalCount, err := db.NewSelect().
 		Model(&FeedbackEntryEntity{}).Count(ctx)
 	if err != nil {
-		return PaginatedFeedbackEntry{}, err
+		return PaginatedFeedbackEntries{}, err
 	}
 
 	entities := make([]FeedbackEntryEntity, 0, int(pageSize))
@@ -160,23 +173,23 @@ func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page,
 		Limit(int(pageSize)).
 		Offset(int(offset)).
 		Scan(ctx); err != nil {
-		return PaginatedFeedbackEntry{}, err
+		return PaginatedFeedbackEntries{}, err
 	}
 
 	totalPages := (int64(totalCount) + pageSize - 1) / pageSize
 
-	return PaginatedFeedbackEntry{
-		FeedbackEntry: entities,
-		TotalCount:    int64(totalCount),
-		Page:          page,
-		PageSize:      pageSize,
-		TotalPages:    totalPages,
+	return PaginatedFeedbackEntries{
+		FeedbackEntries: entities,
+		TotalCount:      int64(totalCount),
+		Page:            page,
+		PageSize:        pageSize,
+		TotalPages:      totalPages,
 	}, nil
 }
 
-func (fe feedbackEntry) Upsert(ctx context.Context, db storage.Executor, data CreateFeedbackEntryData) (FeedbackEntryEntity, error) {
+func (fe feedbackEntry) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateFeedbackEntryData) (FeedbackEntryEntity, error) {
 	entity := FeedbackEntryEntity{
-		ID:          uuid.New(),
+		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 		StudentName: data.StudentName,

--- a/generator/testdata/golden/scaffold/vue/models/project.go.golden
+++ b/generator/testdata/golden/scaffold/vue/models/project.go.golden
@@ -1,7 +1,10 @@
 package models
 
+// andurel:model-mode crud
+
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testapp/internal/storage"
 	"testapp/internal/validation"
@@ -20,16 +23,16 @@ type ProjectEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (e *ProjectEntity) Validate() error {
-	return nil
-}
-
 func (p project) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (ProjectEntity, error) {
 	var entity ProjectEntity
-	if err := db.NewSelect().
+	err := db.NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProjectEntity{}, ErrNotFound
+		}
 		return ProjectEntity{}, err
 	}
 
@@ -62,10 +65,9 @@ func (p project) Create(ctx context.Context, db storage.Executor, data CreatePro
 }
 
 type UpdateProjectData struct {
-	ID        uuid.UUID
-	Title     string
-	Status    string
-	UpdatedAt time.Time
+	ID     uuid.UUID
+	Title  string
+	Status string
 }
 
 func (p project) Update(ctx context.Context, db storage.Executor, data UpdateProjectData) (ProjectEntity, error) {
@@ -80,14 +82,18 @@ func (p project) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		return ProjectEntity{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewUpdate().
+	err := db.NewUpdate().
 		Model(&entity).
 		Column("title").
 		Column("status").
 		Column("updated_at").
 		WherePK().
 		Returning("*").
-		Scan(ctx); err != nil {
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProjectEntity{}, ErrNotFound
+		}
 		return ProjectEntity{}, err
 	}
 
@@ -95,12 +101,20 @@ func (p project) Update(ctx context.Context, db storage.Executor, data UpdatePro
 }
 
 func (p project) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*ProjectEntity)(nil)).
+	var entity ProjectEntity
+	err := db.NewDelete().
+		Model(&entity).
 		Where("id = ?", id).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (p project) All(ctx context.Context, db storage.Executor) ([]ProjectEntity, error) {
@@ -161,9 +175,9 @@ func (p project) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (p project) Upsert(ctx context.Context, db storage.Executor, data CreateProjectData) (ProjectEntity, error) {
+func (p project) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateProjectData) (ProjectEntity, error) {
 	entity := ProjectEntity{
-		ID:        uuid.New(),
+		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Title:     data.Title,

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -58,25 +58,23 @@ func ToCamelCase(s string) string {
 
 	var builder strings.Builder
 	builder.Grow(len(s))
-
-	// First part stays lowercase
-	builder.WriteString(strings.ToLower(parts[0]))
-
-	// Capitalize first letter of remaining parts
-	for i := 1; i < len(parts); i++ {
-		if len(parts[i]) > 0 {
-			builder.WriteString(strings.ToUpper(parts[i][:1]))
-			if len(parts[i]) > 1 {
-				builder.WriteString(strings.ToLower(parts[i][1:]))
-			}
+	for i, part := range parts {
+		if part == "" {
+			continue
 		}
+		if i == 0 {
+			builder.WriteString(strings.ToLower(part))
+			continue
+		}
+		builder.WriteString(pascalNamePart(part))
 	}
 
 	return builder.String()
 }
 
-// ToLowerCamelCase converts a PascalCase identifier into camelCase by lowercasing the first character.
-// Examples: "NewUser" -> "newUser", "AdminUser" -> "adminUser", "User" -> "user"
+// ToLowerCamelCase converts a PascalCase identifier into camelCase while
+// preserving word boundaries encoded by a leading uppercase run.
+// Examples: "NewUser" -> "newUser", "SSHCredential" -> "sshCredential".
 func ToLowerCamelCase(s string) string {
 	if s == "" {
 		return ""
@@ -87,8 +85,19 @@ func ToLowerCamelCase(s string) string {
 		return s
 	}
 
-	// Convert first character to lowercase
-	runes[0] = unicode.ToLower(runes[0])
+	uppercaseEnd := 0
+	for uppercaseEnd < len(runes) && unicode.IsUpper(runes[uppercaseEnd]) {
+		uppercaseEnd++
+	}
+	if uppercaseEnd > 1 && uppercaseEnd < len(runes) && unicode.IsLower(runes[uppercaseEnd]) {
+		uppercaseEnd--
+	}
+	if uppercaseEnd == 0 {
+		uppercaseEnd = 1
+	}
+	for i := 0; i < uppercaseEnd; i++ {
+		runes[i] = unicode.ToLower(runes[i])
+	}
 	return string(runes)
 }
 
@@ -136,17 +145,23 @@ func ToPascalCase(s string) string {
 	var builder strings.Builder
 	builder.Grow(len(s))
 
-	// Capitalize first letter of each part
 	for _, part := range parts {
-		if len(part) > 0 {
-			builder.WriteString(strings.ToUpper(part[:1]))
-			if len(part) > 1 {
-				builder.WriteString(strings.ToLower(part[1:]))
-			}
+		if part != "" {
+			builder.WriteString(pascalNamePart(part))
 		}
 	}
 
 	return builder.String()
+}
+
+func pascalNamePart(part string) string {
+	lower := strings.ToLower(part)
+	runes := []rune(lower)
+	if len(runes) == 0 {
+		return ""
+	}
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
 }
 
 // ParseNamespacedResource splits a resource name into an optional single-level

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -58,12 +58,14 @@ func ToCamelCase(s string) string {
 
 	var builder strings.Builder
 	builder.Grow(len(s))
-	for i, part := range parts {
+	wroteFirstPart := false
+	for _, part := range parts {
 		if part == "" {
 			continue
 		}
-		if i == 0 {
+		if !wroteFirstPart {
 			builder.WriteString(strings.ToLower(part))
+			wroteFirstPart = true
 			continue
 		}
 		builder.WriteString(pascalNamePart(part))
@@ -155,11 +157,7 @@ func ToPascalCase(s string) string {
 }
 
 func pascalNamePart(part string) string {
-	lower := strings.ToLower(part)
-	runes := []rune(lower)
-	if len(runes) == 0 {
-		return ""
-	}
+	runes := []rune(strings.ToLower(part))
 	runes[0] = unicode.ToUpper(runes[0])
 	return string(runes)
 }

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -59,6 +59,8 @@ func TestToCamelCase(t *testing.T) {
 		{name: "empty string", input: "", expected: ""},
 		{name: "already camelCase", input: "adminUsers", expected: "adminusers"},
 		{name: "single char parts", input: "a_b_c", expected: "aBC"},
+		{name: "schema ssh is mechanical", input: "server_ssh_credentials", expected: "serverSshCredentials"},
+		{name: "schema compound is mechanical", input: "wireguard_peers", expected: "wireguardPeers"},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +86,8 @@ func TestToLowerCamelCase(t *testing.T) {
 		{name: "empty string", input: "", expected: ""},
 		{name: "already camelCase", input: "user", expected: "user"},
 		{name: "single char", input: "U", expected: "u"},
+		{name: "leading initialism", input: "SSHCredential", expected: "sshCredential"},
+		{name: "initialism only", input: "URL", expected: "url"},
 	}
 
 	for _, tt := range tests {
@@ -131,6 +135,10 @@ func TestToPascalCase(t *testing.T) {
 		{name: "empty string", input: "", expected: ""},
 		{name: "single char parts", input: "a_b_c", expected: "ABC"},
 		{name: "already lowercase", input: "user", expected: "User"},
+		{name: "schema ssh is mechanical", input: "server_ssh_credentials", expected: "ServerSshCredentials"},
+		{name: "schema compound is mechanical", input: "wireguard_peers", expected: "WireguardPeers"},
+		{name: "schema url is mechanical", input: "url", expected: "Url"},
+		{name: "schema cidr is mechanical", input: "cidr", expected: "Cidr"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -61,6 +61,7 @@ func TestToCamelCase(t *testing.T) {
 		{name: "single char parts", input: "a_b_c", expected: "aBC"},
 		{name: "schema ssh is mechanical", input: "server_ssh_credentials", expected: "serverSshCredentials"},
 		{name: "schema compound is mechanical", input: "wireguard_peers", expected: "wireguardPeers"},
+		{name: "repeated separators", input: "__server__ssh_credentials__", expected: "serverSshCredentials"},
 	}
 
 	for _, tt := range tests {
@@ -139,6 +140,7 @@ func TestToPascalCase(t *testing.T) {
 		{name: "schema compound is mechanical", input: "wireguard_peers", expected: "WireguardPeers"},
 		{name: "schema url is mechanical", input: "url", expected: "Url"},
 		{name: "schema cidr is mechanical", input: "cidr", expected: "Cidr"},
+		{name: "repeated separators", input: "__server__ssh_credentials__", expected: "ServerSshCredentials"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- requires explicit primary keys for generated Upsert methods
- translates missing rows to repository `ErrNotFound` semantics
- removes ignored update timestamp inputs
- adds CRUD, read-only, and create-only model modes
- preserves supplied resource names through pluralization and pagination
- derives schema field names mechanically without an acronym dictionary
- handles leading and repeated separators in schema-derived names
- uses detected primary keys in generated controller tests and views

## Why

Generated APIs contained unusable plural forms, inconsistent initialism handling, ineffective Upserts, hardcoded `ID` view references, and persistence behavior that differed from the repository conventions.
