### PR TITLE
refactor(inertia)!: inject renderer through Fx

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ myapp/
 ├── tsconfig.json
 ```
 
-The auth and default error pages use Inertia, while `controllers/pages.go` keeps the welcome page server-rendered with Templ. `cmd/app/main.go` initializes `internal/inertia` with `inertia/root.go.html`, a path inside the embedded `assets` filesystem. Edit `assets/inertia/root.go.html` to customize the shell; regular Go builds, Docker builds, and `andurel build` include it in the application binary. Run the configured package manager's install command after scaffolding (the `andurel new` output shows the right command based on the configured runtime). Later resource/controller generation still defaults to Templ; pass `--inertia` to `andurel generate controller` or `andurel generate scaffold` for Inertia resource pages (reads the adapter from `andurel.lock`).
+The auth and default error pages use Inertia, while `controllers/pages.go` keeps the welcome page server-rendered with Templ. `cmd/app/main.go` provides one `*inertia.Renderer` through Fx using `inertia/root.go.html` from the embedded `assets` filesystem, then injects it into the router and Inertia controllers. Edit `assets/inertia/root.go.html` to customize the shell; regular Go builds, Docker builds, and `andurel build` include it in the application binary. Run the configured package manager's install command after scaffolding (the `andurel new` output shows the right command based on the configured runtime). Later resource/controller generation still defaults to Templ; pass `--inertia` to `andurel generate controller` or `andurel generate scaffold` for Inertia resource pages (reads the adapter from `andurel.lock`).
 
 When using `--inertia vue`, `--inertia react`, or `--inertia svelte`, controllers can render Inertia pages alongside Templ.
 

--- a/cli/command_behavior_test.go
+++ b/cli/command_behavior_test.go
@@ -791,6 +791,88 @@ func TestGenerateControllerCustomActionInertiaProjectDefaultsToTemplAndInertiaFl
 	}
 }
 
+func TestGenerateControllerCustomInertiaActionPreservesKeyedConstructor(t *testing.T) {
+	resetCLITestSeams(t)
+	rootDir := t.TempDir()
+	writeCLITestFile(t, rootDir, "go.mod", "module example.com/app\n\ngo 1.26\n")
+	writeCLITestFile(t, rootDir, "controllers/dashboards.go", `package controllers
+
+type Dashboards struct {
+	enabled bool
+}
+
+func NewDashboards(enabled bool) Dashboards {
+	return Dashboards{enabled: enabled}
+}
+`)
+
+	lock := layout.NewAndurelLock("test")
+	lock.ScaffoldConfig = &layout.ScaffoldConfig{
+		ProjectName: "app",
+		Database:    "postgresql",
+		Inertia:     "vue",
+	}
+	if err := lock.WriteLockFile(rootDir); err != nil {
+		t.Fatalf("write andurel.lock: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("chdir temp project: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	for range 2 {
+		if err := generateControllerWithActions("Dashboard", "", []string{"overview"}, "vue", false); err != nil {
+			t.Fatalf("generate custom Inertia controller action: %v", err)
+		}
+	}
+
+	controllerPath := filepath.Join(rootDir, "controllers", "dashboards.go")
+	content, err := os.ReadFile(controllerPath)
+	if err != nil {
+		t.Fatalf("read generated controller: %v", err)
+	}
+	controller := string(content)
+	normalizedController := strings.Join(strings.Fields(controller), " ")
+	for _, want := range []string{
+		"type Dashboards struct { enabled bool renderer *inertia.Renderer }",
+		"func NewDashboards(enabled bool, renderer *inertia.Renderer) Dashboards",
+		"return Dashboards{enabled: enabled, renderer: renderer}",
+	} {
+		if !strings.Contains(normalizedController, want) {
+			t.Errorf("generated controller missing %q:\n%s", want, controller)
+		}
+	}
+	for _, want := range []string{
+		`"example.com/app/internal/inertia"`,
+		`return d.renderer.Page(etx, "Dashboard/Overview"`,
+	} {
+		if !strings.Contains(controller, want) {
+			t.Errorf("generated controller missing %q:\n%s", want, controller)
+		}
+	}
+	for _, expected := range []struct {
+		snippet string
+		count   int
+	}{
+		{snippet: "renderer *inertia.Renderer", count: 2},
+		{snippet: "func (d Dashboards) Overview", count: 1},
+	} {
+		if count := strings.Count(normalizedController, expected.snippet); count != expected.count {
+			t.Errorf("generated controller contains %q %d times, want %d:\n%s", expected.snippet, count, expected.count, controller)
+		}
+	}
+	if count := strings.Count(controller, `"example.com/app/internal/inertia"`); count != 1 {
+		t.Errorf("generated controller contains the Inertia import %d times, want once:\n%s", count, controller)
+	}
+}
+
 func TestGenerateControllerSingleCRUDActionVueGeneratesInertiaController(t *testing.T) {
 	resetCLITestSeams(t)
 	rootDir := t.TempDir()

--- a/cli/command_behavior_test.go
+++ b/cli/command_behavior_test.go
@@ -780,6 +780,11 @@ func TestGenerateControllerCustomActionInertiaProjectDefaultsToTemplAndInertiaFl
 
 			assertCLITestFileContains(t, rootDir, "controllers/dashboards.go", tt.wantController)
 			assertCLITestFileNotContains(t, rootDir, "controllers/dashboards.go", tt.unwantedController)
+			if tt.inertia != "" {
+				assertCLITestFileContains(t, rootDir, "controllers/dashboards.go", "renderer *inertia.Renderer")
+				assertCLITestFileContains(t, rootDir, "controllers/dashboards.go", "func NewDashboards(renderer *inertia.Renderer) Dashboards")
+				assertCLITestFileContains(t, rootDir, "controllers/dashboards.go", `return d.renderer.Page(etx, "Dashboard/Overview"`)
+			}
 			assertCLITestFileExists(t, rootDir, tt.wantView)
 			assertCLITestFileMissing(t, rootDir, tt.unwantedView)
 		})
@@ -807,7 +812,8 @@ func TestGenerateControllerSingleCRUDActionVueGeneratesInertiaController(t *test
 	}
 
 	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", "example.com/app/internal/inertia")
-	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", `return inertia.Page(etx, "ProjectInquiry/Show"`)
+	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", "renderer *inertia.Renderer")
+	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", `return pi.renderer.Page(etx, "ProjectInquiry/Show"`)
 	assertCLITestFileNotContains(t, rootDir, "controllers/project_inquiries.go", "example.com/app/internal/hypermedia")
 	assertCLITestFileExists(t, rootDir, filepath.Join("resources", "js", "Pages", "ProjectInquiry", "Show.vue"))
 	assertCLITestFileMissing(t, rootDir, "views/project_inquiries_resource.templ")
@@ -834,7 +840,8 @@ func TestGenerateControllerSingleCRUDActionReactGeneratesInertiaController(t *te
 	}
 
 	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", "example.com/app/internal/inertia")
-	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", `return inertia.Page(etx, "ProjectInquiry/Show"`)
+	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", "renderer *inertia.Renderer")
+	assertCLITestFileContains(t, rootDir, "controllers/project_inquiries.go", `return pi.renderer.Page(etx, "ProjectInquiry/Show"`)
 	assertCLITestFileNotContains(t, rootDir, "controllers/project_inquiries.go", "example.com/app/internal/hypermedia")
 	assertCLITestFileExists(t, rootDir, filepath.Join("resources", "js", "Pages", "ProjectInquiry", "Show.tsx"))
 	assertCLITestFileMissing(t, rootDir, "views/project_inquiries_resource.templ")

--- a/cli/generate_controller.go
+++ b/cli/generate_controller.go
@@ -255,6 +255,16 @@ func generateActionControllerFile(name, namespace, tableName, pluralName, module
 			return err
 		}
 		contentStr := strings.ReplaceAll(string(content), "(etx echo.Context)", "(etx *echo.Context)")
+		if isInertia {
+			contentStr, err = controllergen.EnsureInertiaRendererDependency(
+				contentStr,
+				controllerName,
+				modulePath,
+			)
+			if err != nil {
+				return err
+			}
+		}
 
 		var additions strings.Builder
 		for _, action := range actions {
@@ -311,9 +321,15 @@ func generateActionControllerFile(name, namespace, tableName, pluralName, module
 			sb.WriteString("\t\"github.com/labstack/echo/v5\"\n")
 		}
 		sb.WriteString(")\n\n")
-		fmt.Fprintf(&sb, "type %s struct{}\n\n", controllerName)
-		fmt.Fprintf(&sb, "func New%s() %s {\n", controllerName, controllerName)
-		fmt.Fprintf(&sb, "\treturn %s{}\n", controllerName)
+		if isInertia {
+			fmt.Fprintf(&sb, "type %s struct {\n\trenderer *inertia.Renderer\n}\n\n", controllerName)
+			fmt.Fprintf(&sb, "func New%s(renderer *inertia.Renderer) %s {\n", controllerName, controllerName)
+			fmt.Fprintf(&sb, "\treturn %s{renderer: renderer}\n", controllerName)
+		} else {
+			fmt.Fprintf(&sb, "type %s struct{}\n\n", controllerName)
+			fmt.Fprintf(&sb, "func New%s() %s {\n", controllerName, controllerName)
+			fmt.Fprintf(&sb, "\treturn %s{}\n", controllerName)
+		}
 		sb.WriteString("}\n\n")
 
 		sb.WriteString(customRegisterRoutesMethod(receiverName, controllerName, namespace, resourceName, actions))
@@ -385,10 +401,11 @@ func actionControllerMethodInertia(receiverName, controllerName, namespace, reso
 	if namespace != "" {
 		pageName = naming.NamespaceToPascal(namespace) + "/" + pageName
 	}
-	return fmt.Sprintf("func (%s %s) %s(etx *echo.Context) error {\n\treturn inertia.Page(etx, \"%s\", inertia.Props{})\n}\n\n",
+	return fmt.Sprintf("func (%s %s) %s(etx *echo.Context) error {\n\treturn %s.renderer.Page(etx, \"%s\", inertia.Props{})\n}\n\n",
 		receiverName,
 		controllerName,
 		methodName,
+		receiverName,
 		pageName,
 	)
 }

--- a/cli/generate_controller_helpers_test.go
+++ b/cli/generate_controller_helpers_test.go
@@ -139,8 +139,8 @@ func TestGenerateActionControllerFileModesAndAppend(t *testing.T) {
 		want    string
 	}{
 		{name: "templ", want: "hypermedia.RenderPage"},
-		{name: "react", inertia: "react", want: "inertia.Page"},
-		{name: "svelte", inertia: "svelte", want: "inertia.Page"},
+		{name: "react", inertia: "react", want: "renderer.Page"},
+		{name: "svelte", inertia: "svelte", want: "renderer.Page"},
 		{name: "api", isAPI: true, want: "etx.JSON"},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/contracts/public-api.txt
+++ b/contracts/public-api.txt
@@ -762,6 +762,11 @@ metadata.
 
 FUNCTIONS
 
+func EnsureInertiaRendererDependency(content, controllerName, modulePath string) (string, error)
+    EnsureInertiaRendererDependency adds the renderer field and constructor
+    parameter required by instance-based Inertia actions while preserving the
+    controller's existing dependencies.
+
 func ExistingRouteFileActions(routesPath, resourceName, namespace, pluralName string) ([]string, error)
     ExistingRouteFileActions returns the resource actions declared in a
     generated route file.

--- a/docs/generated-files-and-upgrades.md
+++ b/docs/generated-files-and-upgrades.md
@@ -19,6 +19,20 @@ When an upgrade crosses from a version before `v1.5.4` to `v1.5.4` or later, `an
 
 Do not replace the whole `router/*` tree. These changes preserve valid sessions, replace only cookies that fail secure-cookie decoding, and continue to return configuration, usage, internal, or save errors.
 
+## Inertia renderer injection migration
+
+Starting with `v1.5.6`, new Inertia scaffolds construct one `*inertia.Renderer` through Fx. The composition root injects the embedded asset filesystem, project name, environment, Vite build route, shared application version, and request-scoped flash props. Router and controller constructors receive that renderer and call its `Page`, `Redirect`, `Location`, and `Middleware` methods.
+
+When an Inertia project upgrades across `v1.5.6`, `andurel upgrade` emits a version-gated manual action with the project's module path rendered into copy-ready imports. The release notes must include the same migration:
+
+1. Replace the pre-Fx `inertia.Init` call in `cmd/app/main.go` with an Fx provider that calls `inertia.New` using `assets.Files`, configuration values, `routes.ViteBuild.Path()`, and `inertia.WithRequestProps` for flash propagation.
+2. Add that provider to `fx.Provide`.
+3. Inject `*inertia.Renderer` into `router.New`, include `renderer.Middleware()` in the existing middleware order, and inject the renderer into every Inertia controller constructor.
+4. Replace package-level `inertia.Page`, `inertia.Redirect`, and `inertia.Location` calls with calls on the controller's renderer field.
+5. Run `gofmt`, `go fix ./...`, and `go vet ./...` after reconciling application-owned code.
+
+Framework-owned `internal/inertia` files update automatically. Andurel does not rewrite application-owned controllers because doing so could overwrite user changes. Projects created at `v1.5.6` or later do not receive this migration note.
+
 ## Planning and preview
 
 Run a structured dry run before applying an upgrade:

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
@@ -1793,27 +1793,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1857,6 +1836,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
@@ -1772,15 +1772,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1789,16 +1793,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2770,10 +2792,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2803,7 +2826,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2818,7 +2841,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2829,7 +2852,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2855,9 +2878,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2868,14 +2891,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -2952,13 +2975,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -2994,7 +3019,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -3020,10 +3045,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -3056,7 +3082,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -3073,7 +3099,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -3085,7 +3111,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -3101,13 +3127,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -3132,10 +3158,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -3185,7 +3212,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -3201,7 +3228,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -3211,7 +3238,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -3226,17 +3253,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -3245,12 +3272,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -3269,7 +3296,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -3281,7 +3308,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -3307,21 +3334,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -3347,10 +3374,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -3393,7 +3421,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -3409,7 +3437,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -3421,7 +3449,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -3447,10 +3475,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -3461,14 +3489,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -3479,14 +3507,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -9710,6 +9738,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9717,51 +9746,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -9778,40 +9860,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -9820,8 +9903,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -9835,12 +10049,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -9855,8 +10067,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -9866,7 +10078,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -9882,7 +10094,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -14443,6 +14655,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -14481,7 +14694,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -14502,6 +14722,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -14529,7 +14750,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
@@ -1785,27 +1785,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1849,6 +1828,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
@@ -1764,15 +1764,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1781,16 +1785,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2762,10 +2784,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2795,7 +2818,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2810,7 +2833,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2821,7 +2844,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2847,9 +2870,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2860,14 +2883,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -2944,13 +2967,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -2986,7 +3011,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -3012,10 +3037,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -3048,7 +3074,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -3065,7 +3091,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -3077,7 +3103,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -3093,13 +3119,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -3124,10 +3150,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -3177,7 +3204,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -3193,7 +3220,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -3203,7 +3230,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -3218,17 +3245,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -3237,12 +3264,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -3261,7 +3288,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -3273,7 +3300,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -3299,21 +3326,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -3339,10 +3366,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -3385,7 +3413,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -3401,7 +3429,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -3413,7 +3441,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -3439,10 +3467,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -3453,14 +3481,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -3471,14 +3499,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -8240,6 +8268,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -8247,51 +8276,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -8308,40 +8390,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -8350,8 +8433,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -8365,12 +8579,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -8385,8 +8597,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -8396,7 +8608,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -8412,7 +8624,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -12973,6 +13185,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -13011,7 +13224,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -13032,6 +13252,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -13059,7 +13280,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
@@ -1168,15 +1168,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1185,16 +1189,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2136,10 +2158,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2169,7 +2192,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2184,7 +2207,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2195,7 +2218,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2221,9 +2244,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2234,14 +2257,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -2318,13 +2341,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -2360,7 +2385,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -2386,10 +2411,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -2422,7 +2448,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -2439,7 +2465,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -2451,7 +2477,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -2467,13 +2493,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -2498,10 +2524,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -2551,7 +2578,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -2567,7 +2594,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -2577,7 +2604,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -2592,17 +2619,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -2611,12 +2638,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -2635,7 +2662,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -2647,7 +2674,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -2673,21 +2700,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -2713,10 +2740,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -2759,7 +2787,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -2775,7 +2803,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -2787,7 +2815,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -2813,10 +2841,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2827,14 +2855,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -2845,14 +2873,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -9031,6 +9059,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9038,51 +9067,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -9099,40 +9181,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -9141,8 +9224,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -9156,12 +9370,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -9176,8 +9388,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -9187,7 +9399,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -9203,7 +9415,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -13764,6 +13976,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -13802,7 +14015,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -13823,6 +14043,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -13850,7 +14071,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
@@ -1189,27 +1189,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1253,6 +1232,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
@@ -1870,27 +1870,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1934,6 +1913,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
@@ -1849,15 +1849,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1866,16 +1870,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2847,10 +2869,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2880,7 +2903,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2895,7 +2918,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2906,7 +2929,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2932,9 +2955,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2945,14 +2968,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -3029,13 +3052,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -3071,7 +3096,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -3097,10 +3122,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -3133,7 +3159,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -3150,7 +3176,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -3162,7 +3188,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -3178,13 +3204,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -3209,10 +3235,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -3262,7 +3289,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -3278,7 +3305,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -3288,7 +3315,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -3303,17 +3330,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -3322,12 +3349,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -3346,7 +3373,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -3358,7 +3385,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -3384,21 +3411,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -3424,10 +3451,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -3470,7 +3498,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -3486,7 +3514,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -3498,7 +3526,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -3524,10 +3552,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -3538,14 +3566,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -3556,14 +3584,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -9787,6 +9815,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9794,51 +9823,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -9855,40 +9937,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -9897,8 +9980,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -9912,12 +10126,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -9932,8 +10144,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -9943,7 +10155,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -9959,7 +10171,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -14520,6 +14732,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -14558,7 +14771,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -14579,6 +14799,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -14606,7 +14827,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
@@ -1841,15 +1841,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1858,16 +1862,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2839,10 +2861,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2872,7 +2895,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2887,7 +2910,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2898,7 +2921,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2924,9 +2947,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2937,14 +2960,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -3021,13 +3044,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -3063,7 +3088,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -3089,10 +3114,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -3125,7 +3151,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -3142,7 +3168,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -3154,7 +3180,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -3170,13 +3196,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -3201,10 +3227,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -3254,7 +3281,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -3270,7 +3297,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -3280,7 +3307,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -3295,17 +3322,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -3314,12 +3341,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -3338,7 +3365,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -3350,7 +3377,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -3376,21 +3403,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -3416,10 +3443,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -3462,7 +3490,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -3478,7 +3506,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -3490,7 +3518,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -3516,10 +3544,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -3530,14 +3558,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -3548,14 +3576,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -8317,6 +8345,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -8324,51 +8353,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -8385,40 +8467,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -8427,8 +8510,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -8442,12 +8656,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -8462,8 +8674,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -8473,7 +8685,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -8489,7 +8701,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -13050,6 +13262,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -13088,7 +13301,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -13109,6 +13329,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -13136,7 +13357,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
@@ -1862,27 +1862,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1926,6 +1905,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
@@ -1245,15 +1245,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1262,16 +1266,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2213,10 +2235,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2246,7 +2269,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2261,7 +2284,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2272,7 +2295,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2298,9 +2321,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2311,14 +2334,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -2395,13 +2418,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -2437,7 +2462,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -2463,10 +2488,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -2499,7 +2525,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -2516,7 +2542,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -2528,7 +2554,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -2544,13 +2570,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -2575,10 +2601,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -2628,7 +2655,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -2644,7 +2671,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -2654,7 +2681,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -2669,17 +2696,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -2688,12 +2715,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -2712,7 +2739,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -2724,7 +2751,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -2750,21 +2777,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -2790,10 +2817,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -2836,7 +2864,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -2852,7 +2880,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -2864,7 +2892,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -2890,10 +2918,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2904,14 +2932,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -2922,14 +2950,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -9108,6 +9136,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9115,51 +9144,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -9176,40 +9258,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -9218,8 +9301,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -9233,12 +9447,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -9253,8 +9465,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -9264,7 +9476,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -9280,7 +9492,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -13841,6 +14053,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -13879,7 +14092,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -13900,6 +14120,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -13927,7 +14148,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
@@ -1266,27 +1266,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1330,6 +1309,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
@@ -1237,15 +1237,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1254,16 +1258,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2205,10 +2227,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2238,7 +2261,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2253,7 +2276,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2264,7 +2287,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2290,9 +2313,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2303,14 +2326,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -2387,13 +2410,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -2429,7 +2454,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -2455,10 +2480,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -2491,7 +2517,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -2508,7 +2534,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -2520,7 +2546,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -2536,13 +2562,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -2567,10 +2593,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -2620,7 +2647,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -2636,7 +2663,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -2646,7 +2673,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -2661,17 +2688,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -2680,12 +2707,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -2704,7 +2731,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -2716,7 +2743,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -2742,21 +2769,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -2782,10 +2809,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -2828,7 +2856,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -2844,7 +2872,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -2856,7 +2884,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -2882,10 +2910,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2896,14 +2924,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -2914,14 +2942,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -7638,6 +7666,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -7645,51 +7674,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -7706,40 +7788,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -7748,8 +7831,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -7763,12 +7977,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -7783,8 +7995,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -7794,7 +8006,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -7810,7 +8022,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -12371,6 +12583,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -12409,7 +12622,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -12430,6 +12650,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -12457,7 +12678,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
@@ -1258,27 +1258,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1322,6 +1301,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
@@ -1153,15 +1153,19 @@ import (
 	"syscall"
 	"time"
 
+	"testapp/assets"
 	mailclients "testapp/clients/email"
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/database"
 	"testapp/email"
 	"testapp/internal/inertia"
+	"testapp/internal/request"
 	"testapp/internal/server"
 	"testapp/queue"
 	"testapp/router"
+	"testapp/router/cookies"
+	"testapp/router/routes"
 	"testapp/services"
 	"testapp/telemetry"
 
@@ -1170,16 +1174,34 @@ import (
 
 var appVersion string
 
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+			provideInertia,
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")
@@ -2121,10 +2143,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -2154,7 +2177,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -2169,7 +2192,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -2180,7 +2203,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -2206,9 +2229,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2219,14 +2242,14 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }
 ```
 
@@ -2303,13 +2326,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -2345,7 +2370,7 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }
 ```
 
@@ -2371,10 +2396,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -2407,7 +2433,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -2424,7 +2450,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -2436,7 +2462,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -2452,13 +2478,13 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }
 ```
 
@@ -2483,10 +2509,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -2536,7 +2563,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -2552,7 +2579,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -2562,7 +2589,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -2577,17 +2604,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -2596,12 +2623,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -2620,7 +2647,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -2632,7 +2659,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -2658,21 +2685,21 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -2698,10 +2725,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -2744,7 +2772,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -2760,7 +2788,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -2772,7 +2800,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -2798,10 +2826,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -2812,14 +2840,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -2830,14 +2858,14 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 ```
 
@@ -7554,6 +7582,7 @@ file -----------rw-r--r-- internal/inertia/render.go
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -7561,51 +7590,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"testapp/assets"
-	"testapp/config"
-	"testapp/internal/request"
-	"testapp/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions       []gonertia.Option
+	sharedProps           Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -7622,40 +7704,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -7664,8 +7747,139 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
+}
+```
+
+file -----------rw-r--r-- internal/inertia/render_test.go
+```
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{ .inertia }}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
 }
 ```
 
@@ -7679,12 +7893,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"testapp/assets"
-	"testapp/config"
 	"testapp/internal/server"
-	"testapp/router/routes"
 )
 
 type viteTags struct {
@@ -7699,8 +7911,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -7710,7 +7922,7 @@ func initVite() (*viteTags, error) {
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -7726,7 +7938,7 @@ func initVite() (*viteTags, error) {
 	}
 
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}
@@ -12287,6 +12499,7 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+	renderer *inertia.Renderer,
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -12325,7 +12538,14 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
-	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -12346,6 +12566,7 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+	renderer *inertia.Renderer,
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -12373,7 +12594,7 @@ func SetupGlobalMiddleware(
 		session.Middleware(sessionStore),
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
-		inertia.Middleware(),
+		renderer.Middleware(),
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,
 		echomw.Recover(),

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
@@ -1174,27 +1174,6 @@ import (
 
 var appVersion string
 
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -1238,6 +1217,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+}
+
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
 }
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {

--- a/generator/controller_view_generation_golden_test.go
+++ b/generator/controller_view_generation_golden_test.go
@@ -196,7 +196,7 @@ func TestControllerViewGenerationNamespacedInertia(t *testing.T) {
 
 	assertControllerViewGoldenFileMissing(t, filepath.Join("views", "admin_widgets_resource.templ"))
 	assertGeneratedFileContains(t, filepath.Join("resources", "js", "Pages", "Admin", "Widget", "Show.vue"), "<template>")
-	assertGeneratedFileContains(t, filepath.Join("controllers", "admin", "widgets.go"), `return inertia.Page(etx, "Admin/Widget/Show"`)
+	assertGeneratedFileContains(t, filepath.Join("controllers", "admin", "widgets.go"), `return w.renderer.Page(etx, "Admin/Widget/Show"`)
 }
 
 func TestControllerViewGenerationGoldensInertiaProjectDefaultsToTempl(t *testing.T) {
@@ -238,7 +238,7 @@ func TestControllerViewGenerationGoldensReactInertiaFlagGeneratesReactPages(t *t
 	assertGeneratedFileContains(t, filepath.Join("resources", "js", "Pages", "Widget", "Show.tsx"), "export default function Show")
 	assertGeneratedFileContains(t, "controllers/widgets.go", "testapp/internal/inertia")
 	assertGeneratedFileNotContains(t, "controllers/widgets.go", "testapp/internal/hypermedia")
-	assertGeneratedFileContains(t, "controllers/widgets.go", "return inertia.Page(etx, \"Widget/Index\"")
+	assertGeneratedFileContains(t, "controllers/widgets.go", "return w.renderer.Page(etx, \"Widget/Index\"")
 }
 
 func TestControllerViewGenerationGoldensSingleVueActionGeneratesInertiaController(t *testing.T) {
@@ -252,7 +252,7 @@ func TestControllerViewGenerationGoldensSingleVueActionGeneratesInertiaControlle
 	assertGeneratedFileContains(t, filepath.Join("resources", "js", "Pages", "Widget", "Show.vue"), "<template>")
 	assertGeneratedFileContains(t, "controllers/widgets.go", "testapp/internal/inertia")
 	assertGeneratedFileNotContains(t, "controllers/widgets.go", "testapp/internal/hypermedia")
-	assertGeneratedFileContains(t, "controllers/widgets.go", "return inertia.Page(etx, \"Widget/Show\"")
+	assertGeneratedFileContains(t, "controllers/widgets.go", "return w.renderer.Page(etx, \"Widget/Show\"")
 }
 
 func TestControllerViewGenerationGoldensVueActionDoesNotInheritTemplViewActions(t *testing.T) {
@@ -271,7 +271,7 @@ func TestControllerViewGenerationGoldensVueActionDoesNotInheritTemplViewActions(
 	assertGeneratedFileContains(t, "controllers/widgets.go", "testapp/internal/hypermedia")
 	assertGeneratedFileContains(t, "controllers/widgets.go", "testapp/internal/inertia")
 	assertGeneratedFileContains(t, "controllers/widgets.go", "return hypermedia.RenderPage(etx, views.WidgetIndex")
-	assertGeneratedFileContains(t, "controllers/widgets.go", "return inertia.Page(etx, \"Widget/Show\"")
+	assertGeneratedFileContains(t, "controllers/widgets.go", "return w.renderer.Page(etx, \"Widget/Show\"")
 }
 
 func TestControllerViewGenerationGoldensVueActionUpdatesRegisterRoutes(t *testing.T) {
@@ -289,7 +289,7 @@ func TestControllerViewGenerationGoldensVueActionUpdatesRegisterRoutes(t *testin
 	assertGeneratedFileContains(t, "controllers/widgets.go", "Handler: w.Index")
 	assertGeneratedFileContains(t, "controllers/widgets.go", "Handler: w.Show")
 	assertGeneratedFileContains(t, "controllers/widgets.go", "return hypermedia.RenderPage(etx, views.WidgetIndex")
-	assertGeneratedFileContains(t, "controllers/widgets.go", "return inertia.Page(etx, \"Widget/Show\"")
+	assertGeneratedFileContains(t, "controllers/widgets.go", "return w.renderer.Page(etx, \"Widget/Show\"")
 }
 
 func setupControllerViewGoldenProject(t *testing.T, cssComponents bool) Coordinator {

--- a/generator/controllers/file_generator.go
+++ b/generator/controllers/file_generator.go
@@ -170,6 +170,16 @@ func (fg *FileGenerator) GenerateControllerWithActionsForModel(
 		if err != nil {
 			return fmt.Errorf("failed to merge controller file: %w", err)
 		}
+		if layout.IsSupportedInertiaAdapter(inertia) {
+			controllerContent, err = EnsureInertiaRendererDependency(
+				controllerContent,
+				controller.PluralResourceName,
+				modulePath,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to inject Inertia renderer dependency: %w", err)
+			}
+		}
 		controllerContent = ensureRegisterRoutes(controllerContent, controller.ReceiverName, controller.PluralResourceName, namespace, resourceName, actions)
 	}
 
@@ -300,6 +310,147 @@ func mergeControllerImports(existingFile, generatedFile *ast.File) {
 			Path: &ast.BasicLit{Kind: token.STRING, Value: spec.Path.Value},
 		})
 	}
+}
+
+// EnsureInertiaRendererDependency adds the renderer field and constructor
+// parameter required by instance-based Inertia actions while preserving the
+// controller's existing dependencies.
+func EnsureInertiaRendererDependency(content, controllerName, modulePath string) (string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "controller.go", content, parser.ParseComments)
+	if err != nil {
+		return "", fmt.Errorf("parse controller: %w", err)
+	}
+
+	ensureControllerImport(file, modulePath+"/internal/inertia")
+
+	var controllerStruct *ast.StructType
+	var constructor *ast.FuncDecl
+	for _, decl := range file.Decls {
+		switch typed := decl.(type) {
+		case *ast.GenDecl:
+			if typed.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range typed.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok || typeSpec.Name.Name != controllerName {
+					continue
+				}
+				controllerStruct, _ = typeSpec.Type.(*ast.StructType)
+			}
+		case *ast.FuncDecl:
+			if typed.Recv == nil && typed.Name.Name == "New"+controllerName {
+				constructor = typed
+			}
+		}
+	}
+	if controllerStruct == nil {
+		return "", fmt.Errorf("controller type %s is not a struct", controllerName)
+	}
+	if constructor == nil {
+		return "", fmt.Errorf("constructor New%s not found", controllerName)
+	}
+
+	if !fieldListHasName(controllerStruct.Fields, "renderer") {
+		controllerStruct.Fields.List = append(controllerStruct.Fields.List, &ast.Field{
+			Names: []*ast.Ident{ast.NewIdent("renderer")},
+			Type: &ast.StarExpr{X: &ast.SelectorExpr{
+				X:   ast.NewIdent("inertia"),
+				Sel: ast.NewIdent("Renderer"),
+			}},
+		})
+	}
+	if !fieldListHasName(constructor.Type.Params, "renderer") {
+		constructor.Type.Params.List = append(constructor.Type.Params.List, &ast.Field{
+			Names: []*ast.Ident{ast.NewIdent("renderer")},
+			Type: &ast.StarExpr{X: &ast.SelectorExpr{
+				X:   ast.NewIdent("inertia"),
+				Sel: ast.NewIdent("Renderer"),
+			}},
+		})
+	}
+
+	constructorUpdated := false
+	ast.Inspect(constructor.Body, func(node ast.Node) bool {
+		composite, ok := node.(*ast.CompositeLit)
+		if !ok || constructorUpdated {
+			return true
+		}
+		ident, ok := composite.Type.(*ast.Ident)
+		if !ok || ident.Name != controllerName {
+			return true
+		}
+		for _, element := range composite.Elts {
+			if keyed, ok := element.(*ast.KeyValueExpr); ok {
+				if key, ok := keyed.Key.(*ast.Ident); ok && key.Name == "renderer" {
+					constructorUpdated = true
+					return false
+				}
+			}
+		}
+		if len(composite.Elts) > 0 {
+			if _, keyed := composite.Elts[0].(*ast.KeyValueExpr); keyed {
+				composite.Elts = append(composite.Elts, &ast.KeyValueExpr{
+					Key:   ast.NewIdent("renderer"),
+					Value: ast.NewIdent("renderer"),
+				})
+				constructorUpdated = true
+				return false
+			}
+		}
+		composite.Elts = append(composite.Elts, ast.NewIdent("renderer"))
+		constructorUpdated = true
+		return false
+	})
+	if !constructorUpdated {
+		return "", fmt.Errorf("constructor New%s does not return %s", controllerName, controllerName)
+	}
+
+	var out strings.Builder
+	if err := format.Node(&out, fset, file); err != nil {
+		return "", fmt.Errorf("format controller: %w", err)
+	}
+	return out.String(), nil
+}
+
+func ensureControllerImport(file *ast.File, importPath string) {
+	quotedPath := fmt.Sprintf("%q", importPath)
+	for _, spec := range file.Imports {
+		if spec.Path.Value == quotedPath {
+			return
+		}
+	}
+
+	var importDecl *ast.GenDecl
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if ok && genDecl.Tok == token.IMPORT {
+			importDecl = genDecl
+			break
+		}
+	}
+	if importDecl == nil {
+		importDecl = &ast.GenDecl{Tok: token.IMPORT}
+		file.Decls = append([]ast.Decl{importDecl}, file.Decls...)
+	}
+	importDecl.Specs = append(importDecl.Specs, &ast.ImportSpec{
+		Path: &ast.BasicLit{Kind: token.STRING, Value: quotedPath},
+	})
+}
+
+func fieldListHasName(fields *ast.FieldList, name string) bool {
+	if fields == nil {
+		return false
+	}
+	for _, field := range fields.List {
+		for _, fieldName := range field.Names {
+			if fieldName.Name == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func importDecl(decl ast.Decl) bool {

--- a/generator/templates/inertia_resource_controller.tmpl
+++ b/generator/templates/inertia_resource_controller.tmpl
@@ -54,11 +54,12 @@ import (
 )
 
 type {{.PluralResourceName}} struct {
-	db storage.Pool
+	db       storage.Pool
+	renderer *inertia.Renderer
 }
 
-func New{{.PluralResourceName}}(db storage.Pool) {{.PluralResourceName}} {
-	return {{.PluralResourceName}}{db}
+func New{{.PluralResourceName}}(db storage.Pool, renderer *inertia.Renderer) {{.PluralResourceName}} {
+	return {{.PluralResourceName}}{db: db, renderer: renderer}
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) RegisterRoutes(r *router.Router) error {
@@ -210,10 +211,10 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		perPage,
 	)
 	if err != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Index", inertia.Props{
+	return {{.ReceiverName}}.renderer.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Index", inertia.Props{
 		"items": new{{.ResourceName}}DataList({{.ModelPluralName | ToCamelCase}}List.{{.ModelPluralResourceName}}),
 	})
 }
@@ -222,38 +223,38 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Show(etx *echo.Context) error {
 {{- if or (not .IDType) (eq .IDType "uuid.UUID")}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int64"}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := strconv.ParseInt(etx.Param("id"), 10, 64)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int32"}}
 	parsed, err := strconv.ParseInt(etx.Param("id"), 10, 32)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 	{{.ResourceName | ToLowerCamelCase}}ID := int32(parsed)
 {{- else if eq .IDType "string"}}
 	{{.ResourceName | ToLowerCamelCase}}ID := etx.Param("id")
 	if {{.ResourceName | ToLowerCamelCase}}ID == "" {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- end}}
 
 	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
-	return inertia.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Show", inertia.Props{
+	return {{.ReceiverName}}.renderer.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Show", inertia.Props{
 		"item": new{{.ResourceName}}Data({{.ResourceName | ToLowerCamelCase}}),
 	})
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) New(etx *echo.Context) error {
-	return inertia.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Create", inertia.Props{})
+	return {{.ReceiverName}}.renderer.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Create", inertia.Props{})
 }
 
 type Create{{.ResourceName}}FormPayload struct {
@@ -278,7 +279,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Create(etx *echo.Context) error
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
 	data := models.Create{{.ModelName}}Data{
@@ -299,22 +300,22 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Create(etx *echo.Context) error
 			return flashErr
 		}
 		{{- if HasAction "new"}}
-		return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}New.URL())
+		return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}New.URL())
 		{{- else}}
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		{{- end}}
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "{{.ResourceName}} created successfully"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	{{- if HasAction "show"}}
-	return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Show.URL({{.ResourceName | ToLowerCamelCase}}.{{.IDGoFieldName}}))
+	return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Show.URL({{.ResourceName | ToLowerCamelCase}}.{{.IDGoFieldName}}))
 	{{- else}}
 	_ = {{.ResourceName | ToLowerCamelCase}}
 	{{- if HasAction "index"}}
-	return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
+	return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
 	{{- else}}
 	return etx.NoContent(201)
 	{{- end}}
@@ -325,32 +326,32 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Edit(etx *echo.Context) error {
 {{- if or (not .IDType) (eq .IDType "uuid.UUID")}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int64"}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := strconv.ParseInt(etx.Param("id"), 10, 64)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int32"}}
 	parsed, err := strconv.ParseInt(etx.Param("id"), 10, 32)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 	{{.ResourceName | ToLowerCamelCase}}ID := int32(parsed)
 {{- else if eq .IDType "string"}}
 	{{.ResourceName | ToLowerCamelCase}}ID := etx.Param("id")
 	if {{.ResourceName | ToLowerCamelCase}}ID == "" {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- end}}
 
 	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
-	return inertia.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Edit", inertia.Props{
+	return {{.ReceiverName}}.renderer.Page(etx, "{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Edit", inertia.Props{
 		"item": new{{.ResourceName}}Data({{.ResourceName | ToLowerCamelCase}}),
 	})
 }
@@ -371,23 +372,23 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Update(etx *echo.Context) error
 {{- if or (not .IDType) (eq .IDType "uuid.UUID")}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int64"}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := strconv.ParseInt(etx.Param("id"), 10, 64)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int32"}}
 	parsed, err := strconv.ParseInt(etx.Param("id"), 10, 32)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 	{{.ResourceName | ToLowerCamelCase}}ID := int32(parsed)
 {{- else if eq .IDType "string"}}
 	{{.ResourceName | ToLowerCamelCase}}ID := etx.Param("id")
 	if {{.ResourceName | ToLowerCamelCase}}ID == "" {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- end}}
 
@@ -400,7 +401,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Update(etx *echo.Context) error
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
 	data := models.Update{{.ModelName}}Data{
@@ -419,28 +420,28 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Update(etx *echo.Context) error
 	)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to update {{.ResourceName | ToLowerCamelCase}}: %v", err)); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		{{- if HasAction "edit"}}
-		return inertia.Redirect(
+		return {{.ReceiverName}}.renderer.Redirect(
 			etx,
 			routes.{{.NamespacePascal}}{{.ResourceName}}Edit.URL({{.ResourceName | ToLowerCamelCase}}ID),
 		)
 		{{- else}}
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		{{- end}}
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "{{.ResourceName}} updated successfully"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	{{- if HasAction "show"}}
-	return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Show.URL({{.ResourceName | ToLowerCamelCase}}.{{.IDGoFieldName}}))
+	return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Show.URL({{.ResourceName | ToLowerCamelCase}}.{{.IDGoFieldName}}))
 	{{- else}}
 	_ = {{.ResourceName | ToLowerCamelCase}}
 	{{- if HasAction "index"}}
-	return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
+	return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
 	{{- else}}
 	return etx.NoContent(200)
 	{{- end}}
@@ -451,44 +452,44 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Destroy(etx *echo.Context) erro
 {{- if or (not .IDType) (eq .IDType "uuid.UUID")}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int64"}}
 	{{.ResourceName | ToLowerCamelCase}}ID, err := strconv.ParseInt(etx.Param("id"), 10, 64)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- else if eq .IDType "int32"}}
 	parsed, err := strconv.ParseInt(etx.Param("id"), 10, 32)
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 	{{.ResourceName | ToLowerCamelCase}}ID := int32(parsed)
 {{- else if eq .IDType "string"}}
 	{{.ResourceName | ToLowerCamelCase}}ID := etx.Param("id")
 	if {{.ResourceName | ToLowerCamelCase}}ID == "" {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 {{- end}}
 
 	err = models.{{.ModelName}}.Destroy(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete {{.ResourceName | ToLowerCamelCase}}: %v", err)); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		{{- if HasAction "index"}}
-		return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
+		return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
 		{{- else}}
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		{{- end}}
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "{{.ResourceName}} destroyed successfully"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	{{- if HasAction "index"}}
-	return inertia.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
+	return {{.ReceiverName}}.renderer.Redirect(etx, routes.{{.NamespacePascal}}{{.ResourceName}}Index.URL())
 	{{- else}}
 	return etx.NoContent(200)
 	{{- end}}

--- a/generator/testdata/golden/scaffold/vue/controllers/projects.go.golden
+++ b/generator/testdata/golden/scaffold/vue/controllers/projects.go.golden
@@ -19,11 +19,12 @@ import (
 )
 
 type Projects struct {
-	db storage.Pool
+	db       storage.Pool
+	renderer *inertia.Renderer
 }
 
-func NewProjects(db storage.Pool) Projects {
-	return Projects{db}
+func NewProjects(db storage.Pool, renderer *inertia.Renderer) Projects {
+	return Projects{db: db, renderer: renderer}
 }
 
 func (p Projects) RegisterRoutes(r *router.Router) error {
@@ -146,10 +147,10 @@ func (p Projects) Index(etx *echo.Context) error {
 		perPage,
 	)
 	if err != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Page(etx, "Project/Index", inertia.Props{
+	return p.renderer.Page(etx, "Project/Index", inertia.Props{
 		"items": newProjectDataList(projectsList.Projects),
 	})
 }
@@ -157,21 +158,21 @@ func (p Projects) Index(etx *echo.Context) error {
 func (p Projects) Show(etx *echo.Context) error {
 	projectID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	project, err := models.Project.Find(etx.Request().Context(), p.db.Executor(), projectID)
 	if err != nil {
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
-	return inertia.Page(etx, "Project/Show", inertia.Props{
+	return p.renderer.Page(etx, "Project/Show", inertia.Props{
 		"item": newProjectData(project),
 	})
 }
 
 func (p Projects) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Project/Create", inertia.Props{})
+	return p.renderer.Page(etx, "Project/Create", inertia.Props{})
 }
 
 type CreateProjectFormPayload struct {
@@ -189,7 +190,7 @@ func (p Projects) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
 	data := models.CreateProjectData{
@@ -208,27 +209,27 @@ func (p Projects) Create(etx *echo.Context) error {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to create project: %v", err)); flashErr != nil {
 			return flashErr
 		}
-		return inertia.Redirect(etx, routes.ProjectNew.URL())
+		return p.renderer.Redirect(etx, routes.ProjectNew.URL())
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Project created successfully"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
-	return inertia.Redirect(etx, routes.ProjectShow.URL(project.ID))
+	return p.renderer.Redirect(etx, routes.ProjectShow.URL(project.ID))
 }
 
 func (p Projects) Edit(etx *echo.Context) error {
 	projectID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	project, err := models.Project.Find(etx.Request().Context(), p.db.Executor(), projectID)
 	if err != nil {
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
-	return inertia.Page(etx, "Project/Edit", inertia.Props{
+	return p.renderer.Page(etx, "Project/Edit", inertia.Props{
 		"item": newProjectData(project),
 	})
 }
@@ -241,7 +242,7 @@ type UpdateProjectFormPayload struct {
 func (p Projects) Update(etx *echo.Context) error {
 	projectID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	var payload UpdateProjectFormPayload
@@ -253,7 +254,7 @@ func (p Projects) Update(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
 
 	data := models.UpdateProjectData{
@@ -271,36 +272,36 @@ func (p Projects) Update(etx *echo.Context) error {
 	)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to update project: %v", err)); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(
+		return p.renderer.Redirect(
 			etx,
 			routes.ProjectEdit.URL(projectID),
 		)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Project updated successfully"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
-	return inertia.Redirect(etx, routes.ProjectShow.URL(project.ID))
+	return p.renderer.Redirect(etx, routes.ProjectShow.URL(project.ID))
 }
 
 func (p Projects) Destroy(etx *echo.Context) error {
 	projectID, err := uuid.Parse(etx.Param("id"))
 	if err != nil {
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	err = models.Project.Destroy(etx.Request().Context(), p.db.Executor(), projectID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete project: %v", err)); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ProjectIndex.URL())
+		return p.renderer.Redirect(etx, routes.ProjectIndex.URL())
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Project destroyed successfully"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
-	return inertia.Redirect(etx, routes.ProjectIndex.URL())
+	return p.renderer.Redirect(etx, routes.ProjectIndex.URL())
 }

--- a/layout/inertia_react_test.go
+++ b/layout/inertia_react_test.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -51,17 +52,35 @@ func TestScaffoldReactInertiaAssets(t *testing.T) {
 	assertFileNotContains(t, projectDir, "resources/js/app.tsx", "ComponentType<any>")
 	assertFileNotContains(t, projectDir, "resources/js/app.tsx", "Record<string, any>")
 	assertFileContains(t, projectDir, "cmd/app/main.go", "internal/inertia")
-	assertFileContains(t, projectDir, "cmd/app/main.go", `inertia.Init("inertia/root.go.html")`)
-	assertFileContains(t, projectDir, "internal/inertia/render.go", `"testapp/assets"`)
-	assertFileContains(t, projectDir, "internal/inertia/render.go", `func Init(rootPath string, opts ...Option) error`)
-	assertFileContains(t, projectDir, "internal/inertia/render.go", `assets.Files.ReadFile(rootPath)`)
+	assertFileContains(t, projectDir, "cmd/app/main.go", `func provideInertia() (*inertia.Renderer, error)`)
+	assertFileContains(t, projectDir, "cmd/app/main.go", `fx.Provide(`)
+	assertFileContains(t, projectDir, "cmd/app/main.go", `provideInertia,`)
+	assertFileContains(t, projectDir, "cmd/app/main.go", `inertia.WithRequestProps(`)
+	assertFileContains(t, projectDir, "internal/inertia/render.go", `type Renderer struct`)
+	assertFileContains(t, projectDir, "internal/inertia/render.go", `assetFS fs.FS,`)
+	assertFileContains(t, projectDir, "internal/inertia/render.go", `func (r *Renderer) Page(`)
+	assertFileContains(t, projectDir, "internal/inertia/render.go", `fs.ReadFile(assetFS, rootPath)`)
 	assertFileContains(t, projectDir, "internal/inertia/render.go", `errors.Is(err, fs.ErrNotExist)`)
 	assertFileContains(t, projectDir, "internal/inertia/render.go", `add it at assets/%s and rebuild`)
 	assertFileContains(t, projectDir, "internal/inertia/render.go", `gonertia.NewFromBytes(rootHTML, opts...)`)
 	assertFileNotContains(t, projectDir, "internal/inertia/render.go", "andurel.lock")
+	for _, forbiddenImport := range []string{
+		`"testapp/assets"`,
+		`"testapp/config"`,
+		`"testapp/internal/request"`,
+		`"testapp/router/cookies"`,
+		`"testapp/router/routes"`,
+	} {
+		assertFileNotContains(t, projectDir, "internal/inertia/render.go", forbiddenImport)
+		assertFileNotContains(t, projectDir, "internal/inertia/vite.go", forbiddenImport)
+	}
 	assertFileContains(t, projectDir, "assets/inertia/root.go.html", `{{ .inertia }}`)
 	assertFileMissing(t, projectDir, "views/root.go.html")
-	assertFileContains(t, projectDir, "router/router.go", "inertia.Middleware()")
+	assertFileContains(t, projectDir, "internal/inertia/render_test.go", "TestRendererPageIncludesRequestProps")
+	assertFileContains(t, projectDir, "router/router.go", "renderer *inertia.Renderer")
+	assertFileContains(t, projectDir, "router/router.go", "renderer.Middleware()")
+	assertFileContains(t, projectDir, "controllers/sessions.go", "renderer *inertia.Renderer")
+	assertFileContains(t, projectDir, "controllers/sessions.go", `s.renderer.Page(etx, "Auth/Login"`)
 	assertFileContains(t, projectDir, "go.mod", "github.com/romsar/gonertia")
 	assertFileMissing(t, projectDir, "resources/js/app.ts")
 	assertFileMissing(t, projectDir, "resources/js/Pages/Head.tsx")
@@ -73,6 +92,20 @@ func TestScaffoldReactInertiaAssets(t *testing.T) {
 	assertFileMissing(t, projectDir, "views/registration.templ")
 	assertFileMissing(t, projectDir, "views/reset_password.templ")
 	assertFileMissing(t, projectDir, "views/confirm_email.templ")
+
+	cmd := exec.Command("go", "test", "./internal/inertia")
+	cmd.Dir = projectDir
+	cmd.Env = append(os.Environ(), "GOWORK=off", "GOCACHE="+filepath.Join(projectDir, ".gocache"))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("generated Inertia tests failed: %v\n%s", err, output)
+	}
+
+	cmd = exec.Command("go", "vet", "./...")
+	cmd.Dir = projectDir
+	cmd.Env = append(os.Environ(), "GOWORK=off", "GOCACHE="+filepath.Join(projectDir, ".gocache"))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("generated Inertia project failed go vet: %v\n%s", err, output)
+	}
 
 	lock, err := ReadLockFile(projectDir)
 	if err != nil {

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -393,6 +393,7 @@ var inertiaSharedTemplateMappings = map[TmplTarget]TmplTargetPath{
 	"inertia_framework_root_html.tmpl": "assets/inertia/root.go.html",
 	"inertia_page_options.tmpl":        "internal/inertia/page_options.go",
 	"inertia_render.tmpl":              "internal/inertia/render.go",
+	"inertia_render_test.tmpl":         "internal/inertia/render_test.go",
 	"inertia_assets_routes.tmpl":       "resources/js/routes.ts",
 	"inertia_vite.tmpl":                "internal/inertia/vite.go",
 }

--- a/layout/templates/cmd_app_main.tmpl
+++ b/layout/templates/cmd_app_main.tmpl
@@ -11,6 +11,9 @@ import (
 	"syscall"
 	"time"
 
+{{if .Inertia}}
+	"{{.ModuleName}}/assets"
+{{- end}}
 	mailclients "{{.ModuleName}}/clients/email"
 	"{{.ModuleName}}/config"
 	"{{.ModuleName}}/controllers"
@@ -18,10 +21,15 @@ import (
 	"{{.ModuleName}}/email"
 {{- if .Inertia}}
 	"{{.ModuleName}}/internal/inertia"
+	"{{.ModuleName}}/internal/request"
 {{- end}}
 	"{{.ModuleName}}/internal/server"
 	"{{.ModuleName}}/queue"
 	"{{.ModuleName}}/router"
+{{- if .Inertia}}
+	"{{.ModuleName}}/router/cookies"
+	"{{.ModuleName}}/router/routes"
+{{- end}}
 	"{{.ModuleName}}/services"
 	"{{.ModuleName}}/telemetry"
 
@@ -30,20 +38,38 @@ import (
 
 var appVersion string
 
+{{- if .Inertia}}
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+{{- end}}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-
-{{- if .Inertia}}
-	if err := inertia.Init("inertia/root.go.html"); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize inertia: %s\n", err)
-		os.Exit(1)
-	}
-
-{{- end}}
 	app := fx.New(
 		fx.Provide(
 			func() context.Context { return ctx },
+{{- if .Inertia}}
+			provideInertia,
+{{- end}}
 			func(cfg config.Config) (email.TransactionalSender, email.MarketingSender) {
 				if config.Env == server.ProdEnvironment {
 					log.Fatal("provide real email sender")

--- a/layout/templates/cmd_app_main.tmpl
+++ b/layout/templates/cmd_app_main.tmpl
@@ -38,29 +38,6 @@ import (
 
 var appVersion string
 
-{{- if .Inertia}}
-func provideInertia() (*inertia.Renderer, error) {
-	return inertia.New(
-		assets.Files,
-		"inertia/root.go.html",
-		config.ProjectName,
-		config.Env,
-		routes.ViteBuild.Path(),
-		inertia.WithSharedProp("appVersion", appVersion),
-		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
-			flashes := request.ExtractContext[[]cookies.FlashMessage](
-				ctx,
-				request.SessionFlashesKey,
-			)
-			if len(flashes) == 0 {
-				return nil
-			}
-			return inertia.Props{"flash": flashes}
-		}),
-	)
-}
-{{- end}}
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -107,6 +84,29 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+{{- if .Inertia}}
+func provideInertia() (*inertia.Renderer, error) {
+	return inertia.New(
+		assets.Files,
+		"inertia/root.go.html",
+		config.ProjectName,
+		config.Env,
+		routes.ViteBuild.Path(),
+		inertia.WithSharedProp("appVersion", appVersion),
+		inertia.WithRequestProps(func(ctx context.Context) inertia.Props {
+			flashes := request.ExtractContext[[]cookies.FlashMessage](
+				ctx,
+				request.SessionFlashesKey,
+			)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return inertia.Props{"flash": flashes}
+		}),
+	)
+}
+{{- end}}
 
 func startQueueProcessor(lc fx.Lifecycle, appCtx context.Context, p queue.Processor) {
 	var done <-chan struct{}

--- a/layout/templates/cmd_app_main.tmpl
+++ b/layout/templates/cmd_app_main.tmpl
@@ -84,8 +84,7 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-{{- if .Inertia}}
+{{if .Inertia}}
 func provideInertia() (*inertia.Renderer, error) {
 	return inertia.New(
 		assets.Files,

--- a/layout/templates/controllers_confirmations_inertia.tmpl
+++ b/layout/templates/controllers_confirmations_inertia.tmpl
@@ -17,10 +17,11 @@ import (
 
 type Confirmations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewConfirmations(identity services.Identity) Confirmations {
-	return Confirmations{identity}
+func NewConfirmations(identity services.Identity, renderer *inertia.Renderer) Confirmations {
+	return Confirmations{identity: identity, renderer: renderer}
 }
 
 func (c Confirmations) RegisterRoutes(r *router.Router) error {
@@ -50,7 +51,7 @@ func (c Confirmations) RegisterRoutes(r *router.Router) error {
 }
 
 func (c Confirmations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
+	return c.renderer.Page(etx, "Auth/ConfirmEmail", inertia.Props{})
 }
 
 func (c Confirmations) Create(etx *echo.Context) error {
@@ -65,7 +66,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := c.identity.VerifyEmail(
@@ -76,7 +77,7 @@ func (c Confirmations) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return c.renderer.Page(
 				etx,
 				"Auth/ConfirmEmail",
 				inertia.Props{},
@@ -102,9 +103,9 @@ func (c Confirmations) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+		return c.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -115,12 +116,12 @@ func (c Confirmations) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Email verified successfully!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return c.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return c.renderer.Location(etx, routes.HomePage.URL())
 }

--- a/layout/templates/controllers_pages_inertia.tmpl
+++ b/layout/templates/controllers_pages_inertia.tmpl
@@ -18,13 +18,15 @@ import (
 type Pages struct {
 	db         storage.Pool
 	insertOnly queue.InsertOnly
+	renderer   *inertia.Renderer
 }
 
 func NewPages(
 	db storage.Pool,
 	insertOnly queue.InsertOnly,
+	renderer *inertia.Renderer,
 ) Pages {
-	return Pages{db, insertOnly}
+	return Pages{db: db, insertOnly: insertOnly, renderer: renderer}
 }
 
 func (p Pages) RegisterRoutes(r *router.Router) error {
@@ -60,5 +62,5 @@ func (p Pages) Home(etx *echo.Context) error {
 }
 
 func (p Pages) NotFound(etx *echo.Context) error {
-	return inertia.Page(etx, "Errors/NotFound", inertia.Props{})
+	return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 }

--- a/layout/templates/controllers_registrations_inertia.tmpl
+++ b/layout/templates/controllers_registrations_inertia.tmpl
@@ -18,10 +18,11 @@ import (
 
 type Registrations struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewRegistrations(identity services.Identity) Registrations {
-	return Registrations{identity}
+func NewRegistrations(identity services.Identity, renderer *inertia.Renderer) Registrations {
+	return Registrations{identity: identity, renderer: renderer}
 }
 
 func (r Registrations) RegisterRoutes(rtr *router.Router) error {
@@ -54,7 +55,7 @@ func (r Registrations) RegisterRoutes(rtr *router.Router) error {
 }
 
 func (r Registrations) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Registration", inertia.Props{})
+	return r.renderer.Page(etx, "Auth/Registration", inertia.Props{})
 }
 
 func (r Registrations) Create(etx *echo.Context) error {
@@ -71,7 +72,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return r.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := r.identity.RegisterUser(
@@ -83,7 +84,7 @@ func (r Registrations) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return r.renderer.Page(
 				etx,
 				"Auth/Registration",
 				inertia.Props{},
@@ -99,11 +100,11 @@ func (r Registrations) Create(etx *echo.Context) error {
 		)
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to register user"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return r.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.RegistrationNew.URL())
+		return r.renderer.Redirect(etx, routes.RegistrationNew.URL())
 	}
 
-	return inertia.Redirect(etx, routes.ConfirmationNew.URL())
+	return r.renderer.Redirect(etx, routes.ConfirmationNew.URL())
 }

--- a/layout/templates/controllers_reset_passwords_inertia.tmpl
+++ b/layout/templates/controllers_reset_passwords_inertia.tmpl
@@ -17,10 +17,11 @@ import (
 
 type ResetPasswords struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewResetPasswords(identity services.Identity) ResetPasswords {
-	return ResetPasswords{identity}
+func NewResetPasswords(identity services.Identity, renderer *inertia.Renderer) ResetPasswords {
+	return ResetPasswords{identity: identity, renderer: renderer}
 }
 
 func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
@@ -70,7 +71,7 @@ func (rp ResetPasswords) RegisterRoutes(r *router.Router) error {
 }
 
 func (rp ResetPasswords) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
+	return rp.renderer.Page(etx, "Auth/ResetPasswordRequest", inertia.Props{})
 }
 
 func (rp ResetPasswords) Create(etx *echo.Context) error {
@@ -86,7 +87,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.RequestResetPassword(
@@ -96,7 +97,7 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPasswordRequest",
 				inertia.Props{},
@@ -111,17 +112,17 @@ func (rp ResetPasswords) Create(etx *echo.Context) error {
 			err,
 		)
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Failed to send password reset code"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "If an account exists with that email, you will receive password reset instructions."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }
 
 func (rp ResetPasswords) Edit(etx *echo.Context) error {
@@ -130,12 +131,12 @@ func (rp ResetPasswords) Edit(etx *echo.Context) error {
 	token := etx.Param("token")
 	if token == "" {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, "Invalid or missing reset token"); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
-		return inertia.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, routes.PasswordNew.URL(), http.StatusSeeOther)
 	}
 
-	return inertia.Page(etx, "Auth/ResetPassword", inertia.Props{
+	return rp.renderer.Page(etx, "Auth/ResetPassword", inertia.Props{
 		"token": token,
 	})
 }
@@ -154,7 +155,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	if err := rp.identity.ResetPassword(
@@ -166,7 +167,7 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		},
 	); err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return rp.renderer.Page(
 				etx,
 				"Auth/ResetPassword",
 				inertia.Props{"token": payload.Token},
@@ -192,19 +193,19 @@ func (rp ResetPasswords) Update(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 		redirectPath := routes.PasswordEdit.URL(payload.Token)
 		if payload.Token != "" {
 			redirectPath = routes.PasswordEdit.URL(payload.Token)
 		}
 
-		return inertia.Redirect(etx, redirectPath, http.StatusSeeOther)
+		return rp.renderer.Redirect(etx, redirectPath, http.StatusSeeOther)
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Password reset successfully! Please log in."); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return rp.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return rp.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }

--- a/layout/templates/controllers_sessions_inertia.tmpl
+++ b/layout/templates/controllers_sessions_inertia.tmpl
@@ -18,10 +18,11 @@ import (
 
 type Sessions struct {
 	identity services.Identity
+	renderer *inertia.Renderer
 }
 
-func NewSessions(identity services.Identity) Sessions {
-	return Sessions{identity}
+func NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {
+	return Sessions{identity: identity, renderer: renderer}
 }
 
 func (s Sessions) RegisterRoutes(r *router.Router) error {
@@ -64,7 +65,7 @@ func (s Sessions) RegisterRoutes(r *router.Router) error {
 }
 
 func (s Sessions) New(etx *echo.Context) error {
-	return inertia.Page(etx, "Auth/Login", inertia.Props{})
+	return s.renderer.Page(etx, "Auth/Login", inertia.Props{})
 }
 
 func (s Sessions) Create(etx *echo.Context) error {
@@ -80,7 +81,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/BadRequest", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
 	user, err := s.identity.AuthenticateUser(
@@ -92,7 +93,7 @@ func (s Sessions) Create(etx *echo.Context) error {
 	)
 	if err != nil {
 		if validationErrors, ok := validation.As(err); ok {
-			return inertia.Page(
+			return s.renderer.Page(
 				etx,
 				"Auth/Login",
 				inertia.Props{},
@@ -118,10 +119,10 @@ func (s Sessions) Create(etx *echo.Context) error {
 		}
 
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, errorMsg); flashErr != nil {
-			return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+			return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 		}
 
-		return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+		return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 	}
 
 	if err := cookies.CreateAppSession(etx, user); err != nil {
@@ -132,14 +133,14 @@ func (s Sessions) Create(etx *echo.Context) error {
 			err,
 		)
 
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged in!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Location(etx, routes.HomePage.URL())
+	return s.renderer.Location(etx, routes.HomePage.URL())
 }
 
 func (s Sessions) Destroy(etx *echo.Context) error {
@@ -150,12 +151,12 @@ func (s Sessions) Destroy(etx *echo.Context) error {
 			"error",
 			err,
 		)
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
 	if flashErr := cookies.AddFlash(etx, cookies.FlashSuccess, "Successfully logged out!"); flashErr != nil {
-		return inertia.Page(etx, "Errors/InternalError", inertia.Props{})
+		return s.renderer.Page(etx, "Errors/InternalError", inertia.Props{})
 	}
 
-	return inertia.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
+	return s.renderer.Redirect(etx, routes.SessionNew.URL(), http.StatusSeeOther)
 }

--- a/layout/templates/inertia_render.tmpl
+++ b/layout/templates/inertia_render.tmpl
@@ -3,6 +3,7 @@
 package inertia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -10,51 +11,104 @@ import (
 
 	"github.com/labstack/echo/v5"
 	gonertia "github.com/romsar/gonertia/v3"
-
-	"{{.ModuleName}}/assets"
-	"{{.ModuleName}}/config"
-	"{{.ModuleName}}/internal/request"
-	"{{.ModuleName}}/router/cookies"
 )
 
 type Props = gonertia.Props
-type Option = gonertia.Option
 
-var gInertia *gonertia.Inertia
+type RequestPropsProvider func(context.Context) Props
 
-func Init(rootPath string, opts ...Option) error {
-	rootHTML, err := assets.Files.ReadFile(rootPath)
+type Option func(*rendererOptions)
+
+type rendererOptions struct {
+	gonertiaOptions      []gonertia.Option
+	sharedProps          Props
+	requestPropsProviders []RequestPropsProvider
+}
+
+type Renderer struct {
+	engine                *gonertia.Inertia
+	requestPropsProviders []RequestPropsProvider
+}
+
+func WithGonertiaOptions(opts ...gonertia.Option) Option {
+	return func(options *rendererOptions) {
+		options.gonertiaOptions = append(options.gonertiaOptions, opts...)
+	}
+}
+
+func WithSharedProp(key string, value any) Option {
+	return func(options *rendererOptions) {
+		if options.sharedProps == nil {
+			options.sharedProps = make(Props)
+		}
+		options.sharedProps[key] = value
+	}
+}
+
+func WithRequestProps(provider RequestPropsProvider) Option {
+	return func(options *rendererOptions) {
+		if provider != nil {
+			options.requestPropsProviders = append(options.requestPropsProviders, provider)
+		}
+	}
+}
+
+func New(
+	assetFS fs.FS,
+	rootPath string,
+	projectName string,
+	environment string,
+	buildPathURL string,
+	options ...Option,
+) (*Renderer, error) {
+	if assetFS == nil {
+		return nil, errors.New("inertia: asset filesystem is nil")
+	}
+
+	rootHTML, err := fs.ReadFile(assetFS, rootPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"inertia: embedded root template %q not found; add it at assets/%s and rebuild",
 			rootPath,
 			rootPath,
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
+		return nil, fmt.Errorf("inertia: read embedded root template %q: %w", rootPath, err)
 	}
 
-	tags, err := initVite()
+	tags, err := initVite(assetFS, environment, buildPathURL)
 	if err != nil {
-		return fmt.Errorf("inertia: vite init: %w", err)
+		return nil, fmt.Errorf("inertia: vite init: %w", err)
 	}
 
-	i, err := gonertia.NewFromBytes(rootHTML, opts...)
+	rendererOptions := rendererOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&rendererOptions)
+		}
+	}
+	opts := rendererOptions.gonertiaOptions
+	engine, err := gonertia.NewFromBytes(rootHTML, opts...)
 	if err != nil {
-		return fmt.Errorf("inertia: create renderer: %v", err)
+		return nil, fmt.Errorf("inertia: create renderer: %v", err)
 	}
 
-	i.ShareTemplateData("viteHead", tags.ViteHead)
-	i.ShareTemplateData("viteBody", tags.ViteBody)
-	i.ShareTemplateData("appName", config.ProjectName)
+	engine.ShareTemplateData("viteHead", tags.ViteHead)
+	engine.ShareTemplateData("viteBody", tags.ViteBody)
+	engine.ShareTemplateData("appName", projectName)
+	for key, value := range rendererOptions.sharedProps {
+		engine.ShareProp(key, value)
+	}
 
-	gInertia = i
-	return nil
+	return &Renderer{
+		engine:                engine,
+		requestPropsProviders: rendererOptions.requestPropsProviders,
+	}, nil
 }
 
-func Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
-	if gInertia == nil {
+func (r *Renderer) Page(etx *echo.Context, component string, props Props, opts ...PageOption) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
 
@@ -71,40 +125,41 @@ func Page(etx *echo.Context, component string, props Props, opts ...PageOption) 
 		)))
 	}
 
-	if flashes := request.ExtractContext[[]cookies.FlashMessage](
-		etx.Request().Context(), request.SessionFlashesKey,
-	); len(flashes) > 0 {
-		if props == nil {
-			props = make(Props)
+	mergedProps := make(Props, len(props))
+	for key, value := range props {
+		mergedProps[key] = value
+	}
+	for _, provider := range r.requestPropsProviders {
+		for key, value := range provider(etx.Request().Context()) {
+			mergedProps[key] = value
 		}
-		props["flash"] = flashes
 	}
 
-	if err := gInertia.Render(etx.Response(), etx.Request(), component, props); err != nil {
+	if err := r.engine.Render(etx.Response(), etx.Request(), component, mergedProps); err != nil {
 		return fmt.Errorf("inertia: render page: %v", err)
 	}
 
 	return nil
 }
 
-func Redirect(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Redirect(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Redirect(etx.Response(), etx.Request(), url, status...)
+	r.engine.Redirect(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Location(etx *echo.Context, url string, status ...int) error {
-	if gInertia == nil {
+func (r *Renderer) Location(etx *echo.Context, url string, status ...int) error {
+	if r == nil || r.engine == nil {
 		return errors.New("inertia: not initialized")
 	}
-	gInertia.Location(etx.Response(), etx.Request(), url, status...)
+	r.engine.Location(etx.Response(), etx.Request(), url, status...)
 	return nil
 }
 
-func Middleware() echo.MiddlewareFunc {
-	if gInertia == nil {
+func (r *Renderer) Middleware() echo.MiddlewareFunc {
+	if r == nil || r.engine == nil {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c *echo.Context) error {
 				return errors.New("inertia: not initialized")
@@ -113,6 +168,6 @@ func Middleware() echo.MiddlewareFunc {
 	}
 
 	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
-		return gInertia.Middleware(next)
+		return r.engine.Middleware(next)
 	})
 }

--- a/layout/templates/inertia_render_test.tmpl
+++ b/layout/templates/inertia_render_test.tmpl
@@ -1,0 +1,132 @@
+package inertia
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v5"
+)
+
+type flashContextKey struct{}
+
+func TestRendererPageIncludesRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{"{{"}} .inertia {{"}}"}}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(ctx context.Context) Props {
+			flashes, _ := ctx.Value(flashContextKey{}).([]string)
+			if len(flashes) == 0 {
+				return nil
+			}
+			return Props{"flash": flashes}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	req = req.WithContext(context.WithValue(req.Context(), flashContextKey{}, []string{"saved"}))
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", Props{"name": "Ada"}); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if got := string(page.Props["flash"]); got != `["saved"]` {
+		t.Fatalf("flash prop = %s, want %s", got, `["saved"]`)
+	}
+}
+
+func TestRendererOmitsEmptyRequestProps(t *testing.T) {
+	renderer, err := New(
+		fstest.MapFS{
+			"inertia/root.go.html": &fstest.MapFile{Data: []byte(`<main>{{"{{"}} .inertia {{"}}"}}</main>`)},
+		},
+		"inertia/root.go.html",
+		"testapp",
+		"testing",
+		"/assets/dist/123/*",
+		WithRequestProps(func(context.Context) Props { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/account", nil)
+	req.Header.Set("X-Inertia", "true")
+	rec := httptest.NewRecorder()
+	etx := e.NewContext(req, rec)
+
+	if err := renderer.Page(etx, "Account/Show", nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	var page struct {
+		Props map[string]json.RawMessage `json:"props"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if _, ok := page.Props["flash"]; ok {
+		t.Fatalf("empty flash prop was included: %s", rec.Body.String())
+	}
+}
+
+func TestInitViteUsesInjectedFilesystemAndBuildPath(t *testing.T) {
+	assetFS := fstest.MapFS{
+		"dist/vite/manifest.json": &fstest.MapFile{Data: []byte(`{
+{{- if or (eq .Inertia "vue") (eq .Inertia "svelte")}}
+  "resources/js/app.ts": {"file":"app.js","css":["app.css"],"src":"resources/js/app.ts","isEntry":true}
+{{- end}}
+{{- if eq .Inertia "react"}}
+  "resources/js/app.tsx": {"file":"app.js","css":["app.css"],"src":"resources/js/app.tsx","isEntry":true}
+{{- end}}
+}`)},
+	}
+
+	tags, err := initVite(assetFS, "production", "/assets/dist/123/*")
+	if err != nil {
+		t.Fatalf("initVite: %v", err)
+	}
+	if !strings.Contains(string(tags.ViteHead), `href="/assets/dist/123/app.css"`) {
+		t.Fatalf("ViteHead = %q", tags.ViteHead)
+	}
+	if !strings.Contains(string(tags.ViteBody), `src="/assets/dist/123/app.js"`) {
+		t.Fatalf("ViteBody = %q", tags.ViteBody)
+	}
+}
+
+func TestRendererReportsMissingRoot(t *testing.T) {
+	_, err := New(fstest.MapFS{}, "inertia/root.go.html", "testapp", "testing", "/assets/dist/123/*")
+	if err == nil {
+		t.Fatal("New returned nil error")
+	}
+	if !strings.Contains(err.Error(), "add it at assets/inertia/root.go.html and rebuild") {
+		t.Fatalf("New error = %q", err)
+	}
+	if !strings.Contains(err.Error(), fs.ErrNotExist.Error()) && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("New error does not describe a missing file: %q", err)
+	}
+}

--- a/layout/templates/inertia_vite.tmpl
+++ b/layout/templates/inertia_vite.tmpl
@@ -6,12 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"strings"
 
-	"{{.ModuleName}}/assets"
-	"{{.ModuleName}}/config"
 	"{{.ModuleName}}/internal/server"
-	"{{.ModuleName}}/router/routes"
 )
 
 type viteTags struct {
@@ -26,8 +24,8 @@ type viteManifestEntry struct {
 	IsEntry bool     `json:"isEntry"`
 }
 
-func initVite() (*viteTags, error) {
-	if config.Env != server.ProdEnvironment {
+func initVite(assetFS fs.FS, environment string, buildPathURL string) (*viteTags, error) {
+	if environment != server.ProdEnvironment {
 		tags := &viteTags{
 			ViteHead: template.HTML(`<script type="module" src="http://localhost:5173/assets/dist/@vite/client"></script>`),
 		}
@@ -47,7 +45,7 @@ window.__vite_plugin_react_preamble_installed__ = true
 		return tags, nil
 	}
 
-	data, err := assets.Files.ReadFile("dist/vite/manifest.json")
+	data, err := fs.ReadFile(assetFS, "dist/vite/manifest.json")
 	if err != nil {
 		return nil, fmt.Errorf("vite: read manifest: %w", err)
 	}
@@ -69,7 +67,7 @@ window.__vite_plugin_react_preamble_installed__ = true
 	}
 	{{end}}
 	tags := &viteTags{}
-	viteBuildPrefix := strings.TrimSuffix(routes.ViteBuild.Path(), "*")
+	viteBuildPrefix := strings.TrimSuffix(buildPathURL, "*")
 	for _, css := range entry.CSS {
 		tags.ViteHead += template.HTML(`<link rel="stylesheet" href="` + viteBuildPrefix + css + `">`)
 	}

--- a/layout/templates/router_router.tmpl
+++ b/layout/templates/router_router.tmpl
@@ -36,6 +36,9 @@ type Router struct {
 func New(
 	cfg config.Config,
 	tel *telemetry.Telemetry,
+{{- if .Inertia}}
+	renderer *inertia.Renderer,
+{{- end}}
 ) (*Router, error) {
 	gob.Register(uuid.UUID{})
 	gob.Register(cookies.FlashMessage{})
@@ -74,7 +77,18 @@ func New(
 		defaultHTTPErrorHandler(c, err)
 	}
 
+{{if .Inertia}}
+	globalMiddleware, err := SetupGlobalMiddleware(
+		cfg,
+		tel,
+		authKey,
+		encKey,
+		"_csrf",
+		renderer,
+	)
+{{- else}}
 	globalMiddleware, err := SetupGlobalMiddleware(cfg, tel, authKey, encKey, "_csrf")
+{{- end}}
 	if err != nil {
 		return nil, err
 	}
@@ -95,6 +109,9 @@ func SetupGlobalMiddleware(
 	authKey []byte,
 	encKey []byte,
 	csrfName string,
+{{- if .Inertia}}
+	renderer *inertia.Renderer,
+{{- end}}
 ) ([]echo.MiddlewareFunc, error) {
 	csrfMiddleware, err := middleware.CSRFMiddleware(cfg, csrfName)
 	if err != nil {
@@ -123,7 +140,7 @@ func SetupGlobalMiddleware(
 		middleware.ValidateSession,
 		middleware.RegisterRequestMeta,
 {{- if .Inertia}}
-		inertia.Middleware(),
+		renderer.Middleware(),
 {{- end}}
 		echomw.CORSWithConfig(corsConfig),
 		csrfMiddleware,

--- a/layout/upgrade/plan.go
+++ b/layout/upgrade/plan.go
@@ -82,7 +82,9 @@ func (u *Upgrader) buildPlan(dirty bool) (*upgradePlan, error) {
 		toVersion:   u.opts.TargetVersion,
 		dirty:       dirty,
 	}
-	if crossesVersion(plan.fromVersion, plan.toVersion, sessionCookieRecoveryVersion) {
+	includeInertiaMigration := layout.IsSupportedInertiaAdapter(lock.ScaffoldConfig.Inertia)
+	if crossesVersion(plan.fromVersion, plan.toVersion, sessionCookieRecoveryVersion) ||
+		(includeInertiaMigration && crossesVersion(plan.fromVersion, plan.toVersion, inertiaRendererInjectionVersion)) {
 		modulePath, err := resolveModulePath(u.projectRoot)
 		if err != nil {
 			return nil, fmt.Errorf("resolve module path for manual actions: %w", err)
@@ -91,6 +93,7 @@ func (u *Upgrader) buildPlan(dirty bool) (*upgradePlan, error) {
 			plan.fromVersion,
 			plan.toVersion,
 			modulePath,
+			includeInertiaMigration,
 		)
 		if err != nil {
 			return nil, err

--- a/layout/upgrade/transactional_upgrade_test.go
+++ b/layout/upgrade/transactional_upgrade_test.go
@@ -305,9 +305,9 @@ func TestVersionedInertiaUpgradeEmbedsExistingRoot(t *testing.T) {
 
 	renderer := string(mustReadProjectFile(t, root, "internal/inertia/render.go"))
 	for _, snippet := range []string{
-		`"testapp/assets"`,
-		"func Init(rootPath string, opts ...Option) error",
-		"assets.Files.ReadFile(rootPath)",
+		"type Renderer struct",
+		"assetFS fs.FS",
+		"fs.ReadFile(assetFS, rootPath)",
 		"gonertia.NewFromBytes(rootHTML, opts...)",
 	} {
 		if !strings.Contains(renderer, snippet) {
@@ -316,6 +316,9 @@ func TestVersionedInertiaUpgradeEmbedsExistingRoot(t *testing.T) {
 	}
 	if strings.Contains(renderer, "andurel.lock") {
 		t.Fatalf("managed inertia renderer still reads andurel.lock:\n%s", renderer)
+	}
+	if strings.Contains(renderer, `"testapp/assets"`) {
+		t.Fatalf("managed inertia renderer imports the top-level assets package:\n%s", renderer)
 	}
 }
 

--- a/layout/upgrade/upgrade_notes.go
+++ b/layout/upgrade/upgrade_notes.go
@@ -9,7 +9,10 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const sessionCookieRecoveryVersion = "v1.5.4"
+const (
+	sessionCookieRecoveryVersion    = "v1.5.4"
+	inertiaRendererInjectionVersion = "v1.5.6"
+)
 
 // ManualAction describes an application-owned change that an upgrade cannot
 // apply without risking user code.
@@ -19,42 +22,67 @@ type ManualAction struct {
 	Instructions string `json:"instructions"`
 }
 
-func manualActionsForUpgrade(fromVersion, toVersion, modulePath string) ([]ManualAction, error) {
-	if !crossesVersion(fromVersion, toVersion, sessionCookieRecoveryVersion) {
-		return nil, nil
+func manualActionsForUpgrade(
+	fromVersion string,
+	toVersion string,
+	modulePath string,
+	includeInertiaMigration bool,
+) ([]ManualAction, error) {
+	actions := []ManualAction{}
+
+	if crossesVersion(fromVersion, toVersion, sessionCookieRecoveryVersion) {
+		sessionSource, err := renderTemplateToBytes(
+			"router_cookies_session.tmpl",
+			layouttemplates.Files,
+			&layout.TemplateData{ModuleName: modulePath},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("render session-cookie recovery instructions: %w", err)
+		}
+
+		var instructions strings.Builder
+		instructions.WriteString("The router tree is application-owned, so Andurel did not change it automatically.\n")
+		instructions.WriteString("If this recovery is already present, no action is required.\n\n")
+		instructions.WriteString("1. Create router/cookies/session.go:\n\n```go\n")
+		instructions.Write(sessionSource)
+		instructions.WriteString("```\n\n")
+		instructions.WriteString("2. In router/cookies/cookies.go and router/cookies/flash.go:\n")
+		instructions.WriteString("   - Replace calls to session.Get with getSession.\n")
+		instructions.WriteString("   - Remove the now-unused github.com/labstack/echo-contrib/v5/session imports.\n\n")
+		instructions.WriteString("3. In router/middleware/middleware.go, add this inside ValidateSession after the assets and API bypass and before calling the next handler:\n\n")
+		instructions.WriteString("```go\nif err := cookies.RecoverInvalidSessions(c); err != nil {\n\treturn err\n}\n```\n\n")
+		instructions.WriteString("4. Add this direct requirement to go.mod:\n\n")
+		instructions.WriteString("```go\ngithub.com/gorilla/securecookie v1.1.2\n```\n\n")
+		instructions.WriteString("5. Format and verify the migration:\n\n```text\n")
+		instructions.WriteString("gofmt -w router/cookies/session.go router/cookies/cookies.go router/cookies/flash.go router/middleware/middleware.go\n")
+		instructions.WriteString("go fix ./...\ngo vet ./...\n```\n")
+
+		actions = append(actions, ManualAction{
+			ID:           "session-cookie-recovery-v1.5.4",
+			Title:        "Update application-owned session handling",
+			Instructions: instructions.String(),
+		})
 	}
 
-	sessionSource, err := renderTemplateToBytes(
-		"router_cookies_session.tmpl",
-		layouttemplates.Files,
-		&layout.TemplateData{ModuleName: modulePath},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("render session-cookie recovery instructions: %w", err)
+	if includeInertiaMigration && crossesVersion(fromVersion, toVersion, inertiaRendererInjectionVersion) {
+		var instructions strings.Builder
+		instructions.WriteString("Inertia is now an Fx-managed renderer instance. Framework-owned internal/inertia files update automatically, but Andurel does not rewrite application-owned controllers.\n\n")
+		instructions.WriteString("1. In cmd/app/main.go, add these imports and the renderer provider:\n\n```go\n")
+		fmt.Fprintf(&instructions, "import (\n\t\"%s/assets\"\n\t\"%s/internal/request\"\n\t\"%s/router/cookies\"\n\t\"%s/router/routes\"\n)\n\nfunc provideInertia() (*inertia.Renderer, error) {\n\treturn inertia.New(\n\t\tassets.Files,\n\t\t\"inertia/root.go.html\",\n\t\tconfig.ProjectName,\n\t\tconfig.Env,\n\t\troutes.ViteBuild.Path(),\n\t\tinertia.WithSharedProp(\"appVersion\", appVersion),\n\t\tinertia.WithRequestProps(func(ctx context.Context) inertia.Props {\n\t\t\tflashes := request.ExtractContext[[]cookies.FlashMessage](ctx, request.SessionFlashesKey)\n\t\t\tif len(flashes) == 0 {\n\t\t\t\treturn nil\n\t\t\t}\n\t\t\treturn inertia.Props{\"flash\": flashes}\n\t\t}),\n\t)\n}\n", modulePath, modulePath, modulePath, modulePath)
+		instructions.WriteString("```\n\n2. Remove the old inertia.Init call and add provideInertia to the existing fx.Provide block.\n\n")
+		instructions.WriteString("3. Inject renderer *inertia.Renderer into router.New and pass renderer.Middleware() to the global middleware list.\n\n")
+		instructions.WriteString("4. Add renderer *inertia.Renderer to every Inertia controller constructor and struct. Replace package calls with receiver calls, for example:\n\n```go\ntype Sessions struct {\n\tidentity services.Identity\n\trenderer *inertia.Renderer\n}\n\nfunc NewSessions(identity services.Identity, renderer *inertia.Renderer) Sessions {\n\treturn Sessions{identity: identity, renderer: renderer}\n}\n\nfunc (s Sessions) New(etx *echo.Context) error {\n\treturn s.renderer.Page(etx, \"Auth/Login\", inertia.Props{})\n}\n```\n\n")
+		instructions.WriteString("Apply the same receiver change to Redirect and Location calls in built-in and generated resource controllers.\n\n")
+		instructions.WriteString("5. Format and verify the migration:\n\n```text\ngofmt -w cmd/app/main.go router/router.go\nfind controllers -name '*.go' -type f -exec gofmt -w {} +\ngo fix ./...\ngo vet ./...\n```\n")
+
+		actions = append(actions, ManualAction{
+			ID:           "inertia-renderer-injection-v1.5.6",
+			Title:        "Inject the Inertia renderer through Fx",
+			Instructions: instructions.String(),
+		})
 	}
 
-	var instructions strings.Builder
-	instructions.WriteString("The router tree is application-owned, so Andurel did not change it automatically.\n")
-	instructions.WriteString("If this recovery is already present, no action is required.\n\n")
-	instructions.WriteString("1. Create router/cookies/session.go:\n\n```go\n")
-	instructions.Write(sessionSource)
-	instructions.WriteString("```\n\n")
-	instructions.WriteString("2. In router/cookies/cookies.go and router/cookies/flash.go:\n")
-	instructions.WriteString("   - Replace calls to session.Get with getSession.\n")
-	instructions.WriteString("   - Remove the now-unused github.com/labstack/echo-contrib/v5/session imports.\n\n")
-	instructions.WriteString("3. In router/middleware/middleware.go, add this inside ValidateSession after the assets and API bypass and before calling the next handler:\n\n")
-	instructions.WriteString("```go\nif err := cookies.RecoverInvalidSessions(c); err != nil {\n\treturn err\n}\n```\n\n")
-	instructions.WriteString("4. Add this direct requirement to go.mod:\n\n")
-	instructions.WriteString("```go\ngithub.com/gorilla/securecookie v1.1.2\n```\n\n")
-	instructions.WriteString("5. Format and verify the migration:\n\n```text\n")
-	instructions.WriteString("gofmt -w router/cookies/session.go router/cookies/cookies.go router/cookies/flash.go router/middleware/middleware.go\n")
-	instructions.WriteString("go fix ./...\ngo vet ./...\n```\n")
-
-	return []ManualAction{{
-		ID:           "session-cookie-recovery-v1.5.4",
-		Title:        "Update application-owned session handling",
-		Instructions: instructions.String(),
-	}}, nil
+	return actions, nil
 }
 
 func crossesVersion(fromVersion, toVersion, boundary string) bool {

--- a/layout/upgrade/upgrade_notes_test.go
+++ b/layout/upgrade/upgrade_notes_test.go
@@ -22,7 +22,7 @@ func TestSessionRecoveryManualActionVersionGate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actions, err := manualActionsForUpgrade(test.from, test.to, "example.com/acme")
+			actions, err := manualActionsForUpgrade(test.from, test.to, "example.com/acme", false)
 			if err != nil {
 				t.Fatalf("manualActionsForUpgrade returned an error: %v", err)
 			}
@@ -52,6 +52,60 @@ func TestSessionRecoveryManualActionVersionGate(t *testing.T) {
 				if strings.Contains(action.Instructions, unwanted) {
 					t.Errorf("manual action contains %q:\n%s", unwanted, action.Instructions)
 				}
+			}
+		})
+	}
+}
+
+func TestInertiaRendererManualActionVersionGate(t *testing.T) {
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want bool
+	}{
+		{name: "first affected upgrade", from: "v1.5.5", to: "v1.5.6", want: true},
+		{name: "skips directly over release", from: "v1.4.0", to: "v1.6.0", want: true},
+		{name: "already received note", from: "v1.5.6", to: "v1.6.0", want: false},
+		{name: "target predates release", from: "v1.5.4", to: "v1.5.5", want: false},
+		{name: "development version", from: "dev", to: "v1.5.6", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actions, err := manualActionsForUpgrade(test.from, test.to, "example.com/acme", true)
+			if err != nil {
+				t.Fatalf("manualActionsForUpgrade returned an error: %v", err)
+			}
+
+			var action *ManualAction
+			for i := range actions {
+				if actions[i].ID == "inertia-renderer-injection-v1.5.6" {
+					action = &actions[i]
+					break
+				}
+			}
+			if got := action != nil; got != test.want {
+				t.Fatalf("Inertia action present = %t, want %t: %#v", got, test.want, actions)
+			}
+			if !test.want {
+				return
+			}
+
+			for _, want := range []string{
+				`"example.com/acme/assets"`,
+				`func provideInertia() (*inertia.Renderer, error)`,
+				`inertia.WithRequestProps`,
+				`renderer *inertia.Renderer`,
+				`renderer.Middleware()`,
+				`s.renderer.Page`,
+			} {
+				if !strings.Contains(action.Instructions, want) {
+					t.Errorf("manual action missing %q:\n%s", want, action.Instructions)
+				}
+			}
+			if strings.Contains(action.Instructions, "{{.ModuleName}}") {
+				t.Errorf("manual action contains an unresolved module placeholder:\n%s", action.Instructions)
 			}
 		})
 	}


### PR DESCRIPTION
Move Inertia assets, configuration, and request props to the composition root. Generate instance-based router and controller wiring, including safe mixed-controller upgrades.

BREAKING CHANGE: Generated Inertia controllers now receive *inertia.Renderer through Fx. Existing projects should follow the v1.5.6 migration emitted by andurel upgrade and included in the release guidance.