### PR TITLE
feat(models): V2 model dependency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ andurel generate controller Dashboard --model-name User
 andurel generate controller Dashboard index overview --model-name User
 ```
 
-In this mode, controller/UI artifacts use `Dashboard` (`controllers/dashboards.go`, `views/dashboards_resource.templ`, `/dashboards` routes), while model calls and entity types use `User` (`models.User.Paginate`, `models.User.Find`, `models.UserEntity`, `models.CreateUserData`, `models.UpdateUserData`). This is only for `generate controller`; `generate scaffold` keeps the existing one-resource-name behavior.
+In this mode, controller/UI artifacts use `Dashboard` (`controllers/dashboards.go`, `views/dashboards_resource.templ`, `/dashboards` routes), while model calls and entity types use `User` (`users.Paginate`, `users.Find`, `models.User`, `models.CreateUserData`, `models.UpdateUserData`). This is only for `generate controller`; `generate scaffold` keeps the existing one-resource-name behavior.
 
 Use `--api` to generate a JSON API controller instead. The controller is placed under `controllers/api` with `echo.JSON` responses and no views:
 

--- a/cli/command_behavior_test.go
+++ b/cli/command_behavior_test.go
@@ -226,7 +226,7 @@ func TestGenerateModelDryRunReportsHumanSummary(t *testing.T) {
 			Path:       "models/model.go",
 			Exists:     true,
 			OldContent: "package models\n",
-			NewContent: "package models\n\nvar Product product\n",
+			NewContent: "package models\n\n\tNewProducts,\n",
 		},
 		{
 			Path:       "models/product.go",
@@ -1338,7 +1338,7 @@ func TestGenerateControllerSingleCRUDActionInertiaProjectDefaultsToTemplControll
 		t,
 		rootDir,
 		"views/project_inquiries_resource.templ",
-		"Items []models.ProjectInquiryEntity",
+		"Items []models.ProjectInquiry",
 	)
 	assertCLITestFileNotContains(
 		t,

--- a/cli/generate_controller.go
+++ b/cli/generate_controller.go
@@ -76,7 +76,7 @@ and the default action set excludes new/edit.`,
 
   andurel generate controller Dashboard --model-name User
 
-      Generates dashboard controller, views, and routes backed by models.User.
+      Generates dashboard controller, views, and routes backed by models.Users.
 
   andurel generate controller Users --api
 

--- a/cli/generate_model_dry_run_test.go
+++ b/cli/generate_model_dry_run_test.go
@@ -20,11 +20,11 @@ func TestBuildModelPlanMutationReportUsesPlannedStrings(t *testing.T) {
 			Path:       filepath.Join(root, "models", "model.go"),
 			Exists:     true,
 			OldContent: "package models\n",
-			NewContent: "package models\n\nvar Product product\n",
+			NewContent: "package models\n\n\tNewProducts,\n",
 		},
 		{
 			Path:       filepath.Join(root, "models", "product.go"),
-			NewContent: "package models\n\ntype ProductEntity struct{}\n",
+			NewContent: "package models\n\ntype Product struct{}\n",
 		},
 	}}
 
@@ -35,7 +35,7 @@ func TestBuildModelPlanMutationReportUsesPlannedStrings(t *testing.T) {
 	if !slices.Equal(report.FilesUpdated, []string{"models/model.go"}) {
 		t.Fatalf("updated files = %#v", report.FilesUpdated)
 	}
-	for _, want := range []string{"diff --git a/models/model.go", "+var Product product", "diff --git a/models/product.go", "+type ProductEntity struct{}"} {
+	for _, want := range []string{"diff --git a/models/model.go", "+NewProducts,", "diff --git a/models/product.go", "+type Product struct{}"} {
 		if !strings.Contains(report.Diff, want) {
 			t.Fatalf("planned diff missing %q:\n%s", want, report.Diff)
 		}
@@ -47,7 +47,18 @@ func TestGenerateModelDryRunReportsFactoryWithoutMutatingProject(t *testing.T) {
 
 	rootDir := t.TempDir()
 	writeCLITestFile(t, rootDir, "go.mod", "module example.com/app\n\ngo 1.26.5\n")
-	writeCLITestFile(t, rootDir, "models/model.go", "package models\n\ntype (\n)\n\nvar (\n)\n")
+	writeCLITestFile(t, rootDir, "models/model.go", `package models
+
+import "go.uber.org/fx"
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
+)
+`)
 	writeCLITestFile(t, rootDir, "migrations/000100_create_products.sql", `-- +goose Up
 CREATE TABLE products (
     id UUID PRIMARY KEY,

--- a/cli/model_test.go
+++ b/cli/model_test.go
@@ -11,8 +11,8 @@ import (
 
 func changedModelUpdate() *generator.UpdateModelResult {
 	return &generator.UpdateModelResult{
-		OldStruct:         "type WidgetEntity struct {\n\tName string\n}\n",
-		NewStruct:         "type WidgetEntity struct {\n\tName string\n\tCount int64\n}\n",
+		OldStruct:         "type Widget struct {\n\tName string\n}\n",
+		NewStruct:         "type Widget struct {\n\tName string\n\tCount int64\n}\n",
 		ModelPath:         "models/widget.go",
 		HasChanges:        true,
 		OldFactoryContent: "package factories\n\nvar Count = 1\n",

--- a/e2e/testdata/golden/scaffolds/postgresql-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-aws-ses-css-components.golden
@@ -1777,6 +1777,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1817,6 +1818,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -7586,9 +7588,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -7596,9 +7598,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -7610,7 +7612,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -7619,10 +7621,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7633,7 +7635,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7645,8 +7647,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7711,9 +7713,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7721,9 +7723,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7735,7 +7737,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7744,10 +7746,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7758,7 +7760,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -7770,8 +7772,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -7823,14 +7825,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -7864,7 +7875,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -7875,7 +7899,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -7914,44 +7938,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -7964,7 +7987,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -7974,12 +7997,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7990,19 +8012,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8025,9 +8046,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8050,17 +8070,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8071,16 +8091,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -8095,14 +8114,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8146,7 +8165,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -8157,7 +8189,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -8165,11 +8197,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -8197,39 +8229,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8245,18 +8276,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -8267,12 +8297,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8286,22 +8316,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -8319,7 +8348,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -8330,10 +8359,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -8345,27 +8374,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8376,16 +8405,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -8400,14 +8428,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8702,7 +8730,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -10322,23 +10350,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -10351,22 +10379,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -10374,19 +10402,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -10464,7 +10492,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -10496,6 +10524,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -10516,6 +10546,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -10526,6 +10558,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -10539,6 +10573,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -10604,7 +10640,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -10629,9 +10668,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10699,24 +10737,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10726,24 +10766,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10751,24 +10791,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10779,23 +10819,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10853,7 +10893,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10875,9 +10918,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10963,9 +11005,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11004,7 +11048,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11025,7 +11069,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -11043,7 +11087,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-aws-ses.golden
@@ -1769,6 +1769,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1809,6 +1810,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -6116,9 +6118,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -6126,9 +6128,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -6140,7 +6142,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -6149,10 +6151,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6163,7 +6165,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -6175,8 +6177,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -6241,9 +6243,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -6251,9 +6253,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -6265,7 +6267,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -6274,10 +6276,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6288,7 +6290,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -6300,8 +6302,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -6353,14 +6355,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -6394,7 +6405,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -6405,7 +6429,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -6444,44 +6468,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -6494,7 +6517,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -6504,12 +6527,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6520,19 +6542,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6555,9 +6576,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6580,17 +6600,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6601,16 +6621,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -6625,14 +6644,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6676,7 +6695,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6687,7 +6719,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -6695,11 +6727,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6727,39 +6759,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6775,18 +6806,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6797,12 +6827,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6816,22 +6846,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -6849,7 +6878,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -6860,10 +6889,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -6875,27 +6904,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6906,16 +6935,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -6930,14 +6958,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7232,7 +7260,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -8852,23 +8880,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -8881,22 +8909,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -8904,19 +8932,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -8994,7 +9022,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9026,6 +9054,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9046,6 +9076,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9056,6 +9088,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9069,6 +9103,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9134,7 +9170,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9159,9 +9198,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9229,24 +9267,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9256,24 +9296,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -9281,24 +9321,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -9309,23 +9349,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -9383,7 +9423,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9405,9 +9448,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9493,9 +9535,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9534,7 +9578,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9555,7 +9599,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -9573,7 +9617,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-css-components.golden
@@ -1167,6 +1167,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1207,6 +1208,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -6878,9 +6880,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -6888,9 +6890,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -6902,7 +6904,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -6911,10 +6913,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6925,7 +6927,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -6937,8 +6939,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7003,9 +7005,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7013,9 +7015,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7027,7 +7029,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7036,10 +7038,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7050,7 +7052,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -7062,8 +7064,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -7115,14 +7117,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -7156,7 +7167,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -7167,7 +7191,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -7206,44 +7230,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -7256,7 +7279,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -7266,12 +7289,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7282,19 +7304,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7317,9 +7338,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7342,17 +7362,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7363,16 +7383,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -7387,14 +7406,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7438,7 +7457,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -7449,7 +7481,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -7457,11 +7489,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -7489,39 +7521,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7537,18 +7568,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7559,12 +7589,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7578,22 +7608,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -7611,7 +7640,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -7622,10 +7651,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -7637,27 +7666,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7668,16 +7697,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -7692,14 +7720,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7994,7 +8022,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -9614,23 +9642,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -9643,22 +9671,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -9666,19 +9694,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9756,7 +9784,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9788,6 +9816,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9808,6 +9838,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9818,6 +9850,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9831,6 +9865,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9896,7 +9932,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9921,9 +9960,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9991,24 +10029,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10018,24 +10058,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10043,24 +10083,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10071,23 +10111,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10145,7 +10185,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10167,9 +10210,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10255,9 +10297,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10296,7 +10340,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10317,7 +10361,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -10335,7 +10379,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses-css-components.golden
@@ -1854,6 +1854,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1894,6 +1895,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -7663,9 +7665,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -7673,9 +7675,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -7687,7 +7689,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -7696,10 +7698,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7710,7 +7712,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7722,8 +7724,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7788,9 +7790,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7798,9 +7800,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7812,7 +7814,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7821,10 +7823,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7835,7 +7837,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -7847,8 +7849,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -7900,14 +7902,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -7941,7 +7952,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -7952,7 +7976,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -7991,44 +8015,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -8041,7 +8064,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -8051,12 +8074,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -8067,19 +8089,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8102,9 +8123,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8127,17 +8147,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8148,16 +8168,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -8172,14 +8191,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8223,7 +8242,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -8234,7 +8266,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -8242,11 +8274,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -8274,39 +8306,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8322,18 +8353,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -8344,12 +8374,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8363,22 +8393,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -8396,7 +8425,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -8407,10 +8436,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -8422,27 +8451,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8453,16 +8482,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -8477,14 +8505,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8779,7 +8807,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -10399,23 +10427,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -10428,22 +10456,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -10451,19 +10479,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -10541,7 +10569,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -10573,6 +10601,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -10593,6 +10623,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -10603,6 +10635,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -10616,6 +10650,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -10681,7 +10717,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -10706,9 +10745,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10776,24 +10814,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10803,24 +10843,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10828,24 +10868,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10856,23 +10896,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10930,7 +10970,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10952,9 +10995,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11040,9 +11082,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11081,7 +11125,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11102,7 +11146,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -11120,7 +11164,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-aws-ses.golden
@@ -1846,6 +1846,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1886,6 +1887,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -6193,9 +6195,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -6203,9 +6205,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -6217,7 +6219,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -6226,10 +6228,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6240,7 +6242,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -6252,8 +6254,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -6318,9 +6320,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -6328,9 +6330,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -6342,7 +6344,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -6351,10 +6353,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6365,7 +6367,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -6377,8 +6379,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -6430,14 +6432,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -6471,7 +6482,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -6482,7 +6506,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -6521,44 +6545,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -6571,7 +6594,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -6581,12 +6604,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6597,19 +6619,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6632,9 +6653,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6657,17 +6677,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6678,16 +6698,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -6702,14 +6721,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6753,7 +6772,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6764,7 +6796,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -6772,11 +6804,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6804,39 +6836,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6852,18 +6883,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6874,12 +6904,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6893,22 +6923,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -6926,7 +6955,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -6937,10 +6966,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -6952,27 +6981,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6983,16 +7012,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -7007,14 +7035,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7309,7 +7337,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -8929,23 +8957,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -8958,22 +8986,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -8981,19 +9009,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9071,7 +9099,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9103,6 +9131,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9123,6 +9153,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9133,6 +9165,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9146,6 +9180,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9211,7 +9247,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9236,9 +9275,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9306,24 +9344,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9333,24 +9373,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -9358,24 +9398,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -9386,23 +9426,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -9460,7 +9500,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9482,9 +9525,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9570,9 +9612,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9611,7 +9655,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9632,7 +9676,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -9650,7 +9694,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker-css-components.golden
@@ -1244,6 +1244,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1284,6 +1285,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -6955,9 +6957,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -6965,9 +6967,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -6979,7 +6981,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -6988,10 +6990,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7002,7 +7004,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7014,8 +7016,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7080,9 +7082,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7090,9 +7092,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7104,7 +7106,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7113,10 +7115,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7127,7 +7129,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -7139,8 +7141,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -7192,14 +7194,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -7233,7 +7244,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -7244,7 +7268,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -7283,44 +7307,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -7333,7 +7356,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -7343,12 +7366,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7359,19 +7381,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7394,9 +7415,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7419,17 +7439,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7440,16 +7460,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -7464,14 +7483,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7515,7 +7534,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -7526,7 +7558,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -7534,11 +7566,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -7566,39 +7598,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7614,18 +7645,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7636,12 +7666,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7655,22 +7685,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -7688,7 +7717,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -7699,10 +7728,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -7714,27 +7743,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7745,16 +7774,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -7769,14 +7797,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8071,7 +8099,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -9691,23 +9719,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -9720,22 +9748,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -9743,19 +9771,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9833,7 +9861,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9865,6 +9893,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9885,6 +9915,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9895,6 +9927,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9908,6 +9942,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9973,7 +10009,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9998,9 +10037,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10068,24 +10106,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10095,24 +10135,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10120,24 +10160,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10148,23 +10188,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10222,7 +10262,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10244,9 +10287,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10332,9 +10374,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10373,7 +10417,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10394,7 +10438,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -10412,7 +10456,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-docker.golden
@@ -1236,6 +1236,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1276,6 +1277,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -5485,9 +5487,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -5495,9 +5497,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -5509,7 +5511,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -5518,10 +5520,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -5532,7 +5534,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -5544,8 +5546,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -5610,9 +5612,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -5620,9 +5622,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -5634,7 +5636,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -5643,10 +5645,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -5657,7 +5659,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -5669,8 +5671,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -5722,14 +5724,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -5763,7 +5774,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -5774,7 +5798,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -5813,44 +5837,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -5863,7 +5886,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -5873,12 +5896,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -5889,19 +5911,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -5924,9 +5945,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -5949,17 +5969,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -5970,16 +5990,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -5994,14 +6013,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6045,7 +6064,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6056,7 +6088,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -6064,11 +6096,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6096,39 +6128,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6144,18 +6175,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6166,12 +6196,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6185,22 +6215,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -6218,7 +6247,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -6229,10 +6258,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -6244,27 +6273,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6275,16 +6304,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -6299,14 +6327,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6601,7 +6629,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -8221,23 +8249,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -8250,22 +8278,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -8273,19 +8301,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -8363,7 +8391,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -8395,6 +8423,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -8415,6 +8445,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -8425,6 +8457,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -8438,6 +8472,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -8503,7 +8539,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -8528,9 +8567,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -8598,24 +8636,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -8625,24 +8665,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -8650,24 +8690,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -8678,23 +8718,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -8752,7 +8792,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -8774,9 +8817,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -8862,9 +8904,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -8903,7 +8947,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -8924,7 +8968,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -8942,7 +8986,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses-css-components.golden
@@ -1782,6 +1782,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1822,6 +1823,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -7819,9 +7821,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -7829,9 +7831,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -7843,7 +7845,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -7852,10 +7854,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7866,7 +7868,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7878,8 +7880,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7944,9 +7946,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7954,9 +7956,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7968,7 +7970,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7977,10 +7979,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7991,7 +7993,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -8003,8 +8005,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -8056,14 +8058,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -8097,7 +8108,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -8108,7 +8132,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -8147,44 +8171,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -8197,7 +8220,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -8207,12 +8230,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -8223,19 +8245,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8258,9 +8279,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8283,17 +8303,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8304,16 +8324,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -8328,14 +8347,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8379,7 +8398,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -8390,7 +8422,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -8398,11 +8430,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -8430,39 +8462,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8478,18 +8509,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -8500,12 +8530,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8519,22 +8549,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -8552,7 +8581,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -8563,10 +8592,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -8578,27 +8607,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8609,16 +8638,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -8633,14 +8661,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -9409,7 +9437,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -11055,23 +11083,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -11084,22 +11112,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -11107,19 +11135,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -11197,7 +11225,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -11229,6 +11257,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -11249,6 +11279,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -11259,6 +11291,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -11272,6 +11306,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -11337,7 +11373,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -11362,9 +11401,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -11432,24 +11470,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -11459,24 +11499,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -11484,24 +11524,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -11512,23 +11552,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -11586,7 +11626,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11608,9 +11651,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11696,9 +11738,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11737,7 +11781,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11758,7 +11802,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -11776,7 +11820,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-aws-ses.golden
@@ -1774,6 +1774,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1814,6 +1815,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -6349,9 +6351,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -6359,9 +6361,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -6373,7 +6375,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -6382,10 +6384,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6396,7 +6398,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -6408,8 +6410,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -6474,9 +6476,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -6484,9 +6486,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -6498,7 +6500,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -6507,10 +6509,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6521,7 +6523,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -6533,8 +6535,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -6586,14 +6588,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -6627,7 +6638,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -6638,7 +6662,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -6677,44 +6701,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -6727,7 +6750,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -6737,12 +6760,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6753,19 +6775,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6788,9 +6809,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6813,17 +6833,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6834,16 +6854,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -6858,14 +6877,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6909,7 +6928,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6920,7 +6952,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -6928,11 +6960,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6960,39 +6992,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7008,18 +7039,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7030,12 +7060,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7049,22 +7079,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -7082,7 +7111,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -7093,10 +7122,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -7108,27 +7137,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7139,16 +7168,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -7163,14 +7191,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7939,7 +7967,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -9585,23 +9613,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -9614,22 +9642,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -9637,19 +9665,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9727,7 +9755,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9759,6 +9787,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9779,6 +9809,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9789,6 +9821,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9802,6 +9836,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9867,7 +9903,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9892,9 +9931,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9962,24 +10000,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9989,24 +10029,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10014,24 +10054,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10042,23 +10082,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10116,7 +10156,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10138,9 +10181,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10226,9 +10268,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10267,7 +10311,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10288,7 +10332,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -10306,7 +10350,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-css-components.golden
@@ -1172,6 +1172,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1212,6 +1213,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -7111,9 +7113,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -7121,9 +7123,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -7135,7 +7137,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -7144,10 +7146,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7158,7 +7160,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7170,8 +7172,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7236,9 +7238,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7246,9 +7248,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7260,7 +7262,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7269,10 +7271,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7283,7 +7285,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -7295,8 +7297,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -7348,14 +7350,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -7389,7 +7400,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -7400,7 +7424,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -7439,44 +7463,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -7489,7 +7512,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -7499,12 +7522,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7515,19 +7537,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7550,9 +7571,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7575,17 +7595,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7596,16 +7616,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -7620,14 +7639,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7671,7 +7690,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -7682,7 +7714,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -7690,11 +7722,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -7722,39 +7754,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7770,18 +7801,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7792,12 +7822,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7811,22 +7841,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -7844,7 +7873,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -7855,10 +7884,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -7870,27 +7899,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7901,16 +7930,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -7925,14 +7953,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8701,7 +8729,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -10347,23 +10375,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -10376,22 +10404,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -10399,19 +10427,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -10489,7 +10517,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -10521,6 +10549,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -10541,6 +10571,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -10551,6 +10583,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -10564,6 +10598,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -10629,7 +10665,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -10654,9 +10693,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10724,24 +10762,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10751,24 +10791,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10776,24 +10816,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10804,23 +10844,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10878,7 +10918,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10900,9 +10943,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10988,9 +11030,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11029,7 +11073,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11050,7 +11094,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -11068,7 +11112,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses-css-components.golden
@@ -1859,6 +1859,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1899,6 +1900,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -7896,9 +7898,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -7906,9 +7908,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -7920,7 +7922,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -7929,10 +7931,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7943,7 +7945,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7955,8 +7957,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -8021,9 +8023,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -8031,9 +8033,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -8045,7 +8047,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -8054,10 +8056,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -8068,7 +8070,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -8080,8 +8082,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -8133,14 +8135,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -8174,7 +8185,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -8185,7 +8209,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -8224,44 +8248,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -8274,7 +8297,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -8284,12 +8307,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -8300,19 +8322,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8335,9 +8356,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -8360,17 +8380,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8381,16 +8401,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -8405,14 +8424,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8456,7 +8475,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -8467,7 +8499,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -8475,11 +8507,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -8507,39 +8539,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8555,18 +8586,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -8577,12 +8607,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -8596,22 +8626,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -8629,7 +8658,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -8640,10 +8669,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -8655,27 +8684,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -8686,16 +8715,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -8710,14 +8738,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -9486,7 +9514,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -11132,23 +11160,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -11161,22 +11189,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -11184,19 +11212,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -11274,7 +11302,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -11306,6 +11334,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -11326,6 +11356,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -11336,6 +11368,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -11349,6 +11383,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -11414,7 +11450,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -11439,9 +11478,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -11509,24 +11547,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -11536,24 +11576,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -11561,24 +11601,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -11589,23 +11629,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -11663,7 +11703,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11685,9 +11728,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11773,9 +11815,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11814,7 +11858,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11835,7 +11879,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -11853,7 +11897,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-aws-ses.golden
@@ -1851,6 +1851,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1891,6 +1892,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -6426,9 +6428,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -6436,9 +6438,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -6450,7 +6452,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -6459,10 +6461,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6473,7 +6475,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -6485,8 +6487,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -6551,9 +6553,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -6561,9 +6563,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -6575,7 +6577,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -6584,10 +6586,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6598,7 +6600,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -6610,8 +6612,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -6663,14 +6665,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -6704,7 +6715,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -6715,7 +6739,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -6754,44 +6778,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -6804,7 +6827,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -6814,12 +6837,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6830,19 +6852,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6865,9 +6886,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6890,17 +6910,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6911,16 +6931,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -6935,14 +6954,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6986,7 +7005,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6997,7 +7029,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -7005,11 +7037,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -7037,39 +7069,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7085,18 +7116,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7107,12 +7137,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7126,22 +7156,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -7159,7 +7188,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -7170,10 +7199,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -7185,27 +7214,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7216,16 +7245,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -7240,14 +7268,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8016,7 +8044,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -9662,23 +9690,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -9691,22 +9719,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -9714,19 +9742,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9804,7 +9832,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9836,6 +9864,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9856,6 +9886,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9866,6 +9898,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9879,6 +9913,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9944,7 +9980,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9969,9 +10008,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10039,24 +10077,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10066,24 +10106,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10091,24 +10131,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10119,23 +10159,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10193,7 +10233,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10215,9 +10258,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10303,9 +10345,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -10344,7 +10388,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10365,7 +10409,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -10383,7 +10427,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker-css-components.golden
@@ -1249,6 +1249,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1289,6 +1290,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -7188,9 +7190,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -7198,9 +7200,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -7212,7 +7214,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -7221,10 +7223,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7235,7 +7237,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -7247,8 +7249,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -7313,9 +7315,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -7323,9 +7325,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -7337,7 +7339,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -7346,10 +7348,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7360,7 +7362,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -7372,8 +7374,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -7425,14 +7427,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -7466,7 +7477,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -7477,7 +7501,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -7516,44 +7540,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -7566,7 +7589,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -7576,12 +7599,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -7592,19 +7614,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7627,9 +7648,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -7652,17 +7672,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7673,16 +7693,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -7697,14 +7716,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7748,7 +7767,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -7759,7 +7791,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -7767,11 +7799,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -7799,39 +7831,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7847,18 +7878,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -7869,12 +7899,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -7888,22 +7918,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -7921,7 +7950,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -7932,10 +7961,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -7947,27 +7976,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -7978,16 +8007,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -8002,14 +8030,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -8778,7 +8806,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -10424,23 +10452,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -10453,22 +10481,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -10476,19 +10504,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -10566,7 +10594,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -10598,6 +10626,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -10618,6 +10648,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -10628,6 +10660,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -10641,6 +10675,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -10706,7 +10742,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -10731,9 +10770,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10801,24 +10839,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -10828,24 +10868,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -10853,24 +10893,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -10881,23 +10921,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -10955,7 +10995,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -10977,9 +11020,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11065,9 +11107,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -11106,7 +11150,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -11127,7 +11171,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -11145,7 +11189,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue-docker.golden
@@ -1241,6 +1241,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1281,6 +1282,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -5718,9 +5720,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -5728,9 +5730,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -5742,7 +5744,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -5751,10 +5753,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -5765,7 +5767,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -5777,8 +5779,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -5843,9 +5845,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -5853,9 +5855,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -5867,7 +5869,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -5876,10 +5878,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -5890,7 +5892,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -5902,8 +5904,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -5955,14 +5957,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -5996,7 +6007,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -6007,7 +6031,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -6046,44 +6070,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -6096,7 +6119,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -6106,12 +6129,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6122,19 +6144,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6157,9 +6178,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6182,17 +6202,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6203,16 +6223,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -6227,14 +6246,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6278,7 +6297,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6289,7 +6321,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -6297,11 +6329,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6329,39 +6361,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6377,18 +6408,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6399,12 +6429,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6418,22 +6448,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -6451,7 +6480,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -6462,10 +6491,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -6477,27 +6506,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6508,16 +6537,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -6532,14 +6560,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7308,7 +7336,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -8954,23 +8982,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -8983,22 +9011,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -9006,19 +9034,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9096,7 +9124,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9128,6 +9156,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9148,6 +9178,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9158,6 +9190,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9171,6 +9205,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9236,7 +9272,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9261,9 +9300,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9331,24 +9369,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9358,24 +9398,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -9383,24 +9423,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -9411,23 +9451,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -9485,7 +9525,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9507,9 +9550,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9595,9 +9637,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9636,7 +9680,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9657,7 +9701,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -9675,7 +9719,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql-inertia-vue.golden
@@ -1157,6 +1157,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1197,6 +1198,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		inertiaModule,
 		telemetry.Module,
 		services.Module,
@@ -5634,9 +5636,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -5644,9 +5646,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -5658,7 +5660,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -5667,10 +5669,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -5681,7 +5683,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -5693,8 +5695,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -5759,9 +5761,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -5769,9 +5771,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -5783,7 +5785,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -5792,10 +5794,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -5806,7 +5808,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -5818,8 +5820,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -5871,14 +5873,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -5912,7 +5923,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -5923,7 +5947,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -5962,44 +5986,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -6012,7 +6035,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -6022,12 +6045,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -6038,19 +6060,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6073,9 +6094,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -6098,17 +6118,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6119,16 +6139,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -6143,14 +6162,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6194,7 +6213,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -6205,7 +6237,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -6213,11 +6245,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6245,39 +6277,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6293,18 +6324,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6315,12 +6345,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6334,22 +6364,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -6367,7 +6396,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -6378,10 +6407,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -6393,27 +6422,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6424,16 +6453,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -6448,14 +6476,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -7224,7 +7252,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -8870,23 +8898,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -8899,22 +8927,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -8922,19 +8950,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -9012,7 +9040,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -9044,6 +9072,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -9064,6 +9094,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -9074,6 +9106,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -9087,6 +9121,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -9152,7 +9188,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -9177,9 +9216,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9247,24 +9285,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -9274,24 +9314,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -9299,24 +9339,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -9327,23 +9367,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -9401,7 +9441,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9423,9 +9466,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9511,9 +9553,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -9552,7 +9596,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -9573,7 +9617,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -9591,7 +9635,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/e2e/testdata/golden/scaffolds/postgresql.golden
+++ b/e2e/testdata/golden/scaffolds/postgresql.golden
@@ -1152,6 +1152,7 @@ import (
 	"testapp/config"
 	"testapp/controllers"
 	"testapp/email"
+	"testapp/models"
 	"testapp/router"
 	"testapp/services"
 	"testapp/telemetry"
@@ -1192,6 +1193,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 		telemetry.Module,
 		services.Module,
 		controllers.Module,
@@ -5401,9 +5403,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -5411,9 +5413,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -5425,7 +5427,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -5434,10 +5436,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -5448,7 +5450,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -5460,8 +5462,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)
@@ -5526,9 +5528,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -5536,9 +5538,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -5550,7 +5552,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -5559,10 +5561,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -5573,7 +5575,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -5585,8 +5587,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)
@@ -5638,14 +5640,23 @@ file -----------rw-r--r-- models/model.go
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 ```
 
@@ -5679,7 +5690,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -5690,7 +5714,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -5729,44 +5753,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -5779,7 +5802,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -5789,12 +5812,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -5805,19 +5827,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -5840,9 +5861,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -5865,17 +5885,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -5886,16 +5906,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -5910,14 +5929,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -5961,7 +5980,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -5972,7 +6004,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -5980,11 +6012,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -6012,39 +6044,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6060,18 +6091,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -6082,12 +6112,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -6101,22 +6131,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -6134,7 +6163,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -6145,10 +6174,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -6160,27 +6189,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -6191,16 +6220,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -6215,14 +6243,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -6517,7 +6545,7 @@ type App struct {
 	IsAuthenticated bool
 }
 
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {
 		return err
@@ -8137,23 +8165,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -8166,22 +8194,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -8189,19 +8217,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,
@@ -8279,7 +8307,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,
@@ -8311,6 +8339,8 @@ package services
 import (
 	"strings"
 
+	"testapp/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -8331,6 +8361,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -8341,6 +8373,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -8354,6 +8388,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,
@@ -8419,7 +8455,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -8444,9 +8483,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -8514,24 +8552,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -8541,24 +8581,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -8566,24 +8606,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -8594,23 +8634,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil
@@ -8668,7 +8708,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -8690,9 +8733,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -8778,9 +8820,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -8819,7 +8863,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -8840,7 +8884,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -8858,7 +8902,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)

--- a/generator/controllers/generator.go
+++ b/generator/controllers/generator.go
@@ -42,6 +42,7 @@ type GeneratedController struct {
 	ModelPluralName         string
 	PluralResourceName      string // The pluralized form of ResourceName (respects --table-name override)
 	ModelPluralResourceName string
+	ModelServiceName        string
 	ReceiverName            string // Short receiver name for methods (e.g., "sf" for StudentFeedback)
 	Namespace               string // "admin" (empty if no namespace)
 	NamespacePascal         string // "Admin" (PascalCase for prefixing)
@@ -125,6 +126,7 @@ func (g *Generator) Build(cat *catalog.Catalog, config Config) (*GeneratedContro
 		ModelPluralName:         modelPluralName,
 		PluralResourceName:      pluralResourceName,
 		ModelPluralResourceName: modelPluralResourceName,
+		ModelServiceName:        inflection.Plural(modelName),
 		ReceiverName:            naming.ToReceiverName(config.ResourceName),
 		Namespace:               config.Namespace,
 		NamespacePascal:         naming.NamespaceToPascal(config.Namespace),

--- a/generator/controllers/template_renderer.go
+++ b/generator/controllers/template_renderer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/jinzhu/inflection"
 	"github.com/mbvlabs/andurel/generator/templates"
 	"github.com/mbvlabs/andurel/internal/errors"
 	"github.com/mbvlabs/andurel/internal/naming"
@@ -66,8 +67,8 @@ func (tr *TemplateRenderer) RenderControllerFile(
 	if controller.ModelPluralName == "" {
 		controller.ModelPluralName = controller.PluralName
 	}
-	if controller.ModelPluralResourceName == "" {
-		controller.ModelPluralResourceName = controller.PluralResourceName
+	if controller.ModelServiceName == "" {
+		controller.ModelServiceName = inflection.Plural(controller.ModelName)
 	}
 	if controller.Package == "" {
 		controller.Package = naming.ControllerPackageName(controller.Namespace)

--- a/generator/factory_sync.go
+++ b/generator/factory_sync.go
@@ -223,7 +223,7 @@ func (m *ModelManager) discoverFactoryResourceNames() ([]string, error) {
 			return nil, fmt.Errorf("read model file %s: %w", path, err)
 		}
 		for _, name := range entityNames(src) {
-			names = append(names, strings.TrimSuffix(name, "Entity"))
+			names = append(names, name)
 		}
 	}
 	slices.Sort(names)
@@ -239,7 +239,7 @@ func (m *ModelManager) factoryModelFromEntity(
 		return nil, "", fmt.Errorf("read model file: %w", err)
 	}
 
-	entityName := resourceName + "Entity"
+	entityName := resourceName
 	fields, _, _, err := parseEntityStruct(src, entityName)
 	if err != nil {
 		return nil, "", err
@@ -435,7 +435,7 @@ func generatedModelFromParsedEntity(
 	genModel := &models.GeneratedModel{
 		Name:          resourceName,
 		PluralName:    naming.DeriveTableName(resourceName),
-		EntityName:    resourceName + "Entity",
+		EntityName:    resourceName,
 		NamespaceVar:  resourceName,
 		Package:       "models",
 		TableName:     tableName,
@@ -1022,13 +1022,28 @@ func entityNames(src []byte) []string {
 		}
 		for _, spec := range genDecl.Specs {
 			typeSpec, ok := spec.(*ast.TypeSpec)
-			if !ok || !strings.HasSuffix(typeSpec.Name.Name, "Entity") {
+			if !ok || !hasBunBaseModel(typeSpec) {
 				continue
 			}
-			if _, ok := typeSpec.Type.(*ast.StructType); ok {
-				names = append(names, typeSpec.Name.Name)
-			}
+			names = append(names, typeSpec.Name.Name)
 		}
 	}
 	return names
+}
+
+func hasBunBaseModel(typeSpec *ast.TypeSpec) bool {
+	structType, ok := typeSpec.Type.(*ast.StructType)
+	if !ok || structType.Fields == nil {
+		return false
+	}
+	for _, field := range structType.Fields.List {
+		if len(field.Names) != 0 {
+			continue
+		}
+		selector, ok := field.Type.(*ast.SelectorExpr)
+		if ok && selector.Sel != nil && selector.Sel.Name == "BaseModel" {
+			return true
+		}
+	}
+	return false
 }

--- a/generator/factory_sync_test.go
+++ b/generator/factory_sync_test.go
@@ -72,13 +72,13 @@ import (
 
 func WithProductsName(value string) ProductOption {
 	return func(f *ProductFactory) {
-		f.ProductEntity.Name = strings.ToUpper(value)
+		f.Product.Name = strings.ToUpper(value)
 	}
 }
 
 func WithProductsPrice(value int16) ProductOption {
 	return func(f *ProductFactory) {
-		f.ProductEntity.Price = int32(value)
+		f.Product.Price = int32(value)
 	}
 }
 
@@ -141,7 +141,7 @@ func TestRenderSyncedFactoryFileRetainsGeneratedTypeImportsAndCanonicalFormattin
 	}
 	factory := &models.GeneratedFactory{
 		ModelName:         "Product",
-		EntityName:        "ProductEntity",
+		EntityName:        "Product",
 		ModulePath:        "example.com/app",
 		IDType:            "int64",
 		IDGoFieldName:     "ID",
@@ -183,7 +183,7 @@ import "net/url"
 
 func WithProductsEndpoint(value url.URL) ProductOption {
 	return func(f *ProductFactory) {
-		f.ProductEntity.Endpoint = value
+		f.Product.Endpoint = value
 	}
 }
 `
@@ -233,7 +233,7 @@ func WithProductsEndpoint(value url.URL) ProductOption {
 func TestRenderSyncedFactoryFileOwnsCorrectAndLegacyPluralHelpers(t *testing.T) {
 	factory := &models.GeneratedFactory{
 		ModelName:         "BackupPolicy",
-		EntityName:        "BackupPolicyEntity",
+		EntityName:        "BackupPolicy",
 		ModulePath:        "example.com/app",
 		IDType:            "int64",
 		IDGoFieldName:     "ID",
@@ -267,7 +267,7 @@ func TestRenderSyncedFactoryFileUsesIrregularModelPlurals(t *testing.T) {
 		t.Run(modelName, func(t *testing.T) {
 			factory := &models.GeneratedFactory{
 				ModelName:         modelName,
-				EntityName:        modelName + "Entity",
+				EntityName:        modelName,
 				ModulePath:        "example.com/app",
 				IDType:            "int64",
 				IDGoFieldName:     "ID",
@@ -290,7 +290,7 @@ func TestRenderSyncedFactoryFileUsesIrregularModelPlurals(t *testing.T) {
 func TestRenderSyncedFactoryFileOwnsLegacyAndCorrectedOptionNames(t *testing.T) {
 	factory := &models.GeneratedFactory{
 		ModelName:         "Application",
-		EntityName:        "ApplicationEntity",
+		EntityName:        "Application",
 		ModulePath:        "example.com/app",
 		IDType:            "int64",
 		IDGoFieldName:     "ID",
@@ -580,7 +580,7 @@ import "net/url"
 
 type ProductState string
 
-type ProductEntity struct {
+type Product struct {
 	ID       int64        ` + "`bun:\"id,pk,autoincrement\"`" + `
 	State    ProductState ` + "`bun:\"state,notnull\"`" + `
 	Endpoint url.URL      ` + "`bun:\"endpoint,notnull\"`" + `
@@ -707,7 +707,7 @@ func TestSyncFactoryUsesMigrationAllowedValuesForDefaults(t *testing.T) {
 
 type ProductStatus string
 
-type ProductEntity struct {
+type Product struct {
 	ID     int64         ` + "`bun:\"id,pk,autoincrement\"`" + `
 	Status ProductStatus ` + "`bun:\"status,notnull\"`" + `
 	Tier   string        ` + "`bun:\"tier,notnull\"`" + `
@@ -766,10 +766,10 @@ CREATE TABLE products (
 func TestDiscoverFactoryResourceNames(t *testing.T) {
 	modelsDir := t.TempDir()
 	files := map[string]string{
-		"product.go":      "package models\ntype ProductEntity struct{}\n",
-		"account.go":      "package models\ntype AccountEntity struct{}\ntype Ignored string\n",
-		"product_test.go": "package models\ntype TestOnlyEntity struct{}\n",
-		"broken.go":       "package models\ntype BrokenEntity struct {",
+		"product.go":      "package models\ntype Product struct {\n\tbun.BaseModel `bun:\"table:products\"`\n}\n",
+		"account.go":      "package models\ntype Account struct {\n\tbun.BaseModel `bun:\"table:accounts\"`\n}\ntype Ignored string\n",
+		"product_test.go": "package models\ntype TestOnly struct {\n\tbun.BaseModel `bun:\"table:tests\"`\n}\n",
+		"broken.go":       "package models\ntype Broken struct {",
 	}
 	for name, content := range files {
 		if err := os.WriteFile(filepath.Join(modelsDir, name), []byte(content), 0o600); err != nil {
@@ -809,8 +809,8 @@ func TestSyncFactoriesHandlesMultipleModelsAndCurrentFactories(t *testing.T) {
 		path := filepath.Join(modelsDir, strings.ToLower(resource)+".go")
 		source := strings.ReplaceAll(
 			factorySyncProductModelSource(),
-			"ProductEntity",
-			resource+"Entity",
+			"Product",
+			resource,
 		)
 		if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
 			t.Fatalf("write %s model: %v", resource, err)
@@ -943,7 +943,7 @@ func containsFactorySyncString(values []string, target string) bool {
 func factorySyncGeneratedFactory() *models.GeneratedFactory {
 	return &models.GeneratedFactory{
 		ModelName:     "Product",
-		EntityName:    "ProductEntity",
+		EntityName:    "Product",
 		ModulePath:    "example.com/app",
 		IDType:        "uuid.UUID",
 		IDGoFieldName: "ID",
@@ -980,7 +980,8 @@ func factorySyncTestModelManager(root, modelsDir string) *ModelManager {
 func factorySyncProductModelSource() string {
 	return `package models
 
-type ProductEntity struct {
+type Product struct {
+	bun.BaseModel ` + "`bun:\"table:products,alias:products\"`" + `
 	ID        uuid.UUID ` + "`bun:\"id,pk,type:uuid\"`" + `
 	Name      string    ` + "`bun:\"name,notnull\"`" + `
 	Price     int32     ` + "`bun:\"price,notnull\"`" + `

--- a/generator/model_generation_golden_test.go
+++ b/generator/model_generation_golden_test.go
@@ -70,8 +70,8 @@ func TestModelGenerationGoldens(t *testing.T) {
 		modelContent := string(content)
 		modelContent = strings.Replace(
 			modelContent,
-			"type ProductEntity struct {",
-			"type ProductStatus string\n\nconst (\n\tProductStatusActive   ProductStatus = \"active\"\n\tProductStatusArchived ProductStatus = \"archived\"\n)\n\ntype ProductEntity struct {",
+			"type Product struct {",
+			"type ProductStatus string\n\nconst (\n\tProductStatusActive   ProductStatus = \"active\"\n\tProductStatusArchived ProductStatus = \"archived\"\n)\n\ntype Product struct {",
 			1,
 		)
 		modelContent = strings.Replace(
@@ -237,13 +237,21 @@ func generatorPackageDir(t *testing.T) string {
 
 const modelNamespaceFixture = `package models
 
-type (
-	token struct{}
-	user  struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token token
-	User  user
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )
 `

--- a/generator/model_manager.go
+++ b/generator/model_manager.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jinzhu/inflection"
 	"github.com/mbvlabs/andurel/generator/files"
 	"github.com/mbvlabs/andurel/generator/internal/catalog"
 	"github.com/mbvlabs/andurel/generator/models"
@@ -276,7 +277,7 @@ func (m *ModelManager) PlanModel(
 		if readErr != nil {
 			return nil, fmt.Errorf("read model registry: %w", readErr)
 		}
-		updatedRegistry, formatErr := planNamespaceRegistration(resourceName, registryContent)
+		updatedRegistry, formatErr := planModelRegistration(resourceName, registryContent)
 		if formatErr != nil {
 			return nil, fmt.Errorf("plan model registry: %w", formatErr)
 		}
@@ -377,10 +378,31 @@ func (m *ModelManager) resolvePrimaryKey(
 	return pkInfo, nil
 }
 
-func planNamespaceRegistration(resourceName, source string) (string, error) {
-	namespaceType := naming.ToLowerCamelCaseFromAny(resourceName)
-	updated := ensureLineInBlock(source, "type (", "\t"+namespaceType+" struct{}")
-	updated = ensureLineInBlock(updated, "var (", "\t"+resourceName+" "+namespaceType)
+func planModelRegistration(resourceName, source string) (string, error) {
+	constructor := "New" + inflection.Plural(resourceName)
+	if strings.Contains(source, constructor+",") || strings.Contains(source, constructor+")") {
+		formatted, err := format.Source([]byte(source))
+		if err != nil {
+			return "", err
+		}
+		return string(formatted), nil
+	}
+
+	provideIdx := strings.Index(source, "fx.Provide(")
+	if provideIdx < 0 {
+		return "", fmt.Errorf("failed to locate fx.Provide in models module")
+	}
+	openIdx := strings.Index(source[provideIdx:], "(")
+	if openIdx < 0 {
+		return "", fmt.Errorf("failed to locate fx.Provide opening parenthesis")
+	}
+	openIdx += provideIdx
+	closeIdx := findMatchingParen(source, openIdx)
+	if closeIdx < 0 {
+		return "", fmt.Errorf("failed to locate fx.Provide closing parenthesis")
+	}
+
+	updated := source[:closeIdx] + "\t" + constructor + ",\n" + source[closeIdx:]
 	formatted, err := format.Source([]byte(updated))
 	if err != nil {
 		return "", err
@@ -388,27 +410,20 @@ func planNamespaceRegistration(resourceName, source string) (string, error) {
 	return string(formatted), nil
 }
 
-// ensureLineInBlock inserts entry as a new line just before the `)` that
-// closes the block opened by blockHeader. If the entry is already present in
-// the file the source is returned unchanged. If the block does not exist a
-// new one is appended.
-func ensureLineInBlock(src, blockHeader, entry string) string {
-	if strings.Contains(src, entry+"\n") {
-		return src
+func findMatchingParen(src string, openIdx int) int {
+	depth := 0
+	for i := openIdx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
 	}
-
-	openIdx := strings.Index(src, blockHeader)
-	if openIdx < 0 {
-		return src + "\n" + blockHeader + "\n" + entry + "\n)\n"
-	}
-
-	closeRel := strings.Index(src[openIdx:], "\n)")
-	if closeRel < 0 {
-		return src
-	}
-	insertAt := openIdx + closeRel + 1
-
-	return src[:insertAt] + entry + "\n" + src[insertAt:]
+	return -1
 }
 
 // readNullType reads the nullable type strategy from andurel.lock.

--- a/generator/model_manager_test.go
+++ b/generator/model_manager_test.go
@@ -11,23 +11,34 @@ import (
 	"github.com/mbvlabs/andurel/internal/cache"
 )
 
-func TestEnsureLineInBlock(t *testing.T) {
-	src := "package models\n\ntype (\n\tuser struct{}\n\ttoken struct{}\n)\n\nvar (\n\tUser user\n\tToken token\n)\n"
+func TestPlanModelRegistration(t *testing.T) {
+	src := `package models
 
-	got := ensureLineInBlock(src, "type (", "\tserver struct{}")
-	if !strings.Contains(got, "\tserver struct{}\n)") {
-		t.Errorf("expected server struct{} inserted before ); got:\n%s", got)
+import "go.uber.org/fx"
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
+)
+`
+
+	got, err := planModelRegistration("Server", src)
+	if err != nil {
+		t.Fatalf("planModelRegistration: %v", err)
+	}
+	if !strings.Contains(got, "NewServers,") {
+		t.Errorf("expected NewServers inserted into fx.Provide; got:\n%s", got)
 	}
 
-	// idempotent
-	again := ensureLineInBlock(got, "type (", "\tserver struct{}")
-	if again != got {
-		t.Errorf("expected idempotent insert, but content changed")
+	again, err := planModelRegistration("Server", got)
+	if err != nil {
+		t.Fatalf("planModelRegistration second call: %v", err)
 	}
-
-	got2 := ensureLineInBlock(got, "var (", "\tServer server")
-	if !strings.Contains(got2, "\tServer server\n)") {
-		t.Errorf("expected Server server inserted into var block; got:\n%s", got2)
+	if strings.Count(again, "NewServers") != 1 {
+		t.Errorf("expected idempotent insert, got:\n%s", again)
 	}
 }
 
@@ -285,7 +296,7 @@ func TestPlanModelFailureDoesNotApplyPartialChanges(t *testing.T) {
 	}
 	if err := os.WriteFile(
 		filepath.Join(root, "models", "model.go"),
-		[]byte("package models\n\ntype (\n)\n\nvar (\n)\n"),
+		[]byte(modelNamespaceFixture),
 		0o644,
 	); err != nil {
 		t.Fatalf("write registry: %v", err)
@@ -321,7 +332,7 @@ func writeModelPlanningFixture(t *testing.T, root string) {
 	t.Helper()
 	if err := os.WriteFile(
 		filepath.Join(root, "models", "model.go"),
-		[]byte("package models\n\ntype (\n)\n\nvar (\n)\n"),
+		[]byte(modelNamespaceFixture),
 		0o644,
 	); err != nil {
 		t.Fatalf("write registry: %v", err)

--- a/generator/model_updater.go
+++ b/generator/model_updater.go
@@ -141,7 +141,7 @@ func (m *ModelManager) UpdateModel(resourceName string) (*UpdateModelResult, err
 		return nil, fmt.Errorf("failed to read model file: %w", err)
 	}
 
-	entityName := resourceName + "Entity"
+	entityName := resourceName
 
 	existingFields, structStart, structEnd, err := parseEntityStruct(src, entityName)
 	if err != nil {

--- a/generator/model_updater_helpers_test.go
+++ b/generator/model_updater_helpers_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestUpdateModelResultDiffsAndStructHelpers(t *testing.T) {
 	result := &UpdateModelResult{
-		OldStruct:         "type ProductEntity struct {\n\tbun.BaseModel `bun:\"table:products,alias:products\"`\n\n\tName string `bun:\"name\"`\n}\n",
-		NewStruct:         "type ProductEntity struct {\n\tbun.BaseModel `bun:\"table:products,alias:products\"`\n\n\tName string `bun:\"name\"`\n\tSku string `bun:\"sku\"`\n}\n",
+		OldStruct:         "type Product struct {\n\tbun.BaseModel `bun:\"table:products,alias:products\"`\n\n\tName string `bun:\"name\"`\n}\n",
+		NewStruct:         "type Product struct {\n\tbun.BaseModel `bun:\"table:products,alias:products\"`\n\n\tName string `bun:\"name\"`\n\tSku string `bun:\"sku\"`\n}\n",
 		OldFactoryContent: "package factories\n\nfunc Old() {}\n",
 		NewFactoryContent: "package factories\n\nfunc New() {}\n",
 	}
@@ -40,12 +40,12 @@ func TestUpdateModelResultDiffsAndStructHelpers(t *testing.T) {
 		t.Fatalf("dropBaseModelLine did not remove embedding and blank line:\n%s", dropped)
 	}
 
-	rendered := renderEntityStruct("ProductEntity", "products", []models.GeneratedField{
+	rendered := renderEntityStruct("Product", "products", []models.GeneratedField{
 		{Name: "ID", Type: "uuid.UUID", BunTag: "id,pk,type:uuid"},
 		{Name: "Name", Type: "ProductName", BunTag: "name"},
 	})
 	for _, want := range []string{
-		"type ProductEntity struct",
+		"type Product struct",
 		"bun.BaseModel `bun:\"table:products,alias:products\"`",
 		"ID uuid.UUID `bun:\"id,pk,type:uuid\"`",
 		"Name ProductName `bun:\"name\"`",
@@ -61,7 +61,7 @@ func TestParseEntityStruct(t *testing.T) {
 
 import "github.com/uptrace/bun"
 
-type ProductEntity struct {
+type Product struct {
 	bun.BaseModel ` + "`bun:\"table:products,alias:products\"`" + `
 
 	ID uuid.UUID ` + "`bun:\"id,pk,type:uuid\"`" + `
@@ -70,7 +70,7 @@ type ProductEntity struct {
 }
 `)
 
-	fields, start, end, err := parseEntityStruct(src, "ProductEntity")
+	fields, start, end, err := parseEntityStruct(src, "Product")
 	if err != nil {
 		t.Fatalf("parseEntityStruct: %v", err)
 	}
@@ -89,14 +89,14 @@ type ProductEntity struct {
 
 	if _, _, _, err := parseEntityStruct(
 		[]byte("package models\nfunc bad("),
-		"ProductEntity",
+		"Product",
 	); err == nil ||
 		!strings.Contains(err.Error(), "failed to parse") {
 		t.Fatalf("expected parse error, got %v", err)
 	}
 	if _, _, _, err := parseEntityStruct(
 		[]byte("package models\ntype Other struct{}\n"),
-		"ProductEntity",
+		"Product",
 	); err == nil ||
 		!strings.Contains(err.Error(), "not found") {
 		t.Fatalf("expected missing entity error, got %v", err)
@@ -159,17 +159,17 @@ func TestRenderCreateAndUpdateDataStructs(t *testing.T) {
 func TestFindFuncAndStructOffsets(t *testing.T) {
 	src := []byte(`package models
 
-type ProductEntity struct {
+type Product struct {
 	ID string
 }
 
 type Alias string
 
-func (p ProductEntity) Create() error {
+func (p Product) Create() error {
 	return nil
 }
 
-func (p *ProductEntity) Update() error {
+func (p *Product) Update() error {
 	return nil
 }
 
@@ -178,40 +178,40 @@ func Create() error {
 }
 `)
 
-	start, end, err := findFuncOffsets(src, "ProductEntity", "Create")
+	start, end, err := findFuncOffsets(src, "Product", "Create")
 	if err != nil {
 		t.Fatalf("findFuncOffsets Create: %v", err)
 	}
-	if got := string(src[start:end]); !strings.Contains(got, "func (p ProductEntity) Create()") {
+	if got := string(src[start:end]); !strings.Contains(got, "func (p Product) Create()") {
 		t.Fatalf("unexpected Create offsets:\n%s", got)
 	}
 
-	start, end, err = findFuncOffsets(src, "ProductEntity", "Update")
+	start, end, err = findFuncOffsets(src, "Product", "Update")
 	if err != nil {
 		t.Fatalf("findFuncOffsets Update: %v", err)
 	}
-	if got := string(src[start:end]); !strings.Contains(got, "func (p *ProductEntity) Update()") {
+	if got := string(src[start:end]); !strings.Contains(got, "func (p *Product) Update()") {
 		t.Fatalf("unexpected Update offsets:\n%s", got)
 	}
 
-	if _, _, err := findFuncOffsets(src, "ProductEntity", "Delete"); err == nil ||
+	if _, _, err := findFuncOffsets(src, "Product", "Delete"); err == nil ||
 		!strings.Contains(err.Error(), "not found") {
 		t.Fatalf("expected missing func error, got %v", err)
 	}
 	if _, _, err := findFuncOffsets(
 		[]byte("package models\nfunc bad("),
-		"ProductEntity",
+		"Product",
 		"Create",
 	); err == nil ||
 		!strings.Contains(err.Error(), "failed to parse") {
 		t.Fatalf("expected func parse error, got %v", err)
 	}
 
-	start, end, err = findStructOffsets(src, "ProductEntity")
+	start, end, err = findStructOffsets(src, "Product")
 	if err != nil {
 		t.Fatalf("findStructOffsets: %v", err)
 	}
-	if got := string(src[start:end]); !strings.Contains(got, "type ProductEntity struct") {
+	if got := string(src[start:end]); !strings.Contains(got, "type Product struct") {
 		t.Fatalf("unexpected struct offsets:\n%s", got)
 	}
 	if _, _, err := findStructOffsets(src, "Alias"); err == nil ||
@@ -220,7 +220,7 @@ func Create() error {
 	}
 	if _, _, err := findStructOffsets(
 		[]byte("package models\nfunc bad("),
-		"ProductEntity",
+		"Product",
 	); err == nil ||
 		!strings.Contains(err.Error(), "failed to parse") {
 		t.Fatalf("expected struct parse error, got %v", err)
@@ -242,7 +242,7 @@ func TestApplyModelUpdateWritesModelAndFactory(t *testing.T) {
 		ModelPath: modelPath,
 		NewFileContent: `package models
 
-type ProductEntity struct {
+type Product struct {
 	Name string
 }
 `,
@@ -258,7 +258,7 @@ func Product() {}
 	if data, err := os.ReadFile(
 		modelPath,
 	); err != nil ||
-		!strings.Contains(string(data), "type ProductEntity struct") {
+		!strings.Contains(string(data), "type Product struct") {
 		t.Fatalf("model write data=%q err=%v", string(data), err)
 	}
 	if data, err := os.ReadFile(

--- a/generator/models/generator.go
+++ b/generator/models/generator.go
@@ -57,10 +57,10 @@ type GeneratedModel struct {
 	IDFieldName         string // SQL column name of PK (e.g., "id", "user_id")
 	IDGoFieldName       string // Go struct field name of PK (e.g., "ID", "UserID")
 	HasPrimaryKey       bool   // Whether the table has any primary key
-	EntityName          string // ServerEntity (resource name + "Entity")
-	NamespaceVar        string // Server (exported, package-scope)
-	NamespaceType       string // server (unexported receiver type)
-	ReceiverName        string // s (for the namespace methods)
+	EntityName          string // User (resource name)
+	NamespaceVar        string // Users (exported service type / constructor base)
+	NamespaceType       string // Users (service type used as method receiver)
+	ReceiverName        string // users (for the service methods)
 	HasCreatedAt        bool
 	HasUpdatedAt        bool
 	Mode                ModelMode
@@ -147,14 +147,15 @@ func (g *Generator) Build(cat *catalog.Catalog, config Config) (*GeneratedModel,
 		g.typeMapper.NullType = config.NullType
 	}
 
-	entityName := config.ResourceName + "Entity"
-	namespaceVar := config.ResourceName
-	namespaceType := naming.ToLowerCamelCaseFromAny(config.ResourceName)
-	receiverName := naming.ToReceiverName(config.ResourceName)
+	entityName := config.ResourceName
+	pluralName := inflection.Plural(config.ResourceName)
+	namespaceVar := pluralName
+	namespaceType := pluralName
+	receiverName := naming.ToLowerCamelCase(pluralName)
 
 	model := &GeneratedModel{
 		Name:            config.ResourceName,
-		PluralName:      inflection.Plural(config.ResourceName),
+		PluralName:      pluralName,
 		EntityName:      entityName,
 		NamespaceVar:    namespaceVar,
 		NamespaceType:   namespaceType,
@@ -176,9 +177,7 @@ func (g *Generator) Build(cat *catalog.Catalog, config Config) (*GeneratedModel,
 	importSet := make(map[string]bool)
 	importSet["context"] = true
 	importSet["github.com/uptrace/bun"] = true
-	if config.ModulePath != "" {
-		importSet["github.com/mbvlabs/andurel/pkg/storage"] = true
-	}
+	importSet["github.com/mbvlabs/andurel/pkg/storage"] = true
 
 	for _, col := range table.Columns {
 		field, err := g.buildField(col)
@@ -500,7 +499,7 @@ func normalizeModelMode(mode ModelMode) ModelMode {
 // GeneratedFactory represents a factory for a model
 type GeneratedFactory struct {
 	ModelName         string
-	EntityName        string // ServerEntity (resource name + "Entity")
+	EntityName        string // User (resource name)
 	NamespaceVar      string // Server (exported, package-scope)
 	Package           string
 	Fields            []FactoryField

--- a/generator/models/generator_test.go
+++ b/generator/models/generator_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jinzhu/inflection"
 	"github.com/mbvlabs/andurel/generator/internal/catalog"
 	"github.com/mbvlabs/andurel/internal/naming"
 )
@@ -236,9 +237,11 @@ func TestGenerateModelUpsertRequiresExplicitPrimaryKey(t *testing.T) {
 				t.Fatalf("read generated model: %v", err)
 			}
 			generated := string(content)
-			signature := "func (" + tt.receiver + " " + strings.ToLower(
+			signature := "func (" + naming.ToLowerCamelCase(
+				inflection.Plural(tt.resource),
+			) + " " + inflection.Plural(
 				tt.resource,
-			) + ") Upsert(ctx context.Context, db storage.Executor, id " + tt.idType + ", data Create" + tt.resource + "Data)"
+			) + ") Upsert(ctx context.Context, id " + tt.idType + ", data Create" + tt.resource + "Data)"
 			upsertStart := strings.Index(generated, signature)
 			if upsertStart < 0 {
 				t.Fatalf(
@@ -352,7 +355,7 @@ func TestGenerateModelPaginationPluralizesAcronymResourcesWithTableOverrides(t *
 			generated := string(content)
 			for _, want := range []string{
 				"type Paginated" + pluralName + " struct",
-				pluralName + " []" + resourceName + "Entity",
+				pluralName + " []" + resourceName,
 				") (Paginated" + pluralName + ", error)",
 			} {
 				if !strings.Contains(generated, want) {
@@ -394,11 +397,11 @@ func TestGenerateModelCRUDUsesRepositoryNotFoundAndTimestampSemantics(t *testing
 			generated,
 		)
 	}
-	if count := strings.Count(generated, "return ProductEntity{}, ErrNotFound"); count != 2 {
+	if count := strings.Count(generated, "return Product{}, ErrNotFound"); count != 2 {
 		t.Fatalf("expected Find and Update to return ErrNotFound, got %d:\n%s", count, generated)
 	}
-	destroyStart := strings.Index(generated, "func (p product) Destroy(")
-	allStart := strings.Index(generated, "func (p product) All(")
+	destroyStart := strings.Index(generated, "func (products Products) Destroy(")
+	allStart := strings.Index(generated, "func (products Products) All(")
 	if destroyStart < 0 || allStart <= destroyStart {
 		t.Fatalf("could not isolate generated Destroy method:\n%s", generated)
 	}
@@ -411,7 +414,7 @@ func TestGenerateModelCRUDUsesRepositoryNotFoundAndTimestampSemantics(t *testing
 	}
 
 	updateDataStart := strings.Index(generated, "type UpdateProductData struct {")
-	updateMethodStart := strings.Index(generated, "func (p product) Update(")
+	updateMethodStart := strings.Index(generated, "func (products Products) Update(")
 	if updateDataStart < 0 || updateMethodStart <= updateDataStart {
 		t.Fatalf("could not isolate generated UpdateProductData:\n%s", generated)
 	}
@@ -547,7 +550,7 @@ func TestGenerateModelModesPersistAndRestrictGeneratedOperations(t *testing.T) {
 			if !strings.Contains(generated, "// andurel:model-mode "+string(tt.wantMode)) {
 				t.Fatalf("generated model does not persist mode %q:\n%s", tt.wantMode, generated)
 			}
-			if strings.Contains(generated, "func (e *ProductEntity) Validate() error") {
+			if strings.Contains(generated, "func (e *Product) Validate() error") {
 				t.Fatalf("generated model contains an empty Validate method:\n%s", generated)
 			}
 			for _, want := range tt.present {
@@ -587,7 +590,7 @@ func TestBuildModelWithoutModulePathOmitsApplicationImports(t *testing.T) {
 	if model.Mode != ModelModeCRUD {
 		t.Fatalf("Build() mode = %q, want %q", model.Mode, ModelModeCRUD)
 	}
-	for _, applicationImport := range []string{"/pkg/storage", "/pkg/validation"} {
+	for _, applicationImport := range []string{"/pkg/validation"} {
 		for _, modelImport := range model.ExternalImports {
 			if strings.HasSuffix(modelImport, applicationImport) {
 				t.Fatalf(
@@ -719,7 +722,7 @@ func TestBuildFactoryMetadata(t *testing.T) {
 	g := NewGenerator("postgresql")
 	genModel := &GeneratedModel{
 		Name:          "Order",
-		EntityName:    "OrderEntity",
+		EntityName:    "Order",
 		NamespaceVar:  "Order",
 		IDType:        "int64",
 		IDGoFieldName: "OrderID",
@@ -785,7 +788,7 @@ func TestBuildFactoryUsesSuppliedModelAndFieldNames(t *testing.T) {
 		t.Run(tt.modelName, func(t *testing.T) {
 			model := &GeneratedModel{
 				Name:       tt.modelName,
-				EntityName: tt.modelName + "Entity",
+				EntityName: tt.modelName,
 				Fields: []GeneratedField{
 					{Name: tt.fieldName, Type: "string"},
 				},
@@ -806,7 +809,7 @@ func TestBuildFactoryUsesSuppliedModelAndFieldNames(t *testing.T) {
 func TestBuildFactoryUsesSchemaAwareSemanticDefaults(t *testing.T) {
 	model := &GeneratedModel{
 		Name:       "Endpoint",
-		EntityName: "EndpointEntity",
+		EntityName: "Endpoint",
 		Fields: []GeneratedField{
 			{Name: "Url", Type: "string"},
 			{Name: "Cidr", Type: "string"},
@@ -913,7 +916,7 @@ func TestGenerateModelAndFactoryFiles(t *testing.T) {
 		t.Fatalf("generate model: %v", err)
 	}
 	modelContent, err := os.ReadFile(modelPath)
-	if err != nil || !strings.Contains(string(modelContent), "type ProductEntity struct") {
+	if err != nil || !strings.Contains(string(modelContent), "type Product struct") {
 		t.Fatalf("generated model = %v\n%s", err, modelContent)
 	}
 

--- a/generator/scaffold_generation_golden_test.go
+++ b/generator/scaffold_generation_golden_test.go
@@ -146,7 +146,7 @@ func TestScaffoldGenerationNamespaced(t *testing.T) {
 		t.Fatalf("failed to generate namespaced scaffold: %v", err)
 	}
 
-	assertGeneratedFileContains(t, filepath.Join("models", "widget.go"), "type WidgetEntity struct")
+	assertGeneratedFileContains(t, filepath.Join("models", "widget.go"), "type Widget struct")
 	assertGeneratedFileContains(
 		t,
 		filepath.Join("controllers", "admin", "widgets.go"),

--- a/generator/table_name_test.go
+++ b/generator/table_name_test.go
@@ -52,7 +52,7 @@ func TestResolveTableName(t *testing.T) {
 	}
 
 	bunModel := func(entityName, table string) string {
-		return "package models\n\ntype " + entityName + "Entity struct {\n\tbun.BaseModel `bun:\"table:" + table + "\"`\n\tID string\n}\n"
+		return "package models\n\ntype " + entityName + " struct {\n\tbun.BaseModel `bun:\"table:" + table + "\"`\n\tID string\n}\n"
 	}
 
 	tests := []struct {
@@ -118,7 +118,7 @@ func TestResolveTableName_OverrideTakesPrecedence(t *testing.T) {
 
 	modelContent := `package models
 
-type StudentFeedbackEntity struct {
+type StudentFeedback struct {
 	bun.BaseModel ` + "`" + `bun:"table:student_feedback"` + "`" + `
 	ID string
 }

--- a/generator/templates/api_resource_controller.tmpl
+++ b/generator/templates/api_resource_controller.tmpl
@@ -52,17 +52,16 @@ import (
 {{- end}}
 	"github.com/labstack/echo/v5"
 	"{{.ModulePath}}/models"
-	"github.com/mbvlabs/andurel/pkg/storage"
 	"{{.ModulePath}}/router"
 	"{{.ModulePath}}/router/routes"
 )
 
 type {{.PluralResourceName}} struct {
-	db storage.Connection
+	{{.ModelServiceName | ToLowerCamelCase}} models.{{.ModelServiceName}}
 }
 
-func New{{.PluralResourceName}}(db storage.Connection) {{.PluralResourceName}} {
-	return {{.PluralResourceName}}{db}
+func New{{.PluralResourceName}}({{.ModelServiceName | ToLowerCamelCase}} models.{{.ModelServiceName}}) {{.PluralResourceName}} {
+	return {{.PluralResourceName}}{ {{.ModelServiceName | ToLowerCamelCase}} }
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) RegisterRoutes(r *router.Router) error {
@@ -148,9 +147,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		}
 	}
 
-	{{.ModelPluralName | ToCamelCase}}List, err := models.{{.ModelName}}.Paginate(
+	{{.ModelPluralName | ToCamelCase}}List, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Paginate(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		page,
 		perPage,
 	)
@@ -158,7 +156,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		return etx.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 	}
 
-	return etx.JSON(http.StatusOK, {{.ModelPluralName | ToCamelCase}}List.{{.ModelPluralResourceName}})
+	return etx.JSON(http.StatusOK, {{.ModelPluralName | ToCamelCase}}List.{{.ModelServiceName}})
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) Show(etx *echo.Context) error {
@@ -185,7 +183,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Show(etx *echo.Context) error {
 	}
 {{- end}}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Find(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		return etx.JSON(http.StatusNotFound, map[string]string{"error": "not found"})
 	}
@@ -332,9 +330,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Create(etx *echo.Context) error
 {{- end}}
 	}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Create(
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Create(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -514,9 +511,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Update(etx *echo.Context) error
 {{- end}}
 	}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Update(
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Update(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -557,7 +553,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Destroy(etx *echo.Context) erro
 	}
 {{- end}}
 
-	err = models.{{.ModelName}}.Destroy(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	err = {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Destroy(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		slog.ErrorContext(
 			etx.Request().Context(),

--- a/generator/templates/inertia_resource_controller.tmpl
+++ b/generator/templates/inertia_resource_controller.tmpl
@@ -47,19 +47,18 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/inertia"
 	"{{.ModulePath}}/models"
-	"github.com/mbvlabs/andurel/pkg/storage"
 	"{{.ModulePath}}/router"
 	"{{.ModulePath}}/router/cookies"
 	"{{.ModulePath}}/router/routes"
 )
 
 type {{.PluralResourceName}} struct {
-	db       storage.Connection
-	renderer *inertia.Renderer
+	{{.ModelServiceName | ToLowerCamelCase}} models.{{.ModelServiceName}}
+	renderer                                 *inertia.Renderer
 }
 
-func New{{.PluralResourceName}}(db storage.Connection, renderer *inertia.Renderer) {{.PluralResourceName}} {
-	return {{.PluralResourceName}}{db: db, renderer: renderer}
+func New{{.PluralResourceName}}({{.ModelServiceName | ToLowerCamelCase}} models.{{.ModelServiceName}}, renderer *inertia.Renderer) {{.PluralResourceName}} {
+	return {{.PluralResourceName}}{ {{.ModelServiceName | ToLowerCamelCase}}: {{.ModelServiceName | ToLowerCamelCase}}, renderer: renderer }
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) RegisterRoutes(r *router.Router) error {
@@ -179,7 +178,7 @@ type {{.ResourceName}}ItemProps struct {
 	Item {{.ResourceName}}Data `json:"item"`
 }
 
-func new{{.ResourceName}}Data(entity models.{{.ModelName}}Entity) {{.ResourceName}}Data {
+func new{{.ResourceName}}Data(entity models.{{.ModelName}}) {{.ResourceName}}Data {
 	return {{.ResourceName}}Data{
 {{- range .Fields}}
 		{{.Name}}: {{InertiaDataValue . (printf "entity.%s" .Name)}},
@@ -187,7 +186,7 @@ func new{{.ResourceName}}Data(entity models.{{.ModelName}}Entity) {{.ResourceNam
 	}
 }
 
-func new{{.ResourceName}}DataList(entities []models.{{.ModelName}}Entity) []{{.ResourceName}}Data {
+func new{{.ResourceName}}DataList(entities []models.{{.ModelName}}) []{{.ResourceName}}Data {
 	items := make([]{{.ResourceName}}Data, 0, len(entities))
 	for _, entity := range entities {
 		items = append(items, new{{.ResourceName}}Data(entity))
@@ -212,9 +211,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		}
 	}
 
-	{{.ModelPluralName | ToCamelCase}}List, err := models.{{.ModelName}}.Paginate(
+	{{.ModelPluralName | ToCamelCase}}List, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Paginate(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		page,
 		perPage,
 	)
@@ -226,7 +224,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		etx,
 		"{{if .Namespace}}{{.NamespacePascal}}/{{end}}{{.ResourceName}}/Index",
 		inertia.FromStruct({{.ResourceName}}IndexProps{
-			Items: new{{.ResourceName}}DataList({{.ModelPluralName | ToCamelCase}}List.{{.ModelPluralResourceName}}),
+			Items: new{{.ResourceName}}DataList({{.ModelPluralName | ToCamelCase}}List.{{.ModelServiceName}}),
 		}),
 	)
 }
@@ -255,7 +253,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Show(etx *echo.Context) error {
 	}
 {{- end}}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Find(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		return {{.ReceiverName}}.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
@@ -306,9 +304,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Create(etx *echo.Context) error
 {{- end}}
 	}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Create(
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Create(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -362,7 +359,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Edit(etx *echo.Context) error {
 	}
 {{- end}}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Find(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		return {{.ReceiverName}}.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
@@ -433,9 +430,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Update(etx *echo.Context) error
 {{- end}}
 	}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Update(
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Update(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -492,7 +488,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Destroy(etx *echo.Context) erro
 	}
 {{- end}}
 
-	err = models.{{.ModelName}}.Destroy(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	err = {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Destroy(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete {{.ResourceName | ToLowerCamelCase}}: %v", err)); flashErr != nil {
 			return {{.ReceiverName}}.renderer.Page(etx, "Errors/InternalError", inertia.Props{})

--- a/generator/templates/model.tmpl
+++ b/generator/templates/model.tmpl
@@ -13,6 +13,19 @@ import (
 {{- end}}
 )
 
+type {{.PluralName}} struct {
+	db queryDB
+}
+
+func New{{.PluralName}}(db storage.Connection) {{.PluralName}} {
+	return {{.PluralName}}{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func ({{.ReceiverName}} {{.PluralName}}) WithTx(tx storage.Transaction) {{.PluralName}} {
+	return {{.PluralName}}{db: tx}
+}
+
 type {{.EntityName}} struct {
 	bun.BaseModel `bun:"table:{{.TableName}},alias:{{.TableName}}"`
 
@@ -22,9 +35,9 @@ type {{.EntityName}} struct {
 }
 
 {{if and .HasPrimaryKey (ne .Mode "create-only")}}
-func ({{.ReceiverName}} {{.NamespaceType}}) Find(ctx context.Context, db storage.Executor, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}) ({{.EntityName}}, error) {
+func ({{.ReceiverName}} {{.PluralName}}) Find(ctx context.Context, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}) ({{.EntityName}}, error) {
 	var entity {{.EntityName}}
-	err := db.NewSelect().
+	err := {{.ReceiverName}}.db.Executor().NewSelect().
 		Model(&entity).
 		Where("{{.IDFieldName}} = ?", id).
 		Scan(ctx)
@@ -53,7 +66,7 @@ type Create{{.Name}}Data struct {
 {{- end}}
 }
 
-func ({{.ReceiverName}} {{.NamespaceType}}) Create(ctx context.Context, db storage.Executor, data Create{{.Name}}Data) ({{.EntityName}}, error) {
+func ({{.ReceiverName}} {{.PluralName}}) Create(ctx context.Context, data Create{{.Name}}Data) ({{.EntityName}}, error) {
 	entity := {{.EntityName}}{
 {{- if .HasPrimaryKey}}
 {{- if not .IsAutoIncrementID}}
@@ -81,7 +94,7 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Create(ctx context.Context, db stora
 		return {{.EntityName}}{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
+	if _, err := {{.ReceiverName}}.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
 		return {{.EntityName}}{}, err
 	}
 
@@ -99,7 +112,7 @@ type Update{{.Name}}Data struct {
 {{- end}}
 }
 
-func ({{.ReceiverName}} {{.NamespaceType}}) Update(ctx context.Context, db storage.Executor, data Update{{.Name}}Data) ({{.EntityName}}, error) {
+func ({{.ReceiverName}} {{.PluralName}}) Update(ctx context.Context, data Update{{.Name}}Data) ({{.EntityName}}, error) {
 	entity := {{.EntityName}}{
 		{{.IDGoFieldName}}: data.{{.IDGoFieldName}},
 {{- if .HasUpdatedAt}}
@@ -116,7 +129,7 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Update(ctx context.Context, db stora
 		return {{.EntityName}}{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := {{.ReceiverName}}.db.Executor().NewUpdate().
 		Model(&entity).
 {{- range .Fields}}
 {{- if and (not .IsPrimaryKey) (ne .Name "CreatedAt")}}
@@ -136,9 +149,9 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Update(ctx context.Context, db stora
 	return entity, nil
 }
 
-func ({{.ReceiverName}} {{.NamespaceType}}) Destroy(ctx context.Context, db storage.Executor, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}) error {
+func ({{.ReceiverName}} {{.PluralName}}) Destroy(ctx context.Context, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}) error {
 	var entity {{.EntityName}}
-	err := db.NewDelete().
+	err := {{.ReceiverName}}.db.Executor().NewDelete().
 		Model(&entity).
 		Where("{{.IDFieldName}} = ?", id).
 		Returning("*").
@@ -155,9 +168,9 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Destroy(ctx context.Context, db stor
 {{end}}
 
 {{if ne .Mode "create-only"}}
-func ({{.ReceiverName}} {{.NamespaceType}}) All(ctx context.Context, db storage.Executor) ([]{{.EntityName}}, error) {
+func ({{.ReceiverName}} {{.PluralName}}) All(ctx context.Context) ([]{{.EntityName}}, error) {
 	var entities []{{.EntityName}}
-	if err := db.NewSelect().
+	if err := {{.ReceiverName}}.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -174,7 +187,7 @@ type Paginated{{.PluralName}} struct {
 	TotalPages int64
 }
 
-func ({{.ReceiverName}} {{.NamespaceType}}) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (Paginated{{.PluralName}}, error) {
+func ({{.ReceiverName}} {{.PluralName}}) Paginate(ctx context.Context, page, pageSize int64) (Paginated{{.PluralName}}, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -187,15 +200,14 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Paginate(ctx context.Context, db sto
 
 	offset := (page - 1) * pageSize
 
-	
-	totalCount, err := db.NewSelect().
+	totalCount, err := {{.ReceiverName}}.db.Executor().NewSelect().
 		Model(&{{.EntityName}}{}).Count(ctx)
 	if err != nil {
 		return Paginated{{.PluralName}}{}, err
 	}
 
 	entities := make([]{{.EntityName}}, 0, int(pageSize))
-	if err := db.NewSelect().
+	if err := {{.ReceiverName}}.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -216,7 +228,7 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Paginate(ctx context.Context, db sto
 {{end}}
 
 {{if and .HasPrimaryKey (eq .Mode "crud")}}
-func ({{.ReceiverName}} {{.NamespaceType}}) Upsert(ctx context.Context, db storage.Executor, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}, data Create{{.Name}}Data) ({{.EntityName}}, error) {
+func ({{.ReceiverName}} {{.PluralName}}) Upsert(ctx context.Context, id {{if .IDType}}{{.IDType}}{{else}}uuid.UUID{{end}}, data Create{{.Name}}Data) ({{.EntityName}}, error) {
 	entity := {{.EntityName}}{
 		{{.IDGoFieldName}}: id,
 {{- if .HasCreatedAt}}
@@ -236,7 +248,7 @@ func ({{.ReceiverName}} {{.NamespaceType}}) Upsert(ctx context.Context, db stora
 		return {{.EntityName}}{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := {{.ReceiverName}}.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT ({{.IDFieldName}}) DO UPDATE").
 {{- range .Fields}}

--- a/generator/templates/resource_controller.tmpl
+++ b/generator/templates/resource_controller.tmpl
@@ -47,7 +47,6 @@ import (
 	"github.com/labstack/echo/v5"
 	"{{.ModulePath}}/models"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 	"{{.ModulePath}}/router"
 	"{{.ModulePath}}/router/cookies"
 	"{{.ModulePath}}/router/routes"
@@ -55,11 +54,11 @@ import (
 )
 
 type {{.PluralResourceName}} struct {
-	db storage.Connection
+	{{.ModelServiceName | ToLowerCamelCase}} models.{{.ModelServiceName}}
 }
 
-func New{{.PluralResourceName}}(db storage.Connection) {{.PluralResourceName}} {
-	return {{.PluralResourceName}}{db}
+func New{{.PluralResourceName}}({{.ModelServiceName | ToLowerCamelCase}} models.{{.ModelServiceName}}) {{.PluralResourceName}} {
+	return {{.PluralResourceName}}{ {{.ModelServiceName | ToLowerCamelCase}} }
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) RegisterRoutes(r *router.Router) error {
@@ -181,9 +180,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		}
 	}
 
-	{{.ModelPluralName | ToCamelCase}}List, err := models.{{.ModelName}}.Paginate(
+	{{.ModelPluralName | ToCamelCase}}List, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Paginate(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		page,
 		perPage,
 	)
@@ -191,7 +189,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Index(etx *echo.Context) error 
 		return hypermedia.RenderPage(etx, views.InternalError())
 	}
 
-	return hypermedia.RenderPage(etx, views.{{.NamespacePascal}}{{.ResourceName}}Index{Items: {{.ModelPluralName | ToCamelCase}}List.{{.ModelPluralResourceName}}}.Page())
+	return hypermedia.RenderPage(etx, views.{{.NamespacePascal}}{{.ResourceName}}Index{Items: {{.ModelPluralName | ToCamelCase}}List.{{.ModelServiceName}}}.Page())
 }
 
 func ({{.ReceiverName}} {{.PluralResourceName}}) Show(etx *echo.Context) error {
@@ -218,7 +216,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Show(etx *echo.Context) error {
 	}
 {{- end}}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Find(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -263,9 +261,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Create(etx *echo.Context) error
 {{- end}}
 	}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Create(
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Create(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -319,7 +316,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Edit(etx *echo.Context) error {
 	}
 {{- end}}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Find(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Find(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -384,9 +381,8 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Update(etx *echo.Context) error
 {{- end}}
 	}
 
-	{{.ResourceName | ToLowerCamelCase}}, err := models.{{.ModelName}}.Update(
+	{{.ResourceName | ToLowerCamelCase}}, err := {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Update(
 		etx.Request().Context(),
-		{{.ReceiverName}}.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -443,7 +439,7 @@ func ({{.ReceiverName}} {{.PluralResourceName}}) Destroy(etx *echo.Context) erro
 	}
 {{- end}}
 
-	err = models.{{.ModelName}}.Destroy(etx.Request().Context(), {{.ReceiverName}}.db.Executor(), {{.ResourceName | ToLowerCamelCase}}ID)
+	err = {{.ReceiverName}}.{{.ModelServiceName | ToLowerCamelCase}}.Destroy(etx.Request().Context(), {{.ResourceName | ToLowerCamelCase}}ID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete {{.ResourceName | ToLowerCamelCase}}: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/controller_views/add_action_bare/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/add_action_bare/controllers/widgets.go.golden
@@ -11,15 +11,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -53,7 +52,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -67,7 +66,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/add_action_bare/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/add_action_bare/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -78,7 +78,7 @@ templ (ws WidgetShow) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/add_action_css_components/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/add_action_css_components/controllers/widgets.go.golden
@@ -11,15 +11,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -53,7 +52,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -67,7 +66,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/add_action_css_components/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/add_action_css_components/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -78,7 +78,7 @@ templ (ws WidgetShow) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/add_view_action_bare/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/add_view_action_bare/controllers/widgets.go.golden
@@ -11,15 +11,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -53,7 +52,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -67,7 +66,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/add_view_action_bare/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/add_view_action_bare/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -78,7 +78,7 @@ templ (ws WidgetShow) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/add_view_action_css_components/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/add_view_action_css_components/controllers/widgets.go.golden
@@ -11,15 +11,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -53,7 +52,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -67,7 +66,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/add_view_action_css_components/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/add_view_action_css_components/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -78,7 +78,7 @@ templ (ws WidgetShow) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/controller_only_bare/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/controller_only_bare/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/controller_views/controller_only_bare/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/controller_only_bare/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -196,7 +196,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/controller_only_css_components/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/controller_only_css_components/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/controller_views/controller_only_css_components/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/controller_only_css_components/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -194,7 +194,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/full_crud_bare/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/full_crud_bare/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/controller_views/full_crud_bare/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/full_crud_bare/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -196,7 +196,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/full_crud_css_components/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/full_crud_css_components/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/controller_views/full_crud_css_components/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/full_crud_css_components/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -194,7 +194,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/controller_views/model_name_bare/controllers/dashboards.go.golden
+++ b/generator/testdata/golden/controller_views/model_name_bare/controllers/dashboards.go.golden
@@ -12,15 +12,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Dashboards struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewDashboards(db storage.Connection) Dashboards {
-	return Dashboards{db}
+func NewDashboards(widgets models.Widgets) Dashboards {
+	return Dashboards{ widgets }
 }
 
 func (d Dashboards) RegisterRoutes(r *router.Router) error {
@@ -64,9 +63,8 @@ func (d Dashboards) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := d.widgets.Paginate(
 		etx.Request().Context(),
-		d.db.Executor(),
 		page,
 		perPage,
 	)
@@ -83,7 +81,7 @@ func (d Dashboards) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	dashboard, err := models.Widget.Find(etx.Request().Context(), d.db.Executor(), dashboardID)
+	dashboard, err := d.widgets.Find(etx.Request().Context(), dashboardID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/single_action_bare/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/single_action_bare/controllers/widgets.go.golden
@@ -11,15 +11,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -44,7 +43,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/single_action_bare/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/single_action_bare/views/widgets_resource.templ.golden
@@ -16,7 +16,7 @@ import (
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {

--- a/generator/testdata/golden/controller_views/single_action_css_components/controllers/widgets.go.golden
+++ b/generator/testdata/golden/controller_views/single_action_css_components/controllers/widgets.go.golden
@@ -11,15 +11,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -44,7 +43,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}

--- a/generator/testdata/golden/controller_views/single_action_css_components/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/controller_views/single_action_css_components/views/widgets_resource.templ.golden
@@ -16,7 +16,7 @@ import (
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {

--- a/generator/testdata/golden/models/audit_log_no_pk.golden
+++ b/generator/testdata/golden/models/audit_log_no_pk.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type AuditLogEntity struct {
+type AuditLogs struct {
+	db queryDB
+}
+
+func NewAuditLogs(db storage.Connection) AuditLogs {
+	return AuditLogs{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (auditLogs AuditLogs) WithTx(tx storage.Transaction) AuditLogs {
+	return AuditLogs{db: tx}
+}
+
+type AuditLog struct {
 	bun.BaseModel `bun:"table:audit_logs,alias:audit_logs"`
 	EventId       uuid.UUID       `bun:"event_id,type:uuid"`
 	Action        string          `bun:"action"`
@@ -33,8 +46,8 @@ type CreateAuditLogData struct {
 	OccurredAt time.Time
 }
 
-func (al auditLog) Create(ctx context.Context, db storage.Executor, data CreateAuditLogData) (AuditLogEntity, error) {
-	entity := AuditLogEntity{
+func (auditLogs AuditLogs) Create(ctx context.Context, data CreateAuditLogData) (AuditLog, error) {
+	entity := AuditLog{
 		EventId:    data.EventId,
 		Action:     data.Action,
 		EntityType: data.EntityType,
@@ -44,19 +57,19 @@ func (al auditLog) Create(ctx context.Context, db storage.Executor, data CreateA
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return AuditLogEntity{}, errors.Join(ErrDomainValidation, err)
+		return AuditLog{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return AuditLogEntity{}, err
+	if _, err := auditLogs.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return AuditLog{}, err
 	}
 
 	return entity, nil
 }
 
-func (al auditLog) All(ctx context.Context, db storage.Executor) ([]AuditLogEntity, error) {
-	var entities []AuditLogEntity
-	if err := db.NewSelect().
+func (auditLogs AuditLogs) All(ctx context.Context) ([]AuditLog, error) {
+	var entities []AuditLog
+	if err := auditLogs.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -66,14 +79,14 @@ func (al auditLog) All(ctx context.Context, db storage.Executor) ([]AuditLogEnti
 }
 
 type PaginatedAuditLogs struct {
-	AuditLogs  []AuditLogEntity
+	AuditLogs  []AuditLog
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (al auditLog) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedAuditLogs, error) {
+func (auditLogs AuditLogs) Paginate(ctx context.Context, page, pageSize int64) (PaginatedAuditLogs, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -86,14 +99,14 @@ func (al auditLog) Paginate(ctx context.Context, db storage.Executor, page, page
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&AuditLogEntity{}).Count(ctx)
+	totalCount, err := auditLogs.db.Executor().NewSelect().
+		Model(&AuditLog{}).Count(ctx)
 	if err != nil {
 		return PaginatedAuditLogs{}, err
 	}
 
-	entities := make([]AuditLogEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]AuditLog, 0, int(pageSize))
+	if err := auditLogs.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).

--- a/generator/testdata/golden/models/event_metric_no_pk_no_uuid.golden
+++ b/generator/testdata/golden/models/event_metric_no_pk_no_uuid.golden
@@ -12,7 +12,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type EventMetricEntity struct {
+type EventMetrics struct {
+	db queryDB
+}
+
+func NewEventMetrics(db storage.Connection) EventMetrics {
+	return EventMetrics{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (eventMetrics EventMetrics) WithTx(tx storage.Transaction) EventMetrics {
+	return EventMetrics{db: tx}
+}
+
+type EventMetric struct {
 	bun.BaseModel `bun:"table:event_metrics,alias:event_metrics"`
 	Action        string    `bun:"action"`
 	EntityType    string    `bun:"entity_type"`
@@ -29,8 +42,8 @@ type CreateEventMetricData struct {
 	OccurredAt time.Time
 }
 
-func (em eventMetric) Create(ctx context.Context, db storage.Executor, data CreateEventMetricData) (EventMetricEntity, error) {
-	entity := EventMetricEntity{
+func (eventMetrics EventMetrics) Create(ctx context.Context, data CreateEventMetricData) (EventMetric, error) {
+	entity := EventMetric{
 		Action:     data.Action,
 		EntityType: data.EntityType,
 		EventCount: data.EventCount,
@@ -39,19 +52,19 @@ func (em eventMetric) Create(ctx context.Context, db storage.Executor, data Crea
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return EventMetricEntity{}, errors.Join(ErrDomainValidation, err)
+		return EventMetric{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return EventMetricEntity{}, err
+	if _, err := eventMetrics.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return EventMetric{}, err
 	}
 
 	return entity, nil
 }
 
-func (em eventMetric) All(ctx context.Context, db storage.Executor) ([]EventMetricEntity, error) {
-	var entities []EventMetricEntity
-	if err := db.NewSelect().
+func (eventMetrics EventMetrics) All(ctx context.Context) ([]EventMetric, error) {
+	var entities []EventMetric
+	if err := eventMetrics.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -61,14 +74,14 @@ func (em eventMetric) All(ctx context.Context, db storage.Executor) ([]EventMetr
 }
 
 type PaginatedEventMetrics struct {
-	EventMetrics []EventMetricEntity
+	EventMetrics []EventMetric
 	TotalCount   int64
 	Page         int64
 	PageSize     int64
 	TotalPages   int64
 }
 
-func (em eventMetric) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedEventMetrics, error) {
+func (eventMetrics EventMetrics) Paginate(ctx context.Context, page, pageSize int64) (PaginatedEventMetrics, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -81,14 +94,14 @@ func (em eventMetric) Paginate(ctx context.Context, db storage.Executor, page, p
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&EventMetricEntity{}).Count(ctx)
+	totalCount, err := eventMetrics.db.Executor().NewSelect().
+		Model(&EventMetric{}).Count(ctx)
 	if err != nil {
 		return PaginatedEventMetrics{}, err
 	}
 
-	entities := make([]EventMetricEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]EventMetric, 0, int(pageSize))
+	if err := eventMetrics.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).

--- a/generator/testdata/golden/models/order_custom_pk.golden
+++ b/generator/testdata/golden/models/order_custom_pk.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type OrderEntity struct {
+type Orders struct {
+	db queryDB
+}
+
+func NewOrders(db storage.Connection) Orders {
+	return Orders{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (orders Orders) WithTx(tx storage.Transaction) Orders {
+	return Orders{db: tx}
+}
+
+type Order struct {
 	bun.BaseModel `bun:"table:orders,alias:orders"`
 	OrderId       uuid.UUID    `bun:"order_id,pk,type:uuid"`
 	CustomerId    uuid.UUID    `bun:"customer_id,type:uuid"`
@@ -26,17 +39,17 @@ type OrderEntity struct {
 	UpdatedAt     time.Time    `bun:"updated_at"`
 }
 
-func (o order) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (OrderEntity, error) {
-	var entity OrderEntity
-	err := db.NewSelect().
+func (orders Orders) Find(ctx context.Context, id uuid.UUID) (Order, error) {
+	var entity Order
+	err := orders.db.Executor().NewSelect().
 		Model(&entity).
 		Where("order_id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return OrderEntity{}, ErrNotFound
+			return Order{}, ErrNotFound
 		}
-		return OrderEntity{}, err
+		return Order{}, err
 	}
 
 	return entity, nil
@@ -50,8 +63,8 @@ type CreateOrderData struct {
 	PlacedAt   sql.NullTime
 }
 
-func (o order) Create(ctx context.Context, db storage.Executor, data CreateOrderData) (OrderEntity, error) {
-	entity := OrderEntity{
+func (orders Orders) Create(ctx context.Context, data CreateOrderData) (Order, error) {
+	entity := Order{
 		OrderId:    uuid.New(),
 		CreatedAt:  time.Now(),
 		UpdatedAt:  time.Now(),
@@ -63,11 +76,11 @@ func (o order) Create(ctx context.Context, db storage.Executor, data CreateOrder
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return OrderEntity{}, errors.Join(ErrDomainValidation, err)
+		return Order{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return OrderEntity{}, err
+	if _, err := orders.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Order{}, err
 	}
 
 	return entity, nil
@@ -82,8 +95,8 @@ type UpdateOrderData struct {
 	PlacedAt   sql.NullTime
 }
 
-func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrderData) (OrderEntity, error) {
-	entity := OrderEntity{
+func (orders Orders) Update(ctx context.Context, data UpdateOrderData) (Order, error) {
+	entity := Order{
 		OrderId:    data.OrderId,
 		UpdatedAt:  time.Now(),
 		CustomerId: data.CustomerId,
@@ -94,10 +107,10 @@ func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrder
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return OrderEntity{}, errors.Join(ErrDomainValidation, err)
+		return Order{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := orders.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("customer_id").
 		Column("reference").
@@ -110,17 +123,17 @@ func (o order) Update(ctx context.Context, db storage.Executor, data UpdateOrder
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return OrderEntity{}, ErrNotFound
+			return Order{}, ErrNotFound
 		}
-		return OrderEntity{}, err
+		return Order{}, err
 	}
 
 	return entity, nil
 }
 
-func (o order) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity OrderEntity
-	err := db.NewDelete().
+func (orders Orders) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Order
+	err := orders.db.Executor().NewDelete().
 		Model(&entity).
 		Where("order_id = ?", id).
 		Returning("*").
@@ -135,9 +148,9 @@ func (o order) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) e
 	return nil
 }
 
-func (o order) All(ctx context.Context, db storage.Executor) ([]OrderEntity, error) {
-	var entities []OrderEntity
-	if err := db.NewSelect().
+func (orders Orders) All(ctx context.Context) ([]Order, error) {
+	var entities []Order
+	if err := orders.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -147,14 +160,14 @@ func (o order) All(ctx context.Context, db storage.Executor) ([]OrderEntity, err
 }
 
 type PaginatedOrders struct {
-	Orders     []OrderEntity
+	Orders     []Order
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (o order) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedOrders, error) {
+func (orders Orders) Paginate(ctx context.Context, page, pageSize int64) (PaginatedOrders, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -167,14 +180,14 @@ func (o order) Paginate(ctx context.Context, db storage.Executor, page, pageSize
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&OrderEntity{}).Count(ctx)
+	totalCount, err := orders.db.Executor().NewSelect().
+		Model(&Order{}).Count(ctx)
 	if err != nil {
 		return PaginatedOrders{}, err
 	}
 
-	entities := make([]OrderEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Order, 0, int(pageSize))
+	if err := orders.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -193,8 +206,8 @@ func (o order) Paginate(ctx context.Context, db storage.Executor, page, pageSize
 	}, nil
 }
 
-func (o order) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateOrderData) (OrderEntity, error) {
-	entity := OrderEntity{
+func (orders Orders) Upsert(ctx context.Context, id uuid.UUID, data CreateOrderData) (Order, error) {
+	entity := Order{
 		OrderId:    id,
 		CreatedAt:  time.Now(),
 		UpdatedAt:  time.Now(),
@@ -206,10 +219,10 @@ func (o order) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, da
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return OrderEntity{}, errors.Join(ErrDomainValidation, err)
+		return Order{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := orders.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (order_id) DO UPDATE").
 		Set("customer_id = excluded.customer_id").
@@ -219,7 +232,7 @@ func (o order) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, da
 		Set("placed_at = excluded.placed_at").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return OrderEntity{}, err
+		return Order{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/models/product_initial.golden
+++ b/generator/testdata/golden/models/product_initial.golden
@@ -15,7 +15,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type ProductEntity struct {
+type Products struct {
+	db queryDB
+}
+
+func NewProducts(db storage.Connection) Products {
+	return Products{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (products Products) WithTx(tx storage.Transaction) Products {
+	return Products{db: tx}
+}
+
+type Product struct {
 	bun.BaseModel `bun:"table:products,alias:products"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	Sku           string          `bun:"sku"`
@@ -33,17 +46,17 @@ type ProductEntity struct {
 	UpdatedAt     time.Time       `bun:"updated_at"`
 }
 
-func (p product) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (ProductEntity, error) {
-	var entity ProductEntity
-	err := db.NewSelect().
+func (products Products) Find(ctx context.Context, id uuid.UUID) (Product, error) {
+	var entity Product
+	err := products.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ProductEntity{}, ErrNotFound
+			return Product{}, ErrNotFound
 		}
-		return ProductEntity{}, err
+		return Product{}, err
 	}
 
 	return entity, nil
@@ -63,8 +76,8 @@ type CreateProductData struct {
 	LaunchedAt  sql.NullTime
 }
 
-func (p product) Create(ctx context.Context, db storage.Executor, data CreateProductData) (ProductEntity, error) {
-	entity := ProductEntity{
+func (products Products) Create(ctx context.Context, data CreateProductData) (Product, error) {
+	entity := Product{
 		ID:          uuid.New(),
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -82,11 +95,11 @@ func (p product) Create(ctx context.Context, db storage.Executor, data CreatePro
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
+		return Product{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return ProductEntity{}, err
+	if _, err := products.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Product{}, err
 	}
 
 	return entity, nil
@@ -107,8 +120,8 @@ type UpdateProductData struct {
 	LaunchedAt  sql.NullTime
 }
 
-func (p product) Update(ctx context.Context, db storage.Executor, data UpdateProductData) (ProductEntity, error) {
-	entity := ProductEntity{
+func (products Products) Update(ctx context.Context, data UpdateProductData) (Product, error) {
+	entity := Product{
 		ID:          data.ID,
 		UpdatedAt:   time.Now(),
 		Sku:         data.Sku,
@@ -125,10 +138,10 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
+		return Product{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := products.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("sku").
 		Column("name").
@@ -147,17 +160,17 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ProductEntity{}, ErrNotFound
+			return Product{}, ErrNotFound
 		}
-		return ProductEntity{}, err
+		return Product{}, err
 	}
 
 	return entity, nil
 }
 
-func (p product) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity ProductEntity
-	err := db.NewDelete().
+func (products Products) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Product
+	err := products.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -172,9 +185,9 @@ func (p product) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID)
 	return nil
 }
 
-func (p product) All(ctx context.Context, db storage.Executor) ([]ProductEntity, error) {
-	var entities []ProductEntity
-	if err := db.NewSelect().
+func (products Products) All(ctx context.Context) ([]Product, error) {
+	var entities []Product
+	if err := products.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -184,14 +197,14 @@ func (p product) All(ctx context.Context, db storage.Executor) ([]ProductEntity,
 }
 
 type PaginatedProducts struct {
-	Products   []ProductEntity
+	Products   []Product
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedProducts, error) {
+func (products Products) Paginate(ctx context.Context, page, pageSize int64) (PaginatedProducts, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -204,14 +217,14 @@ func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&ProductEntity{}).Count(ctx)
+	totalCount, err := products.db.Executor().NewSelect().
+		Model(&Product{}).Count(ctx)
 	if err != nil {
 		return PaginatedProducts{}, err
 	}
 
-	entities := make([]ProductEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Product, 0, int(pageSize))
+	if err := products.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -230,8 +243,8 @@ func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateProductData) (ProductEntity, error) {
-	entity := ProductEntity{
+func (products Products) Upsert(ctx context.Context, id uuid.UUID, data CreateProductData) (Product, error) {
+	entity := Product{
 		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -249,10 +262,10 @@ func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, 
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
+		return Product{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := products.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("sku = excluded.sku").
@@ -268,7 +281,7 @@ func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, 
 		Set("launched_at = excluded.launched_at").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return ProductEntity{}, err
+		return Product{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/models/product_update_diff.golden
+++ b/generator/testdata/golden/models/product_update_diff.golden
@@ -1,7 +1,7 @@
 --- current
 +++ updated
 @@ -1,16 +1,17 @@
- type ProductEntity struct {
+ type Product struct {
 -	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 -	Sku           string          `bun:"sku"`
 -	Name          string          `bun:"name"`

--- a/generator/testdata/golden/models/product_updated.golden
+++ b/generator/testdata/golden/models/product_updated.golden
@@ -15,7 +15,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type ProductEntity struct {
+type Products struct {
+	db queryDB
+}
+
+func NewProducts(db storage.Connection) Products {
+	return Products{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (products Products) WithTx(tx storage.Transaction) Products {
+	return Products{db: tx}
+}
+
+type Product struct {
 	bun.BaseModel `bun:"table:products,alias:products"`
 
 	ID          uuid.UUID       `bun:"id,pk,type:uuid"`
@@ -35,17 +48,17 @@ type ProductEntity struct {
 	Rating      float64         `bun:"rating"`
 }
 
-func (p product) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (ProductEntity, error) {
-	var entity ProductEntity
-	err := db.NewSelect().
+func (products Products) Find(ctx context.Context, id uuid.UUID) (Product, error) {
+	var entity Product
+	err := products.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ProductEntity{}, ErrNotFound
+			return Product{}, ErrNotFound
 		}
-		return ProductEntity{}, err
+		return Product{}, err
 	}
 
 	return entity, nil
@@ -65,8 +78,8 @@ type CreateProductData struct {
 	LaunchedAt  sql.NullTime
 }
 
-func (p product) Create(ctx context.Context, db storage.Executor, data CreateProductData) (ProductEntity, error) {
-	entity := ProductEntity{
+func (products Products) Create(ctx context.Context, data CreateProductData) (Product, error) {
+	entity := Product{
 		ID:          uuid.New(),
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -84,11 +97,11 @@ func (p product) Create(ctx context.Context, db storage.Executor, data CreatePro
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
+		return Product{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return ProductEntity{}, err
+	if _, err := products.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Product{}, err
 	}
 
 	return entity, nil
@@ -109,8 +122,8 @@ type UpdateProductData struct {
 	LaunchedAt  sql.NullTime
 }
 
-func (p product) Update(ctx context.Context, db storage.Executor, data UpdateProductData) (ProductEntity, error) {
-	entity := ProductEntity{
+func (products Products) Update(ctx context.Context, data UpdateProductData) (Product, error) {
+	entity := Product{
 		ID:          data.ID,
 		UpdatedAt:   time.Now(),
 		Sku:         data.Sku,
@@ -127,10 +140,10 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
+		return Product{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := products.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("sku").
 		Column("name").
@@ -149,17 +162,17 @@ func (p product) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ProductEntity{}, ErrNotFound
+			return Product{}, ErrNotFound
 		}
-		return ProductEntity{}, err
+		return Product{}, err
 	}
 
 	return entity, nil
 }
 
-func (p product) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity ProductEntity
-	err := db.NewDelete().
+func (products Products) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Product
+	err := products.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -174,9 +187,9 @@ func (p product) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID)
 	return nil
 }
 
-func (p product) All(ctx context.Context, db storage.Executor) ([]ProductEntity, error) {
-	var entities []ProductEntity
-	if err := db.NewSelect().
+func (products Products) All(ctx context.Context) ([]Product, error) {
+	var entities []Product
+	if err := products.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -186,14 +199,14 @@ func (p product) All(ctx context.Context, db storage.Executor) ([]ProductEntity,
 }
 
 type PaginatedProducts struct {
-	Products   []ProductEntity
+	Products   []Product
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedProducts, error) {
+func (products Products) Paginate(ctx context.Context, page, pageSize int64) (PaginatedProducts, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -206,14 +219,14 @@ func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&ProductEntity{}).Count(ctx)
+	totalCount, err := products.db.Executor().NewSelect().
+		Model(&Product{}).Count(ctx)
 	if err != nil {
 		return PaginatedProducts{}, err
 	}
 
-	entities := make([]ProductEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Product, 0, int(pageSize))
+	if err := products.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -232,8 +245,8 @@ func (p product) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateProductData) (ProductEntity, error) {
-	entity := ProductEntity{
+func (products Products) Upsert(ctx context.Context, id uuid.UUID, data CreateProductData) (Product, error) {
+	entity := Product{
 		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -251,10 +264,10 @@ func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, 
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProductEntity{}, errors.Join(ErrDomainValidation, err)
+		return Product{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := products.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("sku = excluded.sku").
@@ -270,7 +283,7 @@ func (p product) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, 
 		Set("launched_at = excluded.launched_at").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return ProductEntity{}, err
+		return Product{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/array_fields/controllers/documents.go.golden
+++ b/generator/testdata/golden/scaffold/array_fields/controllers/documents.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Documents struct {
-	db storage.Connection
+	documents models.Documents
 }
 
-func NewDocuments(db storage.Connection) Documents {
-	return Documents{db}
+func NewDocuments(documents models.Documents) Documents {
+	return Documents{ documents }
 }
 
 func (d Documents) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (d Documents) Index(etx *echo.Context) error {
 		}
 	}
 
-	documentsList, err := models.Document.Paginate(
+	documentsList, err := d.documents.Paginate(
 		etx.Request().Context(),
-		d.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (d Documents) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	document, err := models.Document.Find(etx.Request().Context(), d.db.Executor(), documentID)
+	document, err := d.documents.Find(etx.Request().Context(), documentID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -177,9 +175,8 @@ func (d Documents) Create(etx *echo.Context) error {
 		IsPublished: payload.IsPublished,
 	}
 
-	document, err := models.Document.Create(
+	document, err := d.documents.Create(
 		etx.Request().Context(),
-		d.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -201,7 +198,7 @@ func (d Documents) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	document, err := models.Document.Find(etx.Request().Context(), d.db.Executor(), documentID)
+	document, err := d.documents.Find(etx.Request().Context(), documentID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -249,9 +246,8 @@ func (d Documents) Update(etx *echo.Context) error {
 		IsPublished: payload.IsPublished,
 	}
 
-	document, err := models.Document.Update(
+	document, err := d.documents.Update(
 		etx.Request().Context(),
-		d.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -276,7 +272,7 @@ func (d Documents) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Document.Destroy(etx.Request().Context(), d.db.Executor(), documentID)
+	err = d.documents.Destroy(etx.Request().Context(), documentID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete document: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/array_fields/models/document.go.golden
+++ b/generator/testdata/golden/scaffold/array_fields/models/document.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type DocumentEntity struct {
+type Documents struct {
+	db queryDB
+}
+
+func NewDocuments(db storage.Connection) Documents {
+	return Documents{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (documents Documents) WithTx(tx storage.Transaction) Documents {
+	return Documents{db: tx}
+}
+
+type Document struct {
 	bun.BaseModel `bun:"table:documents,alias:documents"`
 	ID            uuid.UUID `bun:"id,pk,type:uuid"`
 	Title         string    `bun:"title"`
@@ -26,17 +39,17 @@ type DocumentEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (d document) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (DocumentEntity, error) {
-	var entity DocumentEntity
-	err := db.NewSelect().
+func (documents Documents) Find(ctx context.Context, id uuid.UUID) (Document, error) {
+	var entity Document
+	err := documents.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return DocumentEntity{}, ErrNotFound
+			return Document{}, ErrNotFound
 		}
-		return DocumentEntity{}, err
+		return Document{}, err
 	}
 
 	return entity, nil
@@ -50,8 +63,8 @@ type CreateDocumentData struct {
 	IsPublished bool
 }
 
-func (d document) Create(ctx context.Context, db storage.Executor, data CreateDocumentData) (DocumentEntity, error) {
-	entity := DocumentEntity{
+func (documents Documents) Create(ctx context.Context, data CreateDocumentData) (Document, error) {
+	entity := Document{
 		ID:          uuid.New(),
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -63,11 +76,11 @@ func (d document) Create(ctx context.Context, db storage.Executor, data CreateDo
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return DocumentEntity{}, errors.Join(ErrDomainValidation, err)
+		return Document{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return DocumentEntity{}, err
+	if _, err := documents.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Document{}, err
 	}
 
 	return entity, nil
@@ -82,8 +95,8 @@ type UpdateDocumentData struct {
 	IsPublished bool
 }
 
-func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDocumentData) (DocumentEntity, error) {
-	entity := DocumentEntity{
+func (documents Documents) Update(ctx context.Context, data UpdateDocumentData) (Document, error) {
+	entity := Document{
 		ID:          data.ID,
 		UpdatedAt:   time.Now(),
 		Title:       data.Title,
@@ -94,10 +107,10 @@ func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDo
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return DocumentEntity{}, errors.Join(ErrDomainValidation, err)
+		return Document{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := documents.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("title").
 		Column("tags").
@@ -110,17 +123,17 @@ func (d document) Update(ctx context.Context, db storage.Executor, data UpdateDo
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return DocumentEntity{}, ErrNotFound
+			return Document{}, ErrNotFound
 		}
-		return DocumentEntity{}, err
+		return Document{}, err
 	}
 
 	return entity, nil
 }
 
-func (d document) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity DocumentEntity
-	err := db.NewDelete().
+func (documents Documents) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Document
+	err := documents.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -135,9 +148,9 @@ func (d document) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID
 	return nil
 }
 
-func (d document) All(ctx context.Context, db storage.Executor) ([]DocumentEntity, error) {
-	var entities []DocumentEntity
-	if err := db.NewSelect().
+func (documents Documents) All(ctx context.Context) ([]Document, error) {
+	var entities []Document
+	if err := documents.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -147,14 +160,14 @@ func (d document) All(ctx context.Context, db storage.Executor) ([]DocumentEntit
 }
 
 type PaginatedDocuments struct {
-	Documents  []DocumentEntity
+	Documents  []Document
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (d document) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedDocuments, error) {
+func (documents Documents) Paginate(ctx context.Context, page, pageSize int64) (PaginatedDocuments, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -167,14 +180,14 @@ func (d document) Paginate(ctx context.Context, db storage.Executor, page, pageS
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&DocumentEntity{}).Count(ctx)
+	totalCount, err := documents.db.Executor().NewSelect().
+		Model(&Document{}).Count(ctx)
 	if err != nil {
 		return PaginatedDocuments{}, err
 	}
 
-	entities := make([]DocumentEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Document, 0, int(pageSize))
+	if err := documents.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -193,8 +206,8 @@ func (d document) Paginate(ctx context.Context, db storage.Executor, page, pageS
 	}, nil
 }
 
-func (d document) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateDocumentData) (DocumentEntity, error) {
-	entity := DocumentEntity{
+func (documents Documents) Upsert(ctx context.Context, id uuid.UUID, data CreateDocumentData) (Document, error) {
+	entity := Document{
 		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -206,10 +219,10 @@ func (d document) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID,
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return DocumentEntity{}, errors.Join(ErrDomainValidation, err)
+		return Document{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := documents.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("title = excluded.title").
@@ -219,7 +232,7 @@ func (d document) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID,
 		Set("is_published = excluded.is_published").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return DocumentEntity{}, err
+		return Document{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/array_fields/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/array_fields/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token    struct{}
-	user     struct{}
-	document struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token    token
-	User     user
-	Document document
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewDocuments,
+	),
 )

--- a/generator/testdata/golden/scaffold/array_fields/views/documents_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/array_fields/views/documents_resource.templ.golden
@@ -19,7 +19,7 @@ import (
 
 
 type DocumentIndex struct {
-	Items []models.DocumentEntity
+	Items []models.Document
 }
 
 func (di DocumentIndex) PageFragment() string {
@@ -89,7 +89,7 @@ templ (di DocumentIndex) Page() {
 
 
 type DocumentShow struct {
-	Item models.DocumentEntity
+	Item models.Document
 }
 
 func (ds DocumentShow) PageFragment() string {
@@ -217,7 +217,7 @@ templ (dn DocumentNew) Page() {
 
 
 type DocumentEdit struct {
-	Item models.DocumentEntity
+	Item models.Document
 }
 
 func (de DocumentEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/custom_primary_key/controllers/warehouses.go.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/controllers/warehouses.go.golden
@@ -15,15 +15,14 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Warehouses struct {
-	db storage.Connection
+	warehouses models.Warehouses
 }
 
-func NewWarehouses(db storage.Connection) Warehouses {
-	return Warehouses{db}
+func NewWarehouses(warehouses models.Warehouses) Warehouses {
+	return Warehouses{ warehouses }
 }
 
 func (w Warehouses) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Warehouses) Index(etx *echo.Context) error {
 		}
 	}
 
-	warehousesList, err := models.Warehouse.Paginate(
+	warehousesList, err := w.warehouses.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Warehouses) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	warehouse, err := models.Warehouse.Find(etx.Request().Context(), w.db.Executor(), warehouseID)
+	warehouse, err := w.warehouses.Find(etx.Request().Context(), warehouseID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -168,9 +166,8 @@ func (w Warehouses) Create(etx *echo.Context) error {
 		Location: sql.NullString{String: payload.Location, Valid: true},
 	}
 
-	warehouse, err := models.Warehouse.Create(
+	warehouse, err := w.warehouses.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -192,7 +189,7 @@ func (w Warehouses) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	warehouse, err := models.Warehouse.Find(etx.Request().Context(), w.db.Executor(), warehouseID)
+	warehouse, err := w.warehouses.Find(etx.Request().Context(), warehouseID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -231,9 +228,8 @@ func (w Warehouses) Update(etx *echo.Context) error {
 		Location: sql.NullString{String: payload.Location, Valid: true},
 	}
 
-	warehouse, err := models.Warehouse.Update(
+	warehouse, err := w.warehouses.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -258,7 +254,7 @@ func (w Warehouses) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Warehouse.Destroy(etx.Request().Context(), w.db.Executor(), warehouseID)
+	err = w.warehouses.Destroy(etx.Request().Context(), warehouseID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete warehouse: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/custom_primary_key/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token     struct{}
-	user      struct{}
-	warehouse struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token     token
-	User      user
-	Warehouse warehouse
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewWarehouses,
+	),
 )

--- a/generator/testdata/golden/scaffold/custom_primary_key/models/warehouse.go.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/models/warehouse.go.golden
@@ -13,7 +13,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type WarehouseEntity struct {
+type Warehouses struct {
+	db queryDB
+}
+
+func NewWarehouses(db storage.Connection) Warehouses {
+	return Warehouses{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (warehouses Warehouses) WithTx(tx storage.Transaction) Warehouses {
+	return Warehouses{db: tx}
+}
+
+type Warehouse struct {
 	bun.BaseModel `bun:"table:warehouses,alias:warehouses"`
 	Slug          string         `bun:"slug,pk"`
 	Name          string         `bun:"name"`
@@ -22,17 +35,17 @@ type WarehouseEntity struct {
 	UpdatedAt     time.Time      `bun:"updated_at"`
 }
 
-func (w warehouse) Find(ctx context.Context, db storage.Executor, id string) (WarehouseEntity, error) {
-	var entity WarehouseEntity
-	err := db.NewSelect().
+func (warehouses Warehouses) Find(ctx context.Context, id string) (Warehouse, error) {
+	var entity Warehouse
+	err := warehouses.db.Executor().NewSelect().
 		Model(&entity).
 		Where("slug = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WarehouseEntity{}, ErrNotFound
+			return Warehouse{}, ErrNotFound
 		}
-		return WarehouseEntity{}, err
+		return Warehouse{}, err
 	}
 
 	return entity, nil
@@ -44,8 +57,8 @@ type CreateWarehouseData struct {
 	Slug     string
 }
 
-func (w warehouse) Create(ctx context.Context, db storage.Executor, data CreateWarehouseData) (WarehouseEntity, error) {
-	entity := WarehouseEntity{
+func (warehouses Warehouses) Create(ctx context.Context, data CreateWarehouseData) (Warehouse, error) {
+	entity := Warehouse{
 		Slug:      data.Slug,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -54,11 +67,11 @@ func (w warehouse) Create(ctx context.Context, db storage.Executor, data CreateW
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WarehouseEntity{}, errors.Join(ErrDomainValidation, err)
+		return Warehouse{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return WarehouseEntity{}, err
+	if _, err := warehouses.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Warehouse{}, err
 	}
 
 	return entity, nil
@@ -70,8 +83,8 @@ type UpdateWarehouseData struct {
 	Location sql.NullString
 }
 
-func (w warehouse) Update(ctx context.Context, db storage.Executor, data UpdateWarehouseData) (WarehouseEntity, error) {
-	entity := WarehouseEntity{
+func (warehouses Warehouses) Update(ctx context.Context, data UpdateWarehouseData) (Warehouse, error) {
+	entity := Warehouse{
 		Slug:      data.Slug,
 		UpdatedAt: time.Now(),
 		Name:      data.Name,
@@ -79,10 +92,10 @@ func (w warehouse) Update(ctx context.Context, db storage.Executor, data UpdateW
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WarehouseEntity{}, errors.Join(ErrDomainValidation, err)
+		return Warehouse{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := warehouses.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("location").
@@ -92,17 +105,17 @@ func (w warehouse) Update(ctx context.Context, db storage.Executor, data UpdateW
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WarehouseEntity{}, ErrNotFound
+			return Warehouse{}, ErrNotFound
 		}
-		return WarehouseEntity{}, err
+		return Warehouse{}, err
 	}
 
 	return entity, nil
 }
 
-func (w warehouse) Destroy(ctx context.Context, db storage.Executor, id string) error {
-	var entity WarehouseEntity
-	err := db.NewDelete().
+func (warehouses Warehouses) Destroy(ctx context.Context, id string) error {
+	var entity Warehouse
+	err := warehouses.db.Executor().NewDelete().
 		Model(&entity).
 		Where("slug = ?", id).
 		Returning("*").
@@ -117,9 +130,9 @@ func (w warehouse) Destroy(ctx context.Context, db storage.Executor, id string) 
 	return nil
 }
 
-func (w warehouse) All(ctx context.Context, db storage.Executor) ([]WarehouseEntity, error) {
-	var entities []WarehouseEntity
-	if err := db.NewSelect().
+func (warehouses Warehouses) All(ctx context.Context) ([]Warehouse, error) {
+	var entities []Warehouse
+	if err := warehouses.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -129,14 +142,14 @@ func (w warehouse) All(ctx context.Context, db storage.Executor) ([]WarehouseEnt
 }
 
 type PaginatedWarehouses struct {
-	Warehouses []WarehouseEntity
+	Warehouses []Warehouse
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (w warehouse) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedWarehouses, error) {
+func (warehouses Warehouses) Paginate(ctx context.Context, page, pageSize int64) (PaginatedWarehouses, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -149,14 +162,14 @@ func (w warehouse) Paginate(ctx context.Context, db storage.Executor, page, page
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&WarehouseEntity{}).Count(ctx)
+	totalCount, err := warehouses.db.Executor().NewSelect().
+		Model(&Warehouse{}).Count(ctx)
 	if err != nil {
 		return PaginatedWarehouses{}, err
 	}
 
-	entities := make([]WarehouseEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Warehouse, 0, int(pageSize))
+	if err := warehouses.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -175,8 +188,8 @@ func (w warehouse) Paginate(ctx context.Context, db storage.Executor, page, page
 	}, nil
 }
 
-func (w warehouse) Upsert(ctx context.Context, db storage.Executor, id string, data CreateWarehouseData) (WarehouseEntity, error) {
-	entity := WarehouseEntity{
+func (warehouses Warehouses) Upsert(ctx context.Context, id string, data CreateWarehouseData) (Warehouse, error) {
+	entity := Warehouse{
 		Slug:      id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -185,17 +198,17 @@ func (w warehouse) Upsert(ctx context.Context, db storage.Executor, id string, d
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WarehouseEntity{}, errors.Join(ErrDomainValidation, err)
+		return Warehouse{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := warehouses.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (slug) DO UPDATE").
 		Set("name = excluded.name").
 		Set("location = excluded.location").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return WarehouseEntity{}, err
+		return Warehouse{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/custom_primary_key/views/warehouses_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/custom_primary_key/views/warehouses_resource.templ.golden
@@ -24,7 +24,7 @@ type WarehouseData struct {
 	UpdatedAt time.Time
 }
 
-func newWarehouseData(entity models.WarehouseEntity) WarehouseData {
+func newWarehouseData(entity models.Warehouse) WarehouseData {
 	return WarehouseData{
 		Name: entity.Name,
 		Location: func() string { if !entity.Location.Valid { return "" }; return entity.Location.String }(),
@@ -35,7 +35,7 @@ func newWarehouseData(entity models.WarehouseEntity) WarehouseData {
 
 
 type WarehouseIndex struct {
-	Items []models.WarehouseEntity
+	Items []models.Warehouse
 }
 
 func (wi WarehouseIndex) PageFragment() string {
@@ -100,7 +100,7 @@ templ (wi WarehouseIndex) Page() {
 
 
 type WarehouseShow struct {
-	Item models.WarehouseEntity
+	Item models.Warehouse
 }
 
 func (ws WarehouseShow) PageFragment() string {
@@ -204,7 +204,7 @@ templ (wn WarehouseNew) Page() {
 
 
 type WarehouseEdit struct {
-	Item models.WarehouseEntity
+	Item models.Warehouse
 }
 
 func (we WarehouseEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/full_crud/controllers/widgets.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/full_crud/models/factories/widget.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud/models/factories/widget.go.golden
@@ -11,18 +11,18 @@ import (
 	"testapp/models"
 )
 
-// WidgetFactory wraps models.WidgetEntity for testing
+// WidgetFactory wraps models.Widget for testing
 type WidgetFactory struct {
-	models.WidgetEntity
+	models.Widget
 }
 
 type WidgetOption func(*WidgetFactory)
 
 // BuildWidget creates an in-memory Widget with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateWidget.
-func BuildWidget(opts ...WidgetOption) models.WidgetEntity {
+func BuildWidget(opts ...WidgetOption) models.Widget {
 	f := &WidgetFactory{
-		WidgetEntity: models.WidgetEntity{
+		Widget: models.Widget{
 			Name:     faker.Name(),
 			Quantity: randomInt(1, 1000, 100),
 			Active:   randomBool(),
@@ -33,15 +33,15 @@ func BuildWidget(opts ...WidgetOption) models.WidgetEntity {
 		opt(f)
 	}
 
-	return f.WidgetEntity
+	return f.Widget
 }
 
 // CreateWidget creates and persists a Widget to the database.
 // It returns the entity populated with all DB-assigned values via RETURNING *.
-func CreateWidget(ctx context.Context, exec storage.Executor, opts ...WidgetOption) (models.WidgetEntity, error) {
+func CreateWidget(ctx context.Context, exec storage.Executor, opts ...WidgetOption) (models.Widget, error) {
 	built := BuildWidget(opts...)
 
-	entity := models.WidgetEntity{
+	entity := models.Widget{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -51,15 +51,15 @@ func CreateWidget(ctx context.Context, exec storage.Executor, opts ...WidgetOpti
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.WidgetEntity{}, err
+		return models.Widget{}, err
 	}
 
 	return entity, nil
 }
 
 // CreateWidgets creates multiple Widget records at once
-func CreateWidgets(ctx context.Context, exec storage.Executor, count int, opts ...WidgetOption) ([]models.WidgetEntity, error) {
-	widgets := make([]models.WidgetEntity, 0, count)
+func CreateWidgets(ctx context.Context, exec storage.Executor, count int, opts ...WidgetOption) ([]models.Widget, error) {
+	widgets := make([]models.Widget, 0, count)
 
 	for i := range count {
 		entity, err := CreateWidget(ctx, exec, opts...)
@@ -77,20 +77,20 @@ func CreateWidgets(ctx context.Context, exec storage.Executor, count int, opts .
 // WithWidgetName sets the Name field
 func WithWidgetName(value string) WidgetOption {
 	return func(f *WidgetFactory) {
-		f.WidgetEntity.Name = value
+		f.Widget.Name = value
 	}
 }
 
 // WithWidgetQuantity sets the Quantity field
 func WithWidgetQuantity(value int32) WidgetOption {
 	return func(f *WidgetFactory) {
-		f.WidgetEntity.Quantity = value
+		f.Widget.Quantity = value
 	}
 }
 
 // WithWidgetActive sets the Active field
 func WithWidgetActive(value bool) WidgetOption {
 	return func(f *WidgetFactory) {
-		f.WidgetEntity.Active = value
+		f.Widget.Active = value
 	}
 }

--- a/generator/testdata/golden/scaffold/full_crud/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token  struct{}
-	user   struct{}
-	widget struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token  token
-	User   user
-	Widget widget
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewWidgets,
+	),
 )

--- a/generator/testdata/golden/scaffold/full_crud/models/widget.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud/models/widget.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type WidgetEntity struct {
+type Widgets struct {
+	db queryDB
+}
+
+func NewWidgets(db storage.Connection) Widgets {
+	return Widgets{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (widgets Widgets) WithTx(tx storage.Transaction) Widgets {
+	return Widgets{db: tx}
+}
+
+type Widget struct {
 	bun.BaseModel `bun:"table:widgets,alias:widgets"`
 	ID            uuid.UUID `bun:"id,pk,type:uuid"`
 	Name          string    `bun:"name"`
@@ -24,17 +37,17 @@ type WidgetEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (w widget) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (WidgetEntity, error) {
-	var entity WidgetEntity
-	err := db.NewSelect().
+func (widgets Widgets) Find(ctx context.Context, id uuid.UUID) (Widget, error) {
+	var entity Widget
+	err := widgets.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WidgetEntity{}, ErrNotFound
+			return Widget{}, ErrNotFound
 		}
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil
@@ -46,8 +59,8 @@ type CreateWidgetData struct {
 	Active   bool
 }
 
-func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Create(ctx context.Context, data CreateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -57,11 +70,11 @@ func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidg
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return WidgetEntity{}, err
+	if _, err := widgets.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Widget{}, err
 	}
 
 	return entity, nil
@@ -74,8 +87,8 @@ type UpdateWidgetData struct {
 	Active   bool
 }
 
-func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Update(ctx context.Context, data UpdateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        data.ID,
 		UpdatedAt: time.Now(),
 		Name:      data.Name,
@@ -84,10 +97,10 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := widgets.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("quantity").
@@ -98,17 +111,17 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WidgetEntity{}, ErrNotFound
+			return Widget{}, ErrNotFound
 		}
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil
 }
 
-func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity WidgetEntity
-	err := db.NewDelete().
+func (widgets Widgets) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Widget
+	err := widgets.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -123,9 +136,9 @@ func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) 
 	return nil
 }
 
-func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, error) {
-	var entities []WidgetEntity
-	if err := db.NewSelect().
+func (widgets Widgets) All(ctx context.Context) ([]Widget, error) {
+	var entities []Widget
+	if err := widgets.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -135,14 +148,14 @@ func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, e
 }
 
 type PaginatedWidgets struct {
-	Widgets    []WidgetEntity
+	Widgets    []Widget
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedWidgets, error) {
+func (widgets Widgets) Paginate(ctx context.Context, page, pageSize int64) (PaginatedWidgets, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -155,14 +168,14 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&WidgetEntity{}).Count(ctx)
+	totalCount, err := widgets.db.Executor().NewSelect().
+		Model(&Widget{}).Count(ctx)
 	if err != nil {
 		return PaginatedWidgets{}, err
 	}
 
-	entities := make([]WidgetEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Widget, 0, int(pageSize))
+	if err := widgets.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -181,8 +194,8 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 	}, nil
 }
 
-func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Upsert(ctx context.Context, id uuid.UUID, data CreateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -192,10 +205,10 @@ func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, d
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := widgets.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("name = excluded.name").
@@ -203,7 +216,7 @@ func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, d
 		Set("active = excluded.active").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/full_crud/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/full_crud/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -196,7 +196,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/full_crud_css_components/controllers/widgets.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/full_crud_css_components/models/factories/widget.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/models/factories/widget.go.golden
@@ -11,18 +11,18 @@ import (
 	"testapp/models"
 )
 
-// WidgetFactory wraps models.WidgetEntity for testing
+// WidgetFactory wraps models.Widget for testing
 type WidgetFactory struct {
-	models.WidgetEntity
+	models.Widget
 }
 
 type WidgetOption func(*WidgetFactory)
 
 // BuildWidget creates an in-memory Widget with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateWidget.
-func BuildWidget(opts ...WidgetOption) models.WidgetEntity {
+func BuildWidget(opts ...WidgetOption) models.Widget {
 	f := &WidgetFactory{
-		WidgetEntity: models.WidgetEntity{
+		Widget: models.Widget{
 			Name:     faker.Name(),
 			Quantity: randomInt(1, 1000, 100),
 			Active:   randomBool(),
@@ -33,15 +33,15 @@ func BuildWidget(opts ...WidgetOption) models.WidgetEntity {
 		opt(f)
 	}
 
-	return f.WidgetEntity
+	return f.Widget
 }
 
 // CreateWidget creates and persists a Widget to the database.
 // It returns the entity populated with all DB-assigned values via RETURNING *.
-func CreateWidget(ctx context.Context, exec storage.Executor, opts ...WidgetOption) (models.WidgetEntity, error) {
+func CreateWidget(ctx context.Context, exec storage.Executor, opts ...WidgetOption) (models.Widget, error) {
 	built := BuildWidget(opts...)
 
-	entity := models.WidgetEntity{
+	entity := models.Widget{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -51,15 +51,15 @@ func CreateWidget(ctx context.Context, exec storage.Executor, opts ...WidgetOpti
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.WidgetEntity{}, err
+		return models.Widget{}, err
 	}
 
 	return entity, nil
 }
 
 // CreateWidgets creates multiple Widget records at once
-func CreateWidgets(ctx context.Context, exec storage.Executor, count int, opts ...WidgetOption) ([]models.WidgetEntity, error) {
-	widgets := make([]models.WidgetEntity, 0, count)
+func CreateWidgets(ctx context.Context, exec storage.Executor, count int, opts ...WidgetOption) ([]models.Widget, error) {
+	widgets := make([]models.Widget, 0, count)
 
 	for i := range count {
 		entity, err := CreateWidget(ctx, exec, opts...)
@@ -77,20 +77,20 @@ func CreateWidgets(ctx context.Context, exec storage.Executor, count int, opts .
 // WithWidgetName sets the Name field
 func WithWidgetName(value string) WidgetOption {
 	return func(f *WidgetFactory) {
-		f.WidgetEntity.Name = value
+		f.Widget.Name = value
 	}
 }
 
 // WithWidgetQuantity sets the Quantity field
 func WithWidgetQuantity(value int32) WidgetOption {
 	return func(f *WidgetFactory) {
-		f.WidgetEntity.Quantity = value
+		f.Widget.Quantity = value
 	}
 }
 
 // WithWidgetActive sets the Active field
 func WithWidgetActive(value bool) WidgetOption {
 	return func(f *WidgetFactory) {
-		f.WidgetEntity.Active = value
+		f.Widget.Active = value
 	}
 }

--- a/generator/testdata/golden/scaffold/full_crud_css_components/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token  struct{}
-	user   struct{}
-	widget struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token  token
-	User   user
-	Widget widget
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewWidgets,
+	),
 )

--- a/generator/testdata/golden/scaffold/full_crud_css_components/models/widget.go.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/models/widget.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type WidgetEntity struct {
+type Widgets struct {
+	db queryDB
+}
+
+func NewWidgets(db storage.Connection) Widgets {
+	return Widgets{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (widgets Widgets) WithTx(tx storage.Transaction) Widgets {
+	return Widgets{db: tx}
+}
+
+type Widget struct {
 	bun.BaseModel `bun:"table:widgets,alias:widgets"`
 	ID            uuid.UUID `bun:"id,pk,type:uuid"`
 	Name          string    `bun:"name"`
@@ -24,17 +37,17 @@ type WidgetEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (w widget) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (WidgetEntity, error) {
-	var entity WidgetEntity
-	err := db.NewSelect().
+func (widgets Widgets) Find(ctx context.Context, id uuid.UUID) (Widget, error) {
+	var entity Widget
+	err := widgets.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WidgetEntity{}, ErrNotFound
+			return Widget{}, ErrNotFound
 		}
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil
@@ -46,8 +59,8 @@ type CreateWidgetData struct {
 	Active   bool
 }
 
-func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Create(ctx context.Context, data CreateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -57,11 +70,11 @@ func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidg
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return WidgetEntity{}, err
+	if _, err := widgets.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Widget{}, err
 	}
 
 	return entity, nil
@@ -74,8 +87,8 @@ type UpdateWidgetData struct {
 	Active   bool
 }
 
-func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Update(ctx context.Context, data UpdateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        data.ID,
 		UpdatedAt: time.Now(),
 		Name:      data.Name,
@@ -84,10 +97,10 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := widgets.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("quantity").
@@ -98,17 +111,17 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WidgetEntity{}, ErrNotFound
+			return Widget{}, ErrNotFound
 		}
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil
 }
 
-func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity WidgetEntity
-	err := db.NewDelete().
+func (widgets Widgets) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Widget
+	err := widgets.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -123,9 +136,9 @@ func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) 
 	return nil
 }
 
-func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, error) {
-	var entities []WidgetEntity
-	if err := db.NewSelect().
+func (widgets Widgets) All(ctx context.Context) ([]Widget, error) {
+	var entities []Widget
+	if err := widgets.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -135,14 +148,14 @@ func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, e
 }
 
 type PaginatedWidgets struct {
-	Widgets    []WidgetEntity
+	Widgets    []Widget
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedWidgets, error) {
+func (widgets Widgets) Paginate(ctx context.Context, page, pageSize int64) (PaginatedWidgets, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -155,14 +168,14 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&WidgetEntity{}).Count(ctx)
+	totalCount, err := widgets.db.Executor().NewSelect().
+		Model(&Widget{}).Count(ctx)
 	if err != nil {
 		return PaginatedWidgets{}, err
 	}
 
-	entities := make([]WidgetEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Widget, 0, int(pageSize))
+	if err := widgets.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -181,8 +194,8 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 	}, nil
 }
 
-func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Upsert(ctx context.Context, id uuid.UUID, data CreateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -192,10 +205,10 @@ func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, d
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := widgets.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("name = excluded.name").
@@ -203,7 +216,7 @@ func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, d
 		Set("active = excluded.active").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/full_crud_css_components/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/full_crud_css_components/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -194,7 +194,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/irregular_plural/controllers/companies.go.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/controllers/companies.go.golden
@@ -16,15 +16,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Companies struct {
-	db storage.Connection
+	companies models.Companies
 }
 
-func NewCompanies(db storage.Connection) Companies {
-	return Companies{db}
+func NewCompanies(companies models.Companies) Companies {
+	return Companies{ companies }
 }
 
 func (c Companies) RegisterRoutes(r *router.Router) error {
@@ -113,9 +112,8 @@ func (c Companies) Index(etx *echo.Context) error {
 		}
 	}
 
-	companiesList, err := models.Company.Paginate(
+	companiesList, err := c.companies.Paginate(
 		etx.Request().Context(),
-		c.db.Executor(),
 		page,
 		perPage,
 	)
@@ -132,7 +130,7 @@ func (c Companies) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	company, err := models.Company.Find(etx.Request().Context(), c.db.Executor(), companyID)
+	company, err := c.companies.Find(etx.Request().Context(), companyID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -169,9 +167,8 @@ func (c Companies) Create(etx *echo.Context) error {
 		Industry: sql.NullString{String: payload.Industry, Valid: true},
 	}
 
-	company, err := models.Company.Create(
+	company, err := c.companies.Create(
 		etx.Request().Context(),
-		c.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -193,7 +190,7 @@ func (c Companies) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	company, err := models.Company.Find(etx.Request().Context(), c.db.Executor(), companyID)
+	company, err := c.companies.Find(etx.Request().Context(), companyID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -232,9 +229,8 @@ func (c Companies) Update(etx *echo.Context) error {
 		Industry: sql.NullString{String: payload.Industry, Valid: true},
 	}
 
-	company, err := models.Company.Update(
+	company, err := c.companies.Update(
 		etx.Request().Context(),
-		c.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -259,7 +255,7 @@ func (c Companies) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Company.Destroy(etx.Request().Context(), c.db.Executor(), companyID)
+	err = c.companies.Destroy(etx.Request().Context(), companyID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete company: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/irregular_plural/models/company.go.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/models/company.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type CompanyEntity struct {
+type Companies struct {
+	db queryDB
+}
+
+func NewCompanies(db storage.Connection) Companies {
+	return Companies{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (companies Companies) WithTx(tx storage.Transaction) Companies {
+	return Companies{db: tx}
+}
+
+type Company struct {
 	bun.BaseModel `bun:"table:companies,alias:companies"`
 	ID            uuid.UUID      `bun:"id,pk,type:uuid"`
 	Name          string         `bun:"name"`
@@ -23,17 +36,17 @@ type CompanyEntity struct {
 	UpdatedAt     time.Time      `bun:"updated_at"`
 }
 
-func (c company) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (CompanyEntity, error) {
-	var entity CompanyEntity
-	err := db.NewSelect().
+func (companies Companies) Find(ctx context.Context, id uuid.UUID) (Company, error) {
+	var entity Company
+	err := companies.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return CompanyEntity{}, ErrNotFound
+			return Company{}, ErrNotFound
 		}
-		return CompanyEntity{}, err
+		return Company{}, err
 	}
 
 	return entity, nil
@@ -44,8 +57,8 @@ type CreateCompanyData struct {
 	Industry sql.NullString
 }
 
-func (c company) Create(ctx context.Context, db storage.Executor, data CreateCompanyData) (CompanyEntity, error) {
-	entity := CompanyEntity{
+func (companies Companies) Create(ctx context.Context, data CreateCompanyData) (Company, error) {
+	entity := Company{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -54,11 +67,11 @@ func (c company) Create(ctx context.Context, db storage.Executor, data CreateCom
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return CompanyEntity{}, errors.Join(ErrDomainValidation, err)
+		return Company{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return CompanyEntity{}, err
+	if _, err := companies.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Company{}, err
 	}
 
 	return entity, nil
@@ -70,8 +83,8 @@ type UpdateCompanyData struct {
 	Industry sql.NullString
 }
 
-func (c company) Update(ctx context.Context, db storage.Executor, data UpdateCompanyData) (CompanyEntity, error) {
-	entity := CompanyEntity{
+func (companies Companies) Update(ctx context.Context, data UpdateCompanyData) (Company, error) {
+	entity := Company{
 		ID:        data.ID,
 		UpdatedAt: time.Now(),
 		Name:      data.Name,
@@ -79,10 +92,10 @@ func (c company) Update(ctx context.Context, db storage.Executor, data UpdateCom
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return CompanyEntity{}, errors.Join(ErrDomainValidation, err)
+		return Company{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := companies.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("industry").
@@ -92,17 +105,17 @@ func (c company) Update(ctx context.Context, db storage.Executor, data UpdateCom
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return CompanyEntity{}, ErrNotFound
+			return Company{}, ErrNotFound
 		}
-		return CompanyEntity{}, err
+		return Company{}, err
 	}
 
 	return entity, nil
 }
 
-func (c company) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity CompanyEntity
-	err := db.NewDelete().
+func (companies Companies) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Company
+	err := companies.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -117,9 +130,9 @@ func (c company) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID)
 	return nil
 }
 
-func (c company) All(ctx context.Context, db storage.Executor) ([]CompanyEntity, error) {
-	var entities []CompanyEntity
-	if err := db.NewSelect().
+func (companies Companies) All(ctx context.Context) ([]Company, error) {
+	var entities []Company
+	if err := companies.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -129,14 +142,14 @@ func (c company) All(ctx context.Context, db storage.Executor) ([]CompanyEntity,
 }
 
 type PaginatedCompanies struct {
-	Companies  []CompanyEntity
+	Companies  []Company
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (c company) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedCompanies, error) {
+func (companies Companies) Paginate(ctx context.Context, page, pageSize int64) (PaginatedCompanies, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -149,14 +162,14 @@ func (c company) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&CompanyEntity{}).Count(ctx)
+	totalCount, err := companies.db.Executor().NewSelect().
+		Model(&Company{}).Count(ctx)
 	if err != nil {
 		return PaginatedCompanies{}, err
 	}
 
-	entities := make([]CompanyEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Company, 0, int(pageSize))
+	if err := companies.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -175,8 +188,8 @@ func (c company) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (c company) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateCompanyData) (CompanyEntity, error) {
-	entity := CompanyEntity{
+func (companies Companies) Upsert(ctx context.Context, id uuid.UUID, data CreateCompanyData) (Company, error) {
+	entity := Company{
 		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -185,17 +198,17 @@ func (c company) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, 
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return CompanyEntity{}, errors.Join(ErrDomainValidation, err)
+		return Company{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := companies.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("name = excluded.name").
 		Set("industry = excluded.industry").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return CompanyEntity{}, err
+		return Company{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/irregular_plural/models/factories/company.go.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/models/factories/company.go.golden
@@ -12,18 +12,18 @@ import (
 	"testapp/models"
 )
 
-// CompanyFactory wraps models.CompanyEntity for testing
+// CompanyFactory wraps models.Company for testing
 type CompanyFactory struct {
-	models.CompanyEntity
+	models.Company
 }
 
 type CompanyOption func(*CompanyFactory)
 
 // BuildCompany creates an in-memory Company with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateCompany.
-func BuildCompany(opts ...CompanyOption) models.CompanyEntity {
+func BuildCompany(opts ...CompanyOption) models.Company {
 	f := &CompanyFactory{
-		CompanyEntity: models.CompanyEntity{
+		Company: models.Company{
 			Name:     faker.Name(),
 			Industry: sql.NullString{},
 		},
@@ -33,15 +33,15 @@ func BuildCompany(opts ...CompanyOption) models.CompanyEntity {
 		opt(f)
 	}
 
-	return f.CompanyEntity
+	return f.Company
 }
 
 // CreateCompany creates and persists a Company to the database.
 // It returns the entity populated with all DB-assigned values via RETURNING *.
-func CreateCompany(ctx context.Context, exec storage.Executor, opts ...CompanyOption) (models.CompanyEntity, error) {
+func CreateCompany(ctx context.Context, exec storage.Executor, opts ...CompanyOption) (models.Company, error) {
 	built := BuildCompany(opts...)
 
-	entity := models.CompanyEntity{
+	entity := models.Company{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -50,15 +50,15 @@ func CreateCompany(ctx context.Context, exec storage.Executor, opts ...CompanyOp
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.CompanyEntity{}, err
+		return models.Company{}, err
 	}
 
 	return entity, nil
 }
 
 // CreateCompanies creates multiple Company records at once
-func CreateCompanies(ctx context.Context, exec storage.Executor, count int, opts ...CompanyOption) ([]models.CompanyEntity, error) {
-	companies := make([]models.CompanyEntity, 0, count)
+func CreateCompanies(ctx context.Context, exec storage.Executor, count int, opts ...CompanyOption) ([]models.Company, error) {
+	companies := make([]models.Company, 0, count)
 
 	for i := range count {
 		entity, err := CreateCompany(ctx, exec, opts...)
@@ -76,13 +76,13 @@ func CreateCompanies(ctx context.Context, exec storage.Executor, count int, opts
 // WithCompanyName sets the Name field
 func WithCompanyName(value string) CompanyOption {
 	return func(f *CompanyFactory) {
-		f.CompanyEntity.Name = value
+		f.Company.Name = value
 	}
 }
 
 // WithCompanyIndustry sets the Industry field
 func WithCompanyIndustry(value sql.NullString) CompanyOption {
 	return func(f *CompanyFactory) {
-		f.CompanyEntity.Industry = value
+		f.Company.Industry = value
 	}
 }

--- a/generator/testdata/golden/scaffold/irregular_plural/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token   struct{}
-	user    struct{}
-	company struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token   token
-	User    user
-	Company company
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewCompanies,
+	),
 )

--- a/generator/testdata/golden/scaffold/irregular_plural/views/companies_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/irregular_plural/views/companies_resource.templ.golden
@@ -24,7 +24,7 @@ type CompanyData struct {
 	UpdatedAt time.Time
 }
 
-func newCompanyData(entity models.CompanyEntity) CompanyData {
+func newCompanyData(entity models.Company) CompanyData {
 	return CompanyData{
 		Name: entity.Name,
 		Industry: func() string { if !entity.Industry.Valid { return "" }; return entity.Industry.String }(),
@@ -35,7 +35,7 @@ func newCompanyData(entity models.CompanyEntity) CompanyData {
 
 
 type CompanyIndex struct {
-	Items []models.CompanyEntity
+	Items []models.Company
 }
 
 func (ci CompanyIndex) PageFragment() string {
@@ -100,7 +100,7 @@ templ (ci CompanyIndex) Page() {
 
 
 type CompanyShow struct {
-	Item models.CompanyEntity
+	Item models.Company
 }
 
 func (cs CompanyShow) PageFragment() string {
@@ -204,7 +204,7 @@ templ (cn CompanyNew) Page() {
 
 
 type CompanyEdit struct {
-	Item models.CompanyEntity
+	Item models.Company
 }
 
 func (ce CompanyEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/skip_factory/controllers/widgets.go.golden
+++ b/generator/testdata/golden/scaffold/skip_factory/controllers/widgets.go.golden
@@ -15,15 +15,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Widgets struct {
-	db storage.Connection
+	widgets models.Widgets
 }
 
-func NewWidgets(db storage.Connection) Widgets {
-	return Widgets{db}
+func NewWidgets(widgets models.Widgets) Widgets {
+	return Widgets{ widgets }
 }
 
 func (w Widgets) RegisterRoutes(r *router.Router) error {
@@ -112,9 +111,8 @@ func (w Widgets) Index(etx *echo.Context) error {
 		}
 	}
 
-	widgetsList, err := models.Widget.Paginate(
+	widgetsList, err := w.widgets.Paginate(
 		etx.Request().Context(),
-		w.db.Executor(),
 		page,
 		perPage,
 	)
@@ -131,7 +129,7 @@ func (w Widgets) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -171,9 +169,8 @@ func (w Widgets) Create(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Create(
+	widget, err := w.widgets.Create(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -195,7 +192,7 @@ func (w Widgets) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	widget, err := models.Widget.Find(etx.Request().Context(), w.db.Executor(), widgetID)
+	widget, err := w.widgets.Find(etx.Request().Context(), widgetID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -237,9 +234,8 @@ func (w Widgets) Update(etx *echo.Context) error {
 		Active: payload.Active,
 	}
 
-	widget, err := models.Widget.Update(
+	widget, err := w.widgets.Update(
 		etx.Request().Context(),
-		w.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -264,7 +260,7 @@ func (w Widgets) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.Widget.Destroy(etx.Request().Context(), w.db.Executor(), widgetID)
+	err = w.widgets.Destroy(etx.Request().Context(), widgetID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete widget: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/skip_factory/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/skip_factory/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token  struct{}
-	user   struct{}
-	widget struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token  token
-	User   user
-	Widget widget
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewWidgets,
+	),
 )

--- a/generator/testdata/golden/scaffold/skip_factory/models/widget.go.golden
+++ b/generator/testdata/golden/scaffold/skip_factory/models/widget.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type WidgetEntity struct {
+type Widgets struct {
+	db queryDB
+}
+
+func NewWidgets(db storage.Connection) Widgets {
+	return Widgets{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (widgets Widgets) WithTx(tx storage.Transaction) Widgets {
+	return Widgets{db: tx}
+}
+
+type Widget struct {
 	bun.BaseModel `bun:"table:widgets,alias:widgets"`
 	ID            uuid.UUID `bun:"id,pk,type:uuid"`
 	Name          string    `bun:"name"`
@@ -24,17 +37,17 @@ type WidgetEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (w widget) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (WidgetEntity, error) {
-	var entity WidgetEntity
-	err := db.NewSelect().
+func (widgets Widgets) Find(ctx context.Context, id uuid.UUID) (Widget, error) {
+	var entity Widget
+	err := widgets.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WidgetEntity{}, ErrNotFound
+			return Widget{}, ErrNotFound
 		}
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil
@@ -46,8 +59,8 @@ type CreateWidgetData struct {
 	Active   bool
 }
 
-func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Create(ctx context.Context, data CreateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -57,11 +70,11 @@ func (w widget) Create(ctx context.Context, db storage.Executor, data CreateWidg
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return WidgetEntity{}, err
+	if _, err := widgets.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Widget{}, err
 	}
 
 	return entity, nil
@@ -74,8 +87,8 @@ type UpdateWidgetData struct {
 	Active   bool
 }
 
-func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Update(ctx context.Context, data UpdateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        data.ID,
 		UpdatedAt: time.Now(),
 		Name:      data.Name,
@@ -84,10 +97,10 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := widgets.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("name").
 		Column("quantity").
@@ -98,17 +111,17 @@ func (w widget) Update(ctx context.Context, db storage.Executor, data UpdateWidg
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return WidgetEntity{}, ErrNotFound
+			return Widget{}, ErrNotFound
 		}
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil
 }
 
-func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity WidgetEntity
-	err := db.NewDelete().
+func (widgets Widgets) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Widget
+	err := widgets.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -123,9 +136,9 @@ func (w widget) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) 
 	return nil
 }
 
-func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, error) {
-	var entities []WidgetEntity
-	if err := db.NewSelect().
+func (widgets Widgets) All(ctx context.Context) ([]Widget, error) {
+	var entities []Widget
+	if err := widgets.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -135,14 +148,14 @@ func (w widget) All(ctx context.Context, db storage.Executor) ([]WidgetEntity, e
 }
 
 type PaginatedWidgets struct {
-	Widgets    []WidgetEntity
+	Widgets    []Widget
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedWidgets, error) {
+func (widgets Widgets) Paginate(ctx context.Context, page, pageSize int64) (PaginatedWidgets, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -155,14 +168,14 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&WidgetEntity{}).Count(ctx)
+	totalCount, err := widgets.db.Executor().NewSelect().
+		Model(&Widget{}).Count(ctx)
 	if err != nil {
 		return PaginatedWidgets{}, err
 	}
 
-	entities := make([]WidgetEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Widget, 0, int(pageSize))
+	if err := widgets.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -181,8 +194,8 @@ func (w widget) Paginate(ctx context.Context, db storage.Executor, page, pageSiz
 	}, nil
 }
 
-func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateWidgetData) (WidgetEntity, error) {
-	entity := WidgetEntity{
+func (widgets Widgets) Upsert(ctx context.Context, id uuid.UUID, data CreateWidgetData) (Widget, error) {
+	entity := Widget{
 		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -192,10 +205,10 @@ func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, d
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return WidgetEntity{}, errors.Join(ErrDomainValidation, err)
+		return Widget{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := widgets.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("name = excluded.name").
@@ -203,7 +216,7 @@ func (w widget) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, d
 		Set("active = excluded.active").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return WidgetEntity{}, err
+		return Widget{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/skip_factory/views/widgets_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/skip_factory/views/widgets_resource.templ.golden
@@ -18,7 +18,7 @@ import (
 
 
 type WidgetIndex struct {
-	Items []models.WidgetEntity
+	Items []models.Widget
 }
 
 func (wi WidgetIndex) PageFragment() string {
@@ -84,7 +84,7 @@ templ (wi WidgetIndex) Page() {
 
 
 type WidgetShow struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (ws WidgetShow) PageFragment() string {
@@ -196,7 +196,7 @@ templ (wn WidgetNew) Page() {
 
 
 type WidgetEdit struct {
-	Item models.WidgetEntity
+	Item models.Widget
 }
 
 func (we WidgetEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/table_name_override/controllers/student_feedback.go.golden
+++ b/generator/testdata/golden/scaffold/table_name_override/controllers/student_feedback.go.golden
@@ -17,15 +17,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/hypermedia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type FeedbackEntry struct {
-	db storage.Connection
+	feedbackEntries models.FeedbackEntries
 }
 
-func NewFeedbackEntry(db storage.Connection) FeedbackEntry {
-	return FeedbackEntry{db}
+func NewFeedbackEntry(feedbackEntries models.FeedbackEntries) FeedbackEntry {
+	return FeedbackEntry{ feedbackEntries }
 }
 
 func (fe FeedbackEntry) RegisterRoutes(r *router.Router) error {
@@ -114,9 +113,8 @@ func (fe FeedbackEntry) Index(etx *echo.Context) error {
 		}
 	}
 
-	studentFeedbackList, err := models.FeedbackEntry.Paginate(
+	studentFeedbackList, err := fe.feedbackEntries.Paginate(
 		etx.Request().Context(),
-		fe.db.Executor(),
 		page,
 		perPage,
 	)
@@ -124,7 +122,7 @@ func (fe FeedbackEntry) Index(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.InternalError())
 	}
 
-	return hypermedia.RenderPage(etx, views.FeedbackEntryIndex{Items: studentFeedbackList.FeedbackEntry}.Page())
+	return hypermedia.RenderPage(etx, views.FeedbackEntryIndex{Items: studentFeedbackList.FeedbackEntries}.Page())
 }
 
 func (fe FeedbackEntry) Show(etx *echo.Context) error {
@@ -133,7 +131,7 @@ func (fe FeedbackEntry) Show(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	feedbackEntry, err := models.FeedbackEntry.Find(etx.Request().Context(), fe.db.Executor(), feedbackEntryID)
+	feedbackEntry, err := fe.feedbackEntries.Find(etx.Request().Context(), feedbackEntryID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -184,9 +182,8 @@ func (fe FeedbackEntry) Create(etx *echo.Context) error {
 		}(),
 	}
 
-	feedbackEntry, err := models.FeedbackEntry.Create(
+	feedbackEntry, err := fe.feedbackEntries.Create(
 		etx.Request().Context(),
-		fe.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -208,7 +205,7 @@ func (fe FeedbackEntry) Edit(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	feedbackEntry, err := models.FeedbackEntry.Find(etx.Request().Context(), fe.db.Executor(), feedbackEntryID)
+	feedbackEntry, err := fe.feedbackEntries.Find(etx.Request().Context(), feedbackEntryID)
 	if err != nil {
 		return hypermedia.RenderPage(etx, views.NotFound())
 	}
@@ -261,9 +258,8 @@ func (fe FeedbackEntry) Update(etx *echo.Context) error {
 		}(),
 	}
 
-	feedbackEntry, err := models.FeedbackEntry.Update(
+	feedbackEntry, err := fe.feedbackEntries.Update(
 		etx.Request().Context(),
-		fe.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -288,7 +284,7 @@ func (fe FeedbackEntry) Destroy(etx *echo.Context) error {
 		return hypermedia.RenderPage(etx, views.BadRequest())
 	}
 
-	err = models.FeedbackEntry.Destroy(etx.Request().Context(), fe.db.Executor(), feedbackEntryID)
+	err = fe.feedbackEntries.Destroy(etx.Request().Context(), feedbackEntryID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete feedbackEntry: %v", err)); flashErr != nil {
 			return hypermedia.RenderPage(etx, views.InternalError())

--- a/generator/testdata/golden/scaffold/table_name_override/models/feedback_entry.go.golden
+++ b/generator/testdata/golden/scaffold/table_name_override/models/feedback_entry.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type FeedbackEntryEntity struct {
+type FeedbackEntries struct {
+	db queryDB
+}
+
+func NewFeedbackEntries(db storage.Connection) FeedbackEntries {
+	return FeedbackEntries{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (feedbackEntries FeedbackEntries) WithTx(tx storage.Transaction) FeedbackEntries {
+	return FeedbackEntries{db: tx}
+}
+
+type FeedbackEntry struct {
 	bun.BaseModel `bun:"table:student_feedback,alias:student_feedback"`
 	ID            uuid.UUID     `bun:"id,pk,type:uuid"`
 	StudentName   string        `bun:"student_name"`
@@ -25,17 +38,17 @@ type FeedbackEntryEntity struct {
 	UpdatedAt     time.Time     `bun:"updated_at"`
 }
 
-func (fe feedbackEntry) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (FeedbackEntryEntity, error) {
-	var entity FeedbackEntryEntity
-	err := db.NewSelect().
+func (feedbackEntries FeedbackEntries) Find(ctx context.Context, id uuid.UUID) (FeedbackEntry, error) {
+	var entity FeedbackEntry
+	err := feedbackEntries.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return FeedbackEntryEntity{}, ErrNotFound
+			return FeedbackEntry{}, ErrNotFound
 		}
-		return FeedbackEntryEntity{}, err
+		return FeedbackEntry{}, err
 	}
 
 	return entity, nil
@@ -48,8 +61,8 @@ type CreateFeedbackEntryData struct {
 	SubmittedAt sql.NullTime
 }
 
-func (fe feedbackEntry) Create(ctx context.Context, db storage.Executor, data CreateFeedbackEntryData) (FeedbackEntryEntity, error) {
-	entity := FeedbackEntryEntity{
+func (feedbackEntries FeedbackEntries) Create(ctx context.Context, data CreateFeedbackEntryData) (FeedbackEntry, error) {
+	entity := FeedbackEntry{
 		ID:          uuid.New(),
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -60,11 +73,11 @@ func (fe feedbackEntry) Create(ctx context.Context, db storage.Executor, data Cr
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return FeedbackEntryEntity{}, errors.Join(ErrDomainValidation, err)
+		return FeedbackEntry{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return FeedbackEntryEntity{}, err
+	if _, err := feedbackEntries.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return FeedbackEntry{}, err
 	}
 
 	return entity, nil
@@ -78,8 +91,8 @@ type UpdateFeedbackEntryData struct {
 	SubmittedAt sql.NullTime
 }
 
-func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data UpdateFeedbackEntryData) (FeedbackEntryEntity, error) {
-	entity := FeedbackEntryEntity{
+func (feedbackEntries FeedbackEntries) Update(ctx context.Context, data UpdateFeedbackEntryData) (FeedbackEntry, error) {
+	entity := FeedbackEntry{
 		ID:          data.ID,
 		UpdatedAt:   time.Now(),
 		StudentName: data.StudentName,
@@ -89,10 +102,10 @@ func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data Up
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return FeedbackEntryEntity{}, errors.Join(ErrDomainValidation, err)
+		return FeedbackEntry{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := feedbackEntries.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("student_name").
 		Column("feedback").
@@ -104,17 +117,17 @@ func (fe feedbackEntry) Update(ctx context.Context, db storage.Executor, data Up
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return FeedbackEntryEntity{}, ErrNotFound
+			return FeedbackEntry{}, ErrNotFound
 		}
-		return FeedbackEntryEntity{}, err
+		return FeedbackEntry{}, err
 	}
 
 	return entity, nil
 }
 
-func (fe feedbackEntry) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity FeedbackEntryEntity
-	err := db.NewDelete().
+func (feedbackEntries FeedbackEntries) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity FeedbackEntry
+	err := feedbackEntries.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -129,9 +142,9 @@ func (fe feedbackEntry) Destroy(ctx context.Context, db storage.Executor, id uui
 	return nil
 }
 
-func (fe feedbackEntry) All(ctx context.Context, db storage.Executor) ([]FeedbackEntryEntity, error) {
-	var entities []FeedbackEntryEntity
-	if err := db.NewSelect().
+func (feedbackEntries FeedbackEntries) All(ctx context.Context) ([]FeedbackEntry, error) {
+	var entities []FeedbackEntry
+	if err := feedbackEntries.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -141,14 +154,14 @@ func (fe feedbackEntry) All(ctx context.Context, db storage.Executor) ([]Feedbac
 }
 
 type PaginatedFeedbackEntries struct {
-	FeedbackEntries []FeedbackEntryEntity
+	FeedbackEntries []FeedbackEntry
 	TotalCount      int64
 	Page            int64
 	PageSize        int64
 	TotalPages      int64
 }
 
-func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedFeedbackEntries, error) {
+func (feedbackEntries FeedbackEntries) Paginate(ctx context.Context, page, pageSize int64) (PaginatedFeedbackEntries, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -161,14 +174,14 @@ func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page,
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&FeedbackEntryEntity{}).Count(ctx)
+	totalCount, err := feedbackEntries.db.Executor().NewSelect().
+		Model(&FeedbackEntry{}).Count(ctx)
 	if err != nil {
 		return PaginatedFeedbackEntries{}, err
 	}
 
-	entities := make([]FeedbackEntryEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]FeedbackEntry, 0, int(pageSize))
+	if err := feedbackEntries.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -187,8 +200,8 @@ func (fe feedbackEntry) Paginate(ctx context.Context, db storage.Executor, page,
 	}, nil
 }
 
-func (fe feedbackEntry) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateFeedbackEntryData) (FeedbackEntryEntity, error) {
-	entity := FeedbackEntryEntity{
+func (feedbackEntries FeedbackEntries) Upsert(ctx context.Context, id uuid.UUID, data CreateFeedbackEntryData) (FeedbackEntry, error) {
+	entity := FeedbackEntry{
 		ID:          id,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -199,10 +212,10 @@ func (fe feedbackEntry) Upsert(ctx context.Context, db storage.Executor, id uuid
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return FeedbackEntryEntity{}, errors.Join(ErrDomainValidation, err)
+		return FeedbackEntry{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := feedbackEntries.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("student_name = excluded.student_name").
@@ -211,7 +224,7 @@ func (fe feedbackEntry) Upsert(ctx context.Context, db storage.Executor, id uuid
 		Set("submitted_at = excluded.submitted_at").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return FeedbackEntryEntity{}, err
+		return FeedbackEntry{}, err
 	}
 
 	return entity, nil

--- a/generator/testdata/golden/scaffold/table_name_override/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/table_name_override/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token         struct{}
-	user          struct{}
-	feedbackEntry struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token         token
-	User          user
-	FeedbackEntry feedbackEntry
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewFeedbackEntries,
+	),
 )

--- a/generator/testdata/golden/scaffold/table_name_override/views/student_feedback_resource.templ.golden
+++ b/generator/testdata/golden/scaffold/table_name_override/views/student_feedback_resource.templ.golden
@@ -26,7 +26,7 @@ type FeedbackEntryData struct {
 	UpdatedAt time.Time
 }
 
-func newFeedbackEntryData(entity models.FeedbackEntryEntity) FeedbackEntryData {
+func newFeedbackEntryData(entity models.FeedbackEntry) FeedbackEntryData {
 	return FeedbackEntryData{
 		StudentName: entity.StudentName,
 		Feedback: entity.Feedback,
@@ -39,7 +39,7 @@ func newFeedbackEntryData(entity models.FeedbackEntryEntity) FeedbackEntryData {
 
 
 type FeedbackEntryIndex struct {
-	Items []models.FeedbackEntryEntity
+	Items []models.FeedbackEntry
 }
 
 func (fei FeedbackEntryIndex) PageFragment() string {
@@ -108,7 +108,7 @@ templ (fei FeedbackEntryIndex) Page() {
 
 
 type FeedbackEntryShow struct {
-	Item models.FeedbackEntryEntity
+	Item models.FeedbackEntry
 }
 
 func (fes FeedbackEntryShow) PageFragment() string {
@@ -235,7 +235,7 @@ templ (fen FeedbackEntryNew) Page() {
 
 
 type FeedbackEntryEdit struct {
-	Item models.FeedbackEntryEntity
+	Item models.FeedbackEntry
 }
 
 func (fee FeedbackEntryEdit) PageFragment() string {

--- a/generator/testdata/golden/scaffold/vue/controllers/projects.go.golden
+++ b/generator/testdata/golden/scaffold/vue/controllers/projects.go.golden
@@ -15,16 +15,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/mbvlabs/andurel/pkg/inertia"
-	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
 type Projects struct {
-	db       storage.Connection
-	renderer *inertia.Renderer
+	projects models.Projects
+	renderer                                 *inertia.Renderer
 }
 
-func NewProjects(db storage.Connection, renderer *inertia.Renderer) Projects {
-	return Projects{db: db, renderer: renderer}
+func NewProjects(projects models.Projects, renderer *inertia.Renderer) Projects {
+	return Projects{ projects: projects, renderer: renderer }
 }
 
 func (p Projects) RegisterRoutes(r *router.Router) error {
@@ -148,9 +147,8 @@ func (p Projects) Index(etx *echo.Context) error {
 		}
 	}
 
-	projectsList, err := models.Project.Paginate(
+	projectsList, err := p.projects.Paginate(
 		etx.Request().Context(),
-		p.db.Executor(),
 		page,
 		perPage,
 	)
@@ -173,7 +171,7 @@ func (p Projects) Show(etx *echo.Context) error {
 		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
-	project, err := models.Project.Find(etx.Request().Context(), p.db.Executor(), projectID)
+	project, err := p.projects.Find(etx.Request().Context(), projectID)
 	if err != nil {
 		return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
@@ -216,9 +214,8 @@ func (p Projects) Create(etx *echo.Context) error {
 		Status: payload.Status,
 	}
 
-	project, err := models.Project.Create(
+	project, err := p.projects.Create(
 		etx.Request().Context(),
-		p.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -240,7 +237,7 @@ func (p Projects) Edit(etx *echo.Context) error {
 		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
-	project, err := models.Project.Find(etx.Request().Context(), p.db.Executor(), projectID)
+	project, err := p.projects.Find(etx.Request().Context(), projectID)
 	if err != nil {
 		return p.renderer.Page(etx, "Errors/NotFound", inertia.Props{})
 	}
@@ -285,9 +282,8 @@ func (p Projects) Update(etx *echo.Context) error {
 		Status: payload.Status,
 	}
 
-	project, err := models.Project.Update(
+	project, err := p.projects.Update(
 		etx.Request().Context(),
-		p.db.Executor(),
 		data,
 	)
 	if err != nil {
@@ -312,7 +308,7 @@ func (p Projects) Destroy(etx *echo.Context) error {
 		return p.renderer.Page(etx, "Errors/BadRequest", inertia.Props{})
 	}
 
-	err = models.Project.Destroy(etx.Request().Context(), p.db.Executor(), projectID)
+	err = p.projects.Destroy(etx.Request().Context(), projectID)
 	if err != nil {
 		if flashErr := cookies.AddFlash(etx, cookies.FlashError, fmt.Sprintf("Failed to delete project: %v", err)); flashErr != nil {
 			return p.renderer.Page(etx, "Errors/InternalError", inertia.Props{})

--- a/generator/testdata/golden/scaffold/vue/models/model.go.golden
+++ b/generator/testdata/golden/scaffold/vue/models/model.go.golden
@@ -1,13 +1,20 @@
 package models
 
-type (
-	token   struct{}
-	user    struct{}
-	project struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	Token   token
-	User    user
-	Project project
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+		NewProjects,
+	),
 )

--- a/generator/testdata/golden/scaffold/vue/models/project.go.golden
+++ b/generator/testdata/golden/scaffold/vue/models/project.go.golden
@@ -14,7 +14,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type ProjectEntity struct {
+type Projects struct {
+	db queryDB
+}
+
+func NewProjects(db storage.Connection) Projects {
+	return Projects{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (projects Projects) WithTx(tx storage.Transaction) Projects {
+	return Projects{db: tx}
+}
+
+type Project struct {
 	bun.BaseModel `bun:"table:projects,alias:projects"`
 	ID            uuid.UUID `bun:"id,pk,type:uuid"`
 	Title         string    `bun:"title"`
@@ -23,17 +36,17 @@ type ProjectEntity struct {
 	UpdatedAt     time.Time `bun:"updated_at"`
 }
 
-func (p project) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (ProjectEntity, error) {
-	var entity ProjectEntity
-	err := db.NewSelect().
+func (projects Projects) Find(ctx context.Context, id uuid.UUID) (Project, error) {
+	var entity Project
+	err := projects.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ProjectEntity{}, ErrNotFound
+			return Project{}, ErrNotFound
 		}
-		return ProjectEntity{}, err
+		return Project{}, err
 	}
 
 	return entity, nil
@@ -44,8 +57,8 @@ type CreateProjectData struct {
 	Status string
 }
 
-func (p project) Create(ctx context.Context, db storage.Executor, data CreateProjectData) (ProjectEntity, error) {
-	entity := ProjectEntity{
+func (projects Projects) Create(ctx context.Context, data CreateProjectData) (Project, error) {
+	entity := Project{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -54,11 +67,11 @@ func (p project) Create(ctx context.Context, db storage.Executor, data CreatePro
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProjectEntity{}, errors.Join(ErrDomainValidation, err)
+		return Project{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return ProjectEntity{}, err
+	if _, err := projects.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Project{}, err
 	}
 
 	return entity, nil
@@ -70,8 +83,8 @@ type UpdateProjectData struct {
 	Status string
 }
 
-func (p project) Update(ctx context.Context, db storage.Executor, data UpdateProjectData) (ProjectEntity, error) {
-	entity := ProjectEntity{
+func (projects Projects) Update(ctx context.Context, data UpdateProjectData) (Project, error) {
+	entity := Project{
 		ID:        data.ID,
 		UpdatedAt: time.Now(),
 		Title:     data.Title,
@@ -79,10 +92,10 @@ func (p project) Update(ctx context.Context, db storage.Executor, data UpdatePro
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProjectEntity{}, errors.Join(ErrDomainValidation, err)
+		return Project{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err := db.NewUpdate().
+	err := projects.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("title").
 		Column("status").
@@ -92,17 +105,17 @@ func (p project) Update(ctx context.Context, db storage.Executor, data UpdatePro
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ProjectEntity{}, ErrNotFound
+			return Project{}, ErrNotFound
 		}
-		return ProjectEntity{}, err
+		return Project{}, err
 	}
 
 	return entity, nil
 }
 
-func (p project) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	var entity ProjectEntity
-	err := db.NewDelete().
+func (projects Projects) Destroy(ctx context.Context, id uuid.UUID) error {
+	var entity Project
+	err := projects.db.Executor().NewDelete().
 		Model(&entity).
 		Where("id = ?", id).
 		Returning("*").
@@ -117,9 +130,9 @@ func (p project) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID)
 	return nil
 }
 
-func (p project) All(ctx context.Context, db storage.Executor) ([]ProjectEntity, error) {
-	var entities []ProjectEntity
-	if err := db.NewSelect().
+func (projects Projects) All(ctx context.Context) ([]Project, error) {
+	var entities []Project
+	if err := projects.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -129,14 +142,14 @@ func (p project) All(ctx context.Context, db storage.Executor) ([]ProjectEntity,
 }
 
 type PaginatedProjects struct {
-	Projects   []ProjectEntity
+	Projects   []Project
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (p project) Paginate(ctx context.Context, db storage.Executor, page, pageSize int64) (PaginatedProjects, error) {
+func (projects Projects) Paginate(ctx context.Context, page, pageSize int64) (PaginatedProjects, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -149,14 +162,14 @@ func (p project) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&ProjectEntity{}).Count(ctx)
+	totalCount, err := projects.db.Executor().NewSelect().
+		Model(&Project{}).Count(ctx)
 	if err != nil {
 		return PaginatedProjects{}, err
 	}
 
-	entities := make([]ProjectEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Project, 0, int(pageSize))
+	if err := projects.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).
@@ -175,8 +188,8 @@ func (p project) Paginate(ctx context.Context, db storage.Executor, page, pageSi
 	}, nil
 }
 
-func (p project) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, data CreateProjectData) (ProjectEntity, error) {
-	entity := ProjectEntity{
+func (projects Projects) Upsert(ctx context.Context, id uuid.UUID, data CreateProjectData) (Project, error) {
+	entity := Project{
 		ID:        id,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -185,17 +198,17 @@ func (p project) Upsert(ctx context.Context, db storage.Executor, id uuid.UUID, 
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return ProjectEntity{}, errors.Join(ErrDomainValidation, err)
+		return Project{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if err := db.NewInsert().
+	if err := projects.db.Executor().NewInsert().
 		Model(&entity).
 		On("CONFLICT (id) DO UPDATE").
 		Set("title = excluded.title").
 		Set("status = excluded.status").
 		Returning("*").
 		Scan(ctx); err != nil {
-		return ProjectEntity{}, err
+		return Project{}, err
 	}
 
 	return entity, nil

--- a/generator/views/generator.go
+++ b/generator/views/generator.go
@@ -100,10 +100,14 @@ func (g *Generator) Build(cat *catalog.Catalog, config Config) (*GeneratedView, 
 	if modelPluralName == "" {
 		modelPluralName = config.PluralName
 	}
+	entityName := config.EntityName
+	if entityName == "" {
+		entityName = modelName
+	}
 	view := &GeneratedView{
 		ResourceName:    config.ResourceName,
 		ModelName:       modelName,
-		EntityName:      config.EntityName,
+		EntityName:      entityName,
 		PluralName:      config.PluralName,
 		ModelPluralName: modelPluralName,
 		Namespace:       config.Namespace,
@@ -867,7 +871,7 @@ func (g *Generator) GenerateViewWithControllerActionsForModel(
 	view, err := g.Build(cat, Config{
 		ResourceName:    resourceName,
 		ModelName:       modelName,
-		EntityName:      modelName + "Entity",
+		EntityName:      modelName,
 		PluralName:      pluralName,
 		ModelPluralName: modelPluralName,
 		TableName:       tableName,

--- a/generator/views/helpers_test.go
+++ b/generator/views/helpers_test.go
@@ -69,7 +69,7 @@ func TestViewDataNullTypeHelpers(t *testing.T) {
 	view := &GeneratedView{
 		NamespacePascal: "Admin",
 		ResourceName:    "Product",
-		EntityName:      "ProductEntity",
+		EntityName:      "Product",
 		Fields:          fields[:2],
 	}
 	definition := viewDataDefinition(view)

--- a/layout/generated_application_templates_test.go
+++ b/layout/generated_application_templates_test.go
@@ -70,29 +70,32 @@ func TestGeneratedAPIControllerLivesInAPIPackage(t *testing.T) {
 func TestGeneratedUserAndTokenModelTemplates(t *testing.T) {
 	user := readGeneratedApplicationTemplate(t, "models_user.tmpl")
 	for _, want := range []string{
+		"type Users struct",
+		"func NewUsers(db storage.Connection) Users",
+		"func (users Users) WithTx(tx storage.Transaction) Users",
 		"CreatedAt:        current.CreatedAt",
-		"db.NewDelete()",
+		"users.db.Executor().NewDelete()",
 		"Column(\"email\")",
 		"Column(\"email_validated_at\")",
 		"Column(\"password\")",
 		"Column(\"is_admin\")",
 		"Column(\"updated_at\")",
 		"Returning(\"*\")",
-		"Model(&UserEntity{}).Count(ctx)",
+		"Model(&User{}).Count(ctx)",
 	} {
 		if !strings.Contains(user, want) {
 			t.Errorf("models_user.tmpl missing %q", want)
 		}
 	}
-	if strings.Contains(user, "Model(&UserEntity{}).Scan(ctx, &totalCount)") {
+	if strings.Contains(user, "Model(&User{}).Scan(ctx, &totalCount)") {
 		t.Error("models_user.tmpl still scans a model into the pagination count")
 	}
 
 	token := readGeneratedApplicationTemplate(t, "models_token.tmpl")
-	if !strings.Contains(token, "Model(&TokenEntity{}).Count(ctx)") {
+	if !strings.Contains(token, "Model(&Token{}).Count(ctx)") {
 		t.Error("models_token.tmpl does not use Bun Count")
 	}
-	if strings.Contains(token, "Model(&TokenEntity{}).Scan(ctx, &totalCount)") {
+	if strings.Contains(token, "Model(&Token{}).Scan(ctx, &totalCount)") {
 		t.Error("models_token.tmpl still scans a model into the pagination count")
 	}
 }
@@ -194,7 +197,7 @@ func TestGeneratedAuthenticationTemplates(t *testing.T) {
 	}
 
 	identity := readGeneratedApplicationTemplate(t, "services_identity.tmpl")
-	for _, want := range []string{"AppIdentityProvider", "TokenProvider", "AuthProvider", "GetTokenSigningKey()", "GetPepper()", "GetPreviousPeppers()", "baseURL", "defaultSenderSignature"} {
+	for _, want := range []string{"AppIdentityProvider", "TokenProvider", "AuthProvider", "GetTokenSigningKey()", "GetPepper()", "GetPreviousPeppers()", "baseURL", "defaultSenderSignature", "users                  models.Users", "tokens                 models.Tokens"} {
 		if !strings.Contains(identity, want) {
 			t.Errorf("services_identity.tmpl missing %q", want)
 		}
@@ -207,7 +210,7 @@ func TestGeneratedAuthenticationTemplates(t *testing.T) {
 	for _, want := range []string{
 		"verifyPasswordWithPeppers",
 		"models.HashPassword(data.Password, i.pepper)",
-		"models.User.Update(ctx, i.db.Executor()",
+		"i.users.Update(ctx, models.UpdateUserData{",
 		"persist password rehash",
 	} {
 		if !strings.Contains(authentication, want) {
@@ -247,6 +250,12 @@ func TestGeneratedDatabaseTemplatesUseStandaloneStorage(t *testing.T) {
 	}
 	if !strings.Contains(mainTemplate, "fx.Annotate(newDatabase, fx.As(new(storage.Connection)), fx.As(fx.Self()))") {
 		t.Error("cmd_app_main.tmpl does not provide *storage.Postgres as storage.Connection")
+	}
+	if !strings.Contains(mainTemplate, `"{{.ModuleName}}/models"`) {
+		t.Error("cmd_app_main.tmpl does not import models")
+	}
+	if !strings.Contains(mainTemplate, "models.Module,") {
+		t.Error("cmd_app_main.tmpl does not include models.Module")
 	}
 	if strings.Contains(mainTemplate, "fx.As(fx.Self(), new(storage.Connection))") {
 		t.Error("cmd_app_main.tmpl maps fx.As targets positionally; Self and Connection must be separate As annotations")

--- a/layout/templates/cmd_app_main.tmpl
+++ b/layout/templates/cmd_app_main.tmpl
@@ -15,6 +15,7 @@ import (
 	"{{.ModuleName}}/config"
 	"{{.ModuleName}}/controllers"
 	"{{.ModuleName}}/email"
+	"{{.ModuleName}}/models"
 	"{{.ModuleName}}/router"
 	"{{.ModuleName}}/services"
 	"{{.ModuleName}}/telemetry"
@@ -62,6 +63,7 @@ func main() {
 		config.Module,
 		databaseModule,
 		queueInsertModule,
+		models.Module,
 {{- if .Inertia}}
 		inertiaModule,
 {{- end}}

--- a/layout/templates/models_factories_token.tmpl
+++ b/layout/templates/models_factories_token.tmpl
@@ -13,9 +13,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TokenFactory wraps models.TokenEntity for testing
+// TokenFactory wraps models.Token for testing
 type TokenFactory struct {
-	models.TokenEntity
+	models.Token
 }
 
 // TokenOption is a functional option for configuring a TokenFactory
@@ -23,9 +23,9 @@ type TokenOption func(*TokenFactory)
 
 // BuildToken creates an in-memory Token with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateToken.
-func BuildToken(opts ...TokenOption) models.TokenEntity {
+func BuildToken(opts ...TokenOption) models.Token {
 	f := &TokenFactory{
-		TokenEntity: models.TokenEntity{
+		Token: models.Token{
 			Scope:     "default",
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 			Hash:      "test-hash",
@@ -37,7 +37,7 @@ func BuildToken(opts ...TokenOption) models.TokenEntity {
 		opt(f)
 	}
 
-	return f.TokenEntity
+	return f.Token
 }
 
 // CreateToken creates and persists a Token to the database.
@@ -46,10 +46,10 @@ func CreateToken(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...TokenOption,
-) (models.TokenEntity, error) {
+) (models.Token, error) {
 	built := BuildToken(opts...)
 
-	entity := models.TokenEntity{
+	entity := models.Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -60,7 +60,7 @@ func CreateToken(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.TokenEntity{}, err
+		return models.Token{}, err
 	}
 
 	return entity, nil
@@ -72,8 +72,8 @@ func CreateTokens(
 	exec storage.Executor,
 	count int,
 	opts ...TokenOption,
-) ([]models.TokenEntity, error) {
-	tokens := make([]models.TokenEntity, 0, count)
+) ([]models.Token, error) {
+	tokens := make([]models.Token, 0, count)
 
 	for i := range count {
 		token, err := CreateToken(ctx, exec, opts...)

--- a/layout/templates/models_factories_user.tmpl
+++ b/layout/templates/models_factories_user.tmpl
@@ -14,9 +14,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// UserFactory wraps models.UserEntity for testing
+// UserFactory wraps models.User for testing
 type UserFactory struct {
-	models.UserEntity
+	models.User
 }
 
 // UserOption is a functional option for configuring a UserFactory
@@ -24,9 +24,9 @@ type UserOption func(*UserFactory)
 
 // BuildUser creates an in-memory User with default test values.
 // Auto-managed fields (ID, timestamps) are left at zero and set by CreateUser.
-func BuildUser(opts ...UserOption) models.UserEntity {
+func BuildUser(opts ...UserOption) models.User {
 	f := &UserFactory{
-		UserEntity: models.UserEntity{
+		User: models.User{
 			Email:            faker.Email(),
 			EmailValidatedAt: sql.NullTime{},
 			Password:         defaultPassword(),
@@ -38,7 +38,7 @@ func BuildUser(opts ...UserOption) models.UserEntity {
 		opt(f)
 	}
 
-	return f.UserEntity
+	return f.User
 }
 
 // CreateUser creates and persists a User to the database.
@@ -47,10 +47,10 @@ func CreateUser(
 	ctx context.Context,
 	exec storage.Executor,
 	opts ...UserOption,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	built := BuildUser(opts...)
 
-	entity := models.UserEntity{
+	entity := models.User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -61,7 +61,7 @@ func CreateUser(
 	}
 
 	if err := exec.NewInsert().Model(&entity).Returning("*").Scan(ctx); err != nil {
-		return models.UserEntity{}, err
+		return models.User{}, err
 	}
 
 	return entity, nil
@@ -73,8 +73,8 @@ func CreateUsers(
 	exec storage.Executor,
 	count int,
 	opts ...UserOption,
-) ([]models.UserEntity, error) {
-	users := make([]models.UserEntity, 0, count)
+) ([]models.User, error) {
+	users := make([]models.User, 0, count)
 
 	for i := range count {
 		user, err := CreateUser(ctx, exec, opts...)

--- a/layout/templates/models_model.tmpl
+++ b/layout/templates/models_model.tmpl
@@ -1,12 +1,21 @@
 // Package models contains data models and validation logic.
 package models
 
-type (
-	user  struct{}
-	token struct{}
+import (
+	"github.com/mbvlabs/andurel/pkg/storage"
+
+	"go.uber.org/fx"
 )
 
-var (
-	User  user
-	Token token
+// queryDB is satisfied by storage.Connection and storage.Transaction.
+type queryDB interface {
+	Executor() storage.Executor
+}
+
+var Module = fx.Module(
+	"models",
+	fx.Provide(
+		NewUsers,
+		NewTokens,
+	),
 )

--- a/layout/templates/models_token.tmpl
+++ b/layout/templates/models_token.tmpl
@@ -19,7 +19,20 @@ import (
 	"github.com/uptrace/bun"
 )
 
-type TokenEntity struct {
+type Tokens struct {
+	db queryDB
+}
+
+func NewTokens(db storage.Connection) Tokens {
+	return Tokens{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (tokens Tokens) WithTx(tx storage.Transaction) Tokens {
+	return Tokens{db: tx}
+}
+
+type Token struct {
 	bun.BaseModel `bun:"table:tokens,alias:tokens"`
 	ID            uuid.UUID       `bun:"id,pk,type:uuid"`
 	CreatedAt     time.Time       `bun:"created_at"`
@@ -30,7 +43,7 @@ type TokenEntity struct {
 	MetaData      json.RawMessage `bun:"meta_data,type:jsonb"`
 }
 
-func (t TokenEntity) IsValid(token, secret string) bool {
+func (t Token) IsValid(token, secret string) bool {
 	expected := HashForStorage(token, secret)
 
 	isEqual := hmac.Equal([]byte(expected), []byte(t.Hash))
@@ -69,44 +82,43 @@ func HashForStorage(plain, secret string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 
-func (t token) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (TokenEntity, error) {
-	var entity TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) Find(ctx context.Context, id uuid.UUID) (Token, error) {
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) FindByScopeAndHash(
+func (tokens Tokens) FindByScopeAndHash(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	plainToken string,
-) (TokenEntity, error) {
+) (Token, error) {
 	hash := HashForStorage(plainToken, secret)
 
-	var entity TokenEntity
-	err := db.NewSelect().
+	var entity Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entity).
 		Where("scope = ?", scope).
 		Where("hash = ?", hash).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return TokenEntity{}, ErrNotFound
+			return Token{}, ErrNotFound
 		}
 
-		return TokenEntity{}, err
+		return Token{}, err
 	}
 
 	return entity, nil
@@ -119,7 +131,7 @@ type createTokenData struct {
 	MetaData  json.RawMessage
 }
 
-func (t *TokenEntity) Validate() error {
+func (t *Token) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("scope", t.Scope)
 	b.Required("expires_at", t.ExpiresAt)
@@ -129,12 +141,11 @@ func (t *TokenEntity) Validate() error {
 	return b.Err()
 }
 
-func (t token) createToken(
+func (tokens Tokens) createToken(
 	ctx context.Context,
-	db storage.Executor,
 	data createTokenData,
-) (TokenEntity, error) {
-	entity := TokenEntity{
+) (Token, error) {
+	entity := Token{
 		ID:        uuid.New(),
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -145,19 +156,18 @@ func (t token) createToken(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return TokenEntity{}, errors.Join(ErrDomainValidation, err)
+		return Token{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	if _, err := db.NewInsert().Model(&entity).Exec(ctx); err != nil {
-		return TokenEntity{}, err
+	if _, err := tokens.db.Executor().NewInsert().Model(&entity).Exec(ctx); err != nil {
+		return Token{}, err
 	}
 
 	return entity, nil
 }
 
-func (t token) CreateCode(
+func (tokens Tokens) CreateCode(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -168,7 +178,7 @@ func (t token) CreateCode(
 		return "", err
 	}
 
-	if _, err := t.createToken(ctx, db, createTokenData{
+	if _, err := tokens.createToken(ctx, createTokenData{
 		Scope:     scope,
 		ExpiresAt: expiresAt,
 		Hash:      HashForStorage(tkn, secret),
@@ -180,9 +190,8 @@ func (t token) CreateCode(
 	return tkn, nil
 }
 
-func (t token) Create(
+func (tokens Tokens) Create(
 	ctx context.Context,
-	db storage.Executor,
 	secret string,
 	scope string,
 	expiresAt time.Time,
@@ -193,7 +202,7 @@ func (t token) Create(
 		return "", err
 	}
 
-	if _, err := t.createToken(ctx, db, createTokenData{
+	if _, err := tokens.createToken(ctx, createTokenData{
 		Scope:     scope,
 		ExpiresAt: expiresAt,
 		Hash:      HashForStorage(tkn, secret),
@@ -205,17 +214,17 @@ func (t token) Create(
 	return tkn, nil
 }
 
-func (t token) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*TokenEntity)(nil)).
+func (tokens Tokens) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := tokens.db.Executor().NewDelete().
+		Model((*Token)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 	return err
 }
 
-func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, error) {
-	var entities []TokenEntity
-	err := db.NewSelect().
+func (tokens Tokens) All(ctx context.Context) ([]Token, error) {
+	var entities []Token
+	err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -226,16 +235,15 @@ func (t token) All(ctx context.Context, db storage.Executor) ([]TokenEntity, err
 }
 
 type PaginatedTokens struct {
-	Tokens     []TokenEntity
+	Tokens     []Token
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (t token) Paginate(
+func (tokens Tokens) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedTokens, error) {
 	if page < 1 {
@@ -250,14 +258,14 @@ func (t token) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&TokenEntity{}).Count(ctx)
+	totalCount, err := tokens.db.Executor().NewSelect().
+		Model(&Token{}).Count(ctx)
 	if err != nil {
 		return PaginatedTokens{}, err
 	}
 
-	entities := make([]TokenEntity, 0, int(pageSize))
-	if err := db.NewSelect().
+	entities := make([]Token, 0, int(pageSize))
+	if err := tokens.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).

--- a/layout/templates/models_user.tmpl
+++ b/layout/templates/models_user.tmpl
@@ -20,7 +20,20 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type UserEntity struct {
+type Users struct {
+	db queryDB
+}
+
+func NewUsers(db storage.Connection) Users {
+	return Users{db: db}
+}
+
+// WithTx returns a copy that runs queries inside tx.
+func (users Users) WithTx(tx storage.Transaction) Users {
+	return Users{db: tx}
+}
+
+type User struct {
 	bun.BaseModel    `bun:"table:users,alias:user"`
 	ID               uuid.UUID    `bun:"id,pk,type:uuid"`
 	CreatedAt        time.Time    `bun:"created_at"`
@@ -31,7 +44,7 @@ type UserEntity struct {
 	IsAdmin          bool         `bun:"is_admin"`
 }
 
-func (u *UserEntity) Validate() error {
+func (u *User) Validate() error {
 	b := validation.NewBuilder()
 	b.Required("email", u.Email)
 	b.MaxLen("email", u.Email, 255)
@@ -39,11 +52,11 @@ func (u *UserEntity) Validate() error {
 	return b.Err()
 }
 
-func (u *UserEntity) HasValidatedEmail() bool {
+func (u *User) HasValidatedEmail() bool {
 	return u.EmailValidatedAt.Valid
 }
 
-func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error) {
+func (u *User) ValidPassword(providedPassword, pepper string) (bool, error) {
 	parts := strings.Split(string(u.Password), ":")
 	if len(parts) != 2 {
 		return false, fmt.Errorf("invalid stored password format")
@@ -71,39 +84,38 @@ func (u *UserEntity) ValidPassword(providedPassword, pepper string) (bool, error
 	return subtle.ConstantTimeCompare(newHash, expectedHash) == 1, nil
 }
 
-func (u user) Find(ctx context.Context, db storage.Executor, id uuid.UUID) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+func (users Users) Find(ctx context.Context, id uuid.UUID) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("id = ?", id).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) FindByEmail(
+func (users Users) FindByEmail(
 	ctx context.Context,
-	db storage.Executor,
 	email string,
-) (UserEntity, error) {
-	var entity UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var entity User
+	err := users.db.Executor().NewSelect().
 		Model(&entity).
 		Where("email = ?", strings.ToLower(email)).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -119,18 +131,17 @@ type CreateUserData struct {
 	PasswordPair PasswordPair
 }
 
-func (u user) Create(
+func (users Users) Create(
 	ctx context.Context,
-	db storage.Executor,
 	pepper string,
 	data CreateUserData,
-) (UserEntity, error) {
+) (User, error) {
 	hashedPassword, err := HashPassword(data.PasswordPair.Password, pepper)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               uuid.New(),
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -141,12 +152,12 @@ func (u user) Create(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	_, err = db.NewInsert().Model(&entity).Exec(ctx)
+	_, err = users.db.Executor().NewInsert().Model(&entity).Exec(ctx)
 	if err != nil {
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
@@ -160,22 +171,21 @@ type UpdateUserData struct {
 	IsAdmin          bool
 }
 
-func (u user) Update(
+func (users Users) Update(
 	ctx context.Context,
-	db storage.Executor,
 	data UpdateUserData,
-) (UserEntity, error) {
-	var current UserEntity
-	err := db.NewSelect().
+) (User, error) {
+	var current User
+	err := users.db.Executor().NewSelect().
 		Model(&current).
 		Where("id = ?", data.ID).
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	email := strings.ToLower(data.Email)
@@ -193,7 +203,7 @@ func (u user) Update(
 		password = current.Password
 	}
 
-	entity := UserEntity{
+	entity := User{
 		ID:               data.ID,
 		CreatedAt:        current.CreatedAt,
 		UpdatedAt:        time.Now(),
@@ -204,10 +214,10 @@ func (u user) Update(
 	}
 
 	if err := validation.Validate(&entity); err != nil {
-		return UserEntity{}, errors.Join(ErrDomainValidation, err)
+		return User{}, errors.Join(ErrDomainValidation, err)
 	}
 
-	err = db.NewUpdate().
+	err = users.db.Executor().NewUpdate().
 		Model(&entity).
 		Column("email").
 		Column("email_validated_at").
@@ -219,27 +229,27 @@ func (u user) Update(
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return UserEntity{}, ErrNotFound
+			return User{}, ErrNotFound
 		}
 
-		return UserEntity{}, err
+		return User{}, err
 	}
 
 	return entity, nil
 }
 
-func (u user) Destroy(ctx context.Context, db storage.Executor, id uuid.UUID) error {
-	_, err := db.NewDelete().
-		Model((*UserEntity)(nil)).
+func (users Users) Destroy(ctx context.Context, id uuid.UUID) error {
+	_, err := users.db.Executor().NewDelete().
+		Model((*User)(nil)).
 		Where("id = ?", id).
 		Exec(ctx)
 
 	return err
 }
 
-func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error) {
-	var entities []UserEntity
-	err := db.NewSelect().
+func (users Users) All(ctx context.Context) ([]User, error) {
+	var entities []User
+	err := users.db.Executor().NewSelect().
 		Model(&entities).
 		Scan(ctx)
 	if err != nil {
@@ -250,16 +260,15 @@ func (u user) All(ctx context.Context, db storage.Executor) ([]UserEntity, error
 }
 
 type PaginatedUsers struct {
-	Users      []UserEntity
+	Users      []User
 	TotalCount int64
 	Page       int64
 	PageSize   int64
 	TotalPages int64
 }
 
-func (u user) Paginate(
+func (users Users) Paginate(
 	ctx context.Context,
-	db storage.Executor,
 	page, pageSize int64,
 ) (PaginatedUsers, error) {
 	if page < 1 {
@@ -274,14 +283,14 @@ func (u user) Paginate(
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := db.NewSelect().
-		Model(&UserEntity{}).Count(ctx)
+	totalCount, err := users.db.Executor().NewSelect().
+		Model(&User{}).Count(ctx)
 	if err != nil {
 		return PaginatedUsers{}, err
 	}
 
-	entities := make([]UserEntity, 0, int(pageSize))
-	err = db.NewSelect().
+	entities := make([]User, 0, int(pageSize))
+	err = users.db.Executor().NewSelect().
 		Model(&entities).
 		Limit(int(pageSize)).
 		Offset(int(offset)).

--- a/layout/templates/router_cookies_cookies.tmpl
+++ b/layout/templates/router_cookies_cookies.tmpl
@@ -42,7 +42,7 @@ type App struct {
 {{- if not (len .Blueprint.Cookies.SortedAppFields)}}
 func (s *Session) CreateAppSession(c *echo.Context) error {
 {{- else}}
-func (s *Session) CreateAppSession(c *echo.Context, user models.UserEntity) error {
+func (s *Session) CreateAppSession(c *echo.Context, user models.User) error {
 {{- end}}
 	sess, err := getSession(s.appSessionName, c)
 	if err != nil {

--- a/layout/templates/services_authentication.tmpl
+++ b/layout/templates/services_authentication.tmpl
@@ -25,23 +25,23 @@ type LoginData struct {
 func (i Identity) AuthenticateUser(
 	ctx context.Context,
 	data LoginData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("email", data.Email)
 	b.Required("password", data.Password)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
-	user, err := models.User.FindByEmail(ctx, i.db.Executor(), data.Email)
+	user, err := i.users.FindByEmail(ctx, data.Email)
 
 	if err != nil {
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidCredentials
+			return models.User{}, ErrInvalidCredentials
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find user by email: %w", err)
+		return models.User{}, fmt.Errorf("find user by email: %w", err)
 
 	}
 
@@ -54,22 +54,22 @@ func (i Identity) AuthenticateUser(
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("validate password: %w", err)
+		return models.User{}, fmt.Errorf("validate password: %w", err)
 
 	}
 
 	if !validPassword {
 
-		return models.UserEntity{}, ErrInvalidCredentials
+		return models.User{}, ErrInvalidCredentials
 	}
 
 	if needsRehash {
 		hashedPassword, err := models.HashPassword(data.Password, i.pepper)
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("rehash password with current pepper: %w", err)
+			return models.User{}, fmt.Errorf("rehash password with current pepper: %w", err)
 		}
 
-		user, err = models.User.Update(ctx, i.db.Executor(), models.UpdateUserData{
+		user, err = i.users.Update(ctx, models.UpdateUserData{
 			ID:               user.ID,
 			Email:            user.Email,
 			EmailValidatedAt: user.EmailValidatedAt,
@@ -77,19 +77,19 @@ func (i Identity) AuthenticateUser(
 			IsAdmin:          user.IsAdmin,
 		})
 		if err != nil {
-			return models.UserEntity{}, fmt.Errorf("persist password rehash: %w", err)
+			return models.User{}, fmt.Errorf("persist password rehash: %w", err)
 		}
 	}
 
 	if !user.HasValidatedEmail() {
-		return models.UserEntity{}, ErrEmailNotVerified
+		return models.User{}, ErrEmailNotVerified
 	}
 
 	return user, nil
 }
 
 func verifyPasswordWithPeppers(
-	user models.UserEntity,
+	user models.User,
 	providedPassword string,
 	currentPepper string,
 	previousPeppers []string,

--- a/layout/templates/services_authentication_test.tmpl
+++ b/layout/templates/services_authentication_test.tmpl
@@ -50,7 +50,7 @@ func TestVerifyPasswordWithPeppers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("HashPassword: %v", err)
 			}
-			user := models.UserEntity{Password: []byte(hash)}
+			user := models.User{Password: []byte(hash)}
 
 			valid, needsRehash, err := verifyPasswordWithPeppers(
 				user,

--- a/layout/templates/services_identity.tmpl
+++ b/layout/templates/services_identity.tmpl
@@ -3,6 +3,8 @@ package services
 import (
 	"strings"
 
+	"{{.ModuleName}}/models"
+
 	"github.com/mbvlabs/andurel/pkg/storage"
 )
 
@@ -23,6 +25,8 @@ type AppIdentityProvider interface {
 
 type Identity struct {
 	db                     storage.Connection
+	users                  models.Users
+	tokens                 models.Tokens
 	insertOnly             storage.InsertQueue
 	pepper                 string
 	previousPeppers        []string
@@ -33,6 +37,8 @@ type Identity struct {
 
 func NewIdentity(
 	db storage.Connection,
+	users models.Users,
+	tokens models.Tokens,
 	insertOnly storage.InsertQueue,
 	appCfg AppIdentityProvider,
 	authCfg AuthProvider,
@@ -46,6 +52,8 @@ func NewIdentity(
 
 	return Identity{
 		db:                     db,
+		users:                  users,
+		tokens:                 tokens,
 		insertOnly:             insertOnly,
 		pepper:                 authCfg.GetPepper(),
 		previousPeppers:        validPeppers,

--- a/layout/templates/services_registration.tmpl
+++ b/layout/templates/services_registration.tmpl
@@ -51,7 +51,10 @@ func (i Identity) RegisterUser(
 
 	}
 
-	user, err := models.User.Create(ctx, tx.Executor(), i.pepper, models.CreateUserData{
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.Create(ctx, i.pepper, models.CreateUserData{
 
 		Email: data.Email,
 		PasswordPair: models.PasswordPair{
@@ -76,9 +79,8 @@ func (i Identity) RegisterUser(
 
 	}
 
-	code, err := models.Token.CreateCode(
+	code, err := tokens.CreateCode(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -146,24 +148,26 @@ type VerifyEmailData struct {
 func (i Identity) VerifyEmail(
 	ctx context.Context,
 	data VerifyEmailData,
-) (models.UserEntity, error) {
+) (models.User, error) {
 	b := validation.NewBuilder()
 	b.Required("code", data.Code)
 	if !b.Errors().Empty() {
-		return models.UserEntity{}, b.Errors()
+		return models.User{}, b.Errors()
 	}
 
 	tx, err := i.db.BeginTransaction(ctx, nil)
 
 	if err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("begin email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("begin email verification transaction: %w", err)
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userEmailVerification,
@@ -173,24 +177,24 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrInvalidVerificationCode
+			return models.User{}, ErrInvalidVerificationCode
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find email verification token: %w", err)
+		return models.User{}, fmt.Errorf("find email verification token: %w", err)
 
 	}
 
 	if !token.IsValid(data.Code, i.tokenSigningKey) {
 
 		_ = tx.Rollback()
-		return models.UserEntity{}, ErrExpiredVerificationCode
+		return models.User{}, ErrExpiredVerificationCode
 	}
 
 	var meta map[string]string
 	if err := json.Unmarshal(token.MetaData, &meta); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
+		return models.User{}, fmt.Errorf("unmarshal verification token metadata: %v", err)
 
 	}
 
@@ -198,24 +202,24 @@ func (i Identity) VerifyEmail(
 	if !ok {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, errors.New("verification token metadata missing email")
+		return models.User{}, errors.New("verification token metadata missing email")
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("find verification user: %w", err)
+		return models.User{}, fmt.Errorf("find verification user: %w", err)
 
 	}
 
 	now := time.Now()
-	user, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	user, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: sql.NullTime{Time: now, Valid: true},
@@ -226,23 +230,23 @@ func (i Identity) VerifyEmail(
 		_ = tx.Rollback()
 
 		if errors.Is(err, models.ErrNotFound) {
-			return models.UserEntity{}, ErrUserNotFound
+			return models.User{}, ErrUserNotFound
 		}
 
-		return models.UserEntity{}, fmt.Errorf("mark user email verified: %w", err)
+		return models.User{}, fmt.Errorf("mark user email verified: %w", err)
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
-		return models.UserEntity{}, fmt.Errorf("destroy email verification token: %w", err)
+		return models.User{}, fmt.Errorf("destroy email verification token: %w", err)
 
 	}
 
 	if err := tx.Commit(); err != nil {
 
-		return models.UserEntity{}, fmt.Errorf("commit email verification transaction: %w", err)
+		return models.User{}, fmt.Errorf("commit email verification transaction: %w", err)
 	}
 
 	return user, nil

--- a/layout/templates/services_reset_password.tmpl
+++ b/layout/templates/services_reset_password.tmpl
@@ -47,7 +47,10 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), data.Email)
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	user, err := users.FindByEmail(ctx, data.Email)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -69,9 +72,8 @@ func (i Identity) RequestResetPassword(
 
 	}
 
-	token, err := models.Token.Create(
+	token, err := tokens.Create(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -157,9 +159,11 @@ func (i Identity) ResetPassword(
 
 	}
 
-	token, err := models.Token.FindByScopeAndHash(
+	users := i.users.WithTx(tx)
+	tokens := i.tokens.WithTx(tx)
+
+	token, err := tokens.FindByScopeAndHash(
 		ctx,
-		tx.Executor(),
 		i.tokenSigningKey,
 
 		userResetPassword,
@@ -198,7 +202,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	user, err := models.User.FindByEmail(ctx, tx.Executor(), emailAddr)
+	user, err := users.FindByEmail(ctx, emailAddr)
 	if err != nil {
 		_ = tx.Rollback()
 
@@ -219,7 +223,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	_, err = models.User.Update(ctx, tx.Executor(), models.UpdateUserData{
+	_, err = users.Update(ctx, models.UpdateUserData{
 		ID:               user.ID,
 		Email:            user.Email,
 		EmailValidatedAt: user.EmailValidatedAt,
@@ -237,7 +241,7 @@ func (i Identity) ResetPassword(
 
 	}
 
-	if err := models.Token.Destroy(ctx, tx.Executor(), token.ID); err != nil {
+	if err := tokens.Destroy(ctx, token.ID); err != nil {
 		_ = tx.Rollback()
 
 		return fmt.Errorf("destroy password reset token: %w", err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactor generated applications and the generator so models are Fx-provided plural services that hold `storage.Connection`, instead of singleton namespace objects whose methods take `storage.Executor` on every call.

**Target pattern:**
- `models.Module` with `fx.Provide(NewUsers, NewTokens, …)`
- `type Users struct { db queryDB }` + `func NewUsers(db storage.Connection) Users`
- Entity types drop the `*Entity` suffix (`User`, `Token`, `Widget`)
- Controllers/services receive `models.Users` (etc.) via Fx

**Transaction pattern:** unexported `queryDB` interface (`Executor() storage.Executor`) satisfied by both `storage.Connection` and `storage.Transaction`. Each service has `WithTx(tx storage.Transaction)` returning a copy that runs queries inside the transaction. Registration and password-reset flows keep explicit Begin/Commit/Rollback and call `i.users.WithTx(tx)`.

## Files / templates

- Scaffold: `layout/templates/models_{model,user,token}.tmpl`, factories, identity/auth/registration/reset-password, `cmd_app_main.tmpl`, cookies
- Generator: `generator/templates/model.tmpl`, resource/inertia/API controllers, model registration (`New{Plural}` in `fx.Provide`), factory sync, views entity names
- Goldens: `generator/testdata/golden/` and `e2e/testdata/golden/scaffolds/`

